### PR TITLE
Move ASM classes to org.jacoco namespace for jacocoant.jar

### DIFF
--- a/org.jacoco.ant-nodeps/pom.xml
+++ b/org.jacoco.ant-nodeps/pom.xml
@@ -50,6 +50,14 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.objectweb.asm</pattern>
+                  <shadedPattern>org.jacoco.asm</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/org.jacoco.ant.test/pom.xml
+++ b/org.jacoco.ant.test/pom.xml
@@ -30,7 +30,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>org.jacoco.ant-nodeps</artifactId>
+      <artifactId>org.jacoco.ant</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
With the recent updates of ASM we highly depend on specific Ant versions. Users have reported problems with our jacocoant.jar when conflicting with ASM 3.x. Therefore the ASM classes should be moved to the the org.jacoco namespace.
