### PR TITLE
fix ant documentation for instrument task

### DIFF
--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -724,7 +724,7 @@
 </p>
 
 <pre class="source lang-xml linenums">
-&lt;jacoco:instrument destfile="target/classes-instr"&gt;
+&lt;jacoco:instrument destdir="target/classes-instr"&gt;
     &lt;fileset dir="target/classes" includes="**/*.class"/&gt;
 &lt;/jacoco:instrument&gt;
 </pre>


### PR DESCRIPTION
Trying out the offline instrumentation feature and I noticed that the ant documentation specified to supply the destfile attribute for the instrument task, when it should be destdir.
