### PR TITLE
Add CLI tools for offline instrumentation and report generation

### DIFF
--- a/org.jacoco.agent.rt/META-INF/MANIFEST.MF
+++ b/org.jacoco.agent.rt/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: JaCoCo Agent Runtime Implementation
+Bundle-SymbolicName: org.jacoco.agent.rt
+Bundle-Version: 0.6.3.qualifier
+Bundle-Vendor: Mountainminds GmbH & Co. KG
+Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -79,6 +79,7 @@
     <module>../org.jacoco.agent.rt</module>
     <module>../org.jacoco.agent</module>
     <module>../org.jacoco.ant</module>
+    <module>../org.jacoco.cli</module>
 
     <module>../jacoco-maven-plugin</module>
 
@@ -125,6 +126,7 @@
     <!-- Dependencies versions -->
     <asm.version>4.1</asm.version>
     <ant.version>1.7.1</ant.version>
+    <args4j.version>2.0.16</args4j.version>
     <junit.version>4.8.2</junit.version>
 
     <!-- ================== -->
@@ -182,7 +184,17 @@
         <classifier>nodeps</classifier>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>org.jacoco.cli</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <!-- Third-party dependencies -->
+      <dependency>
+        <groupId>args4j</groupId>
+        <artifactId>args4j</artifactId>
+        <version>${args4j.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm-all</artifactId>

--- a/org.jacoco.cli/.classpath
+++ b/org.jacoco.cli/.classpath
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/org.jacoco.cli/.gitignore
+++ b/org.jacoco.cli/.gitignore
@@ -1,0 +1,3 @@
+/target
+/bin
+/.settings

--- a/org.jacoco.cli/.project
+++ b/org.jacoco.cli/.project
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.jacoco.cli</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>.settings</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/org.jacoco.core/.settings</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/org.jacoco.cli/META-INF/MANIFEST.MF
+++ b/org.jacoco.cli/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: JaCoCo Command Line Interface
+Bundle-SymbolicName: org.jacoco.cli
+Bundle-Version: 0.6.3.qualifier
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-Vendor: Mountainminds GmbH & Co. KG
+Import-Package: org.jacoco.core.analysis;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.core.data;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.core.instr;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.core.runtime;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.report;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.report.csv;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.report.html;bundle-version="[0.6.3,0.6.4)",
+ org.jacoco.report.xml;bundle-version="[0.6.3,0.6.4)",
+ org.kohsuke.args4j;version="[2.0,3.0)",
+ org.objectweb.asm;version="[4.1.0,4.2.0)"

--- a/org.jacoco.cli/about.html
+++ b/org.jacoco.cli/about.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+<head>
+<title>About</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>
+  @build.date@
+</p>
+
+<h3>License</h3>
+
+<p>
+  All Content in this plug-in is made available by Mountainminds GmbH &amp; Co.
+  KG, Munich. Unless otherwise indicated below, the Content is provided to you
+  under the terms and conditions of the Eclipse Public License Version 1.0
+  (&quot;EPL&quot;). A copy of the EPL is available at
+  <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+  For purposes of the EPL, "Program" will mean the Content.
+</p>
+
+</body>
+</html>

--- a/org.jacoco.cli/pom.xml
+++ b/org.jacoco.cli/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jacoco</groupId>
+    <artifactId>org.jacoco.build</artifactId>
+    <version>0.6.3-SNAPSHOT</version>
+    <relativePath>../org.jacoco.build</relativePath>
+  </parent>
+
+  <artifactId>org.jacoco.cli</artifactId>
+
+  <name>JaCoCo :: CLI</name>
+  <description>JaCoCo Command Line Interface</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>org.jacoco.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>org.jacoco.report</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>org.jacoco.cli.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/org.jacoco.cli/src/org/jacoco/cli/FilteredInstrumenter.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/FilteredInstrumenter.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    John Keeping - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.cli;
+
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
+import org.jacoco.core.runtime.WildcardMatcher;
+import org.objectweb.asm.ClassReader;
+
+class FilteredInstrumenter extends Instrumenter {
+
+	private final WildcardMatcher include;
+	private final WildcardMatcher exclude;
+	private int adjustment = 0;
+
+	public FilteredInstrumenter(final IExecutionDataAccessorGenerator runtime,
+			final WildcardMatcher include, final WildcardMatcher exclude) {
+		super(runtime);
+		this.include = include;
+		this.exclude = exclude;
+	}
+
+	public int getAdjustment() {
+		return adjustment;
+	}
+
+	@Override
+	public byte[] instrument(final ClassReader reader) {
+		if (!includeClass(reader.getClassName())) {
+			--adjustment;
+			return reader.b;
+		}
+		return super.instrument(reader);
+	}
+
+	private boolean includeClass(final String internalClassName) {
+		final String className = internalClassName.replace('/', '.');
+		return include.matches(className) && !exclude.matches(className);
+	}
+
+}

--- a/org.jacoco.cli/src/org/jacoco/cli/Instrument.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/Instrument.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    John Keeping - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.cli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.MessageFormat;
+
+import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
+import org.jacoco.core.runtime.WildcardMatcher;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+
+/**
+ * Command-line "instrument" command implementation.
+ */
+public class Instrument {
+
+	private final FilteredInstrumenter instrumenter;
+
+	private final File srcdir;
+	private final File destdir;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param options
+	 *            the options to be applied when instrumenting the classes.
+	 */
+	public Instrument(final InstrumentOptions options) {
+		this.srcdir = options.getSrcdir();
+		this.destdir = options.getDestdir();
+		instrumenter = new FilteredInstrumenter(
+				new OfflineInstrumentationAccessGenerator(),
+				new WildcardMatcher(options.getIncludeExpr()),
+				new WildcardMatcher(options.getExcludeExpr()));
+	}
+
+	/**
+	 * Runs the instrumentation task.
+	 * 
+	 * @return the number of classes instrumented.
+	 * @throws IOException
+	 *             if the task fails to read/write a class.
+	 */
+	public int instrumentAll() throws IOException {
+		final int result = instrumentRecursive(srcdir, destdir);
+		return result + instrumenter.getAdjustment();
+	}
+
+	private int instrumentRecursive(final File src, final File dest)
+			throws IOException {
+		int total = 0;
+		if (src.isDirectory()) {
+			for (final File child : src.listFiles()) {
+				total += instrumentRecursive(child,
+						new File(dest, child.getName()));
+			}
+		} else {
+			total += instrument(src, dest);
+		}
+		return total;
+	}
+
+	private int instrument(final File src, final File dest) throws IOException {
+		final File destParent = dest.getParentFile();
+		// Be careful to avoid a race by trying to construct the output
+		// directory regardless of whether it already exists. Only fail if
+		// we did not create it *and* it does not exist.
+		if (!destParent.mkdirs() && !destParent.exists()) {
+			throw new IOException("failed to create directory: " + destParent);
+		}
+		final InputStream input = new FileInputStream(src);
+		try {
+			final OutputStream output = new FileOutputStream(dest);
+			try {
+				return instrumenter.instrumentAll(input, output);
+			} finally {
+				output.close();
+			}
+		} catch (final IOException e) {
+			dest.delete();
+			throw e;
+		} finally {
+			input.close();
+		}
+	}
+
+	/**
+	 * @param args
+	 *            the command-line arguments.
+	 */
+	public static void main(final String[] args) {
+		final InstrumentOptions options = new InstrumentOptions();
+		final CmdLineParser parser = new CmdLineParser(options);
+		try {
+			parser.parseArgument(args);
+		} catch (final CmdLineException e) {
+			System.err.println(e.getLocalizedMessage());
+			parser.printUsage(System.err);
+			System.exit(1);
+		}
+
+		try {
+			final int total = new Instrument(options).instrumentAll();
+			System.out.println(MessageFormat.format("{0} classes instrumented",
+					Integer.valueOf(total)));
+		} catch (final IOException e) {
+			System.err.println("Failed: " + e.getLocalizedMessage());
+			System.exit(1);
+		}
+	}
+
+}

--- a/org.jacoco.cli/src/org/jacoco/cli/InstrumentOptions.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/InstrumentOptions.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    John Keeping - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.cli;
+
+import java.io.File;
+
+import org.kohsuke.args4j.Option;
+
+/**
+ * Options for offline instrumentation task.
+ */
+public class InstrumentOptions {
+
+	@Option(name = "-srcdir", required = true, usage = "directory containing the class files to be instrumented")
+	private File srcdir;
+
+	@Option(name = "-destdir", required = true, usage = "directory in which to place the instrumented class files")
+	private File destdir;
+
+	@Option(name = "-include", usage = "include filter expression (default: '*')")
+	private String includeExpr = "*";
+
+	@Option(name = "-exclude", usage = "exclude filter expression (default: '')")
+	private String excludeExpr = "";
+
+	/**
+	 * Gets the directory containing the class files to be instrumented.
+	 * 
+	 * @return the input class file directory
+	 */
+	public File getSrcdir() {
+		return srcdir;
+	}
+
+	/**
+	 * Gets the directory into which to write instrumented class files.
+	 * 
+	 * @return the output class file directory
+	 */
+	public File getDestdir() {
+		return destdir;
+	}
+
+	/**
+	 * Gets the "include" filter expression.
+	 * 
+	 * @return the include filter expression
+	 */
+	public String getIncludeExpr() {
+		return includeExpr;
+	}
+
+	/**
+	 * Gets the "exclude" filter expression.
+	 * 
+	 * @return the exclude filter expression
+	 */
+	public String getExcludeExpr() {
+		return excludeExpr;
+	}
+
+}

--- a/org.jacoco.cli/src/org/jacoco/cli/Main.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/Main.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    John Keeping - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.cli;
+
+import java.util.Arrays;
+
+/**
+ * Main class for the command-line tools.
+ */
+public class Main {
+
+	/**
+	 * Entry point for the command line application.
+	 * 
+	 * @param args
+	 *            Arguments to the application.
+	 */
+	public static void main(final String[] args) {
+		if (args.length == 0) {
+			System.err.println("no command specified");
+			System.exit(1);
+		}
+		final String command = args[0];
+		final String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
+		if ("instrument".equals(command)) {
+			Instrument.main(commandArgs);
+		} else if ("report".equals(command)) {
+			Report.main(commandArgs);
+		} else {
+			System.err.println("no such command: " + command);
+			System.exit(1);
+		}
+	}
+
+}

--- a/org.jacoco.cli/src/org/jacoco/cli/Report.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/Report.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    John Keeping - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.cli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IBundleCoverage;
+import org.jacoco.core.data.ExecutionDataReader;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.SessionInfoStore;
+import org.jacoco.report.DirectorySourceFileLocator;
+import org.jacoco.report.FileMultiReportOutput;
+import org.jacoco.report.IReportVisitor;
+import org.jacoco.report.csv.CSVFormatter;
+import org.jacoco.report.html.HTMLFormatter;
+import org.jacoco.report.xml.XMLFormatter;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+
+/**
+ * Command-line "report" command implementation.
+ */
+public class Report {
+
+	private final ReportOptions options;
+	private final File inputFile;
+	private final File classes;
+	private final String title;
+	private ExecutionDataStore dataStore;
+	private SessionInfoStore infoStore;
+	private IBundleCoverage coverage;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param options
+	 *            the options to be applied when generating the report(s).
+	 */
+	public Report(final ReportOptions options) {
+		this.options = options;
+		this.inputFile = options.getInput();
+		this.classes = options.getClasses();
+		this.title = options.getTitle();
+	}
+
+	/**
+	 * Runs the report generation task.
+	 * 
+	 * @throws IOException
+	 *             if any I/O operations fail.
+	 */
+	public void run() throws IOException {
+		loadCoverage();
+
+		final File csv = options.getCsv();
+		if (null != csv) {
+			final CSVFormatter formatter = new CSVFormatter();
+			final OutputStream output = new FileOutputStream(csv);
+			try {
+				generateReport(formatter.createVisitor(output));
+			} catch (final IOException e) {
+				csv.deleteOnExit();
+				throw e;
+			} finally {
+				output.close();
+			}
+		}
+
+		final File html = options.getHtml();
+		if (null != html) {
+			final HTMLFormatter formatter = new HTMLFormatter();
+			generateReport(formatter.createVisitor(new FileMultiReportOutput(
+					html)));
+		}
+
+		final File xml = options.getXml();
+		if (null != xml) {
+			final XMLFormatter formatter = new XMLFormatter();
+			final OutputStream output = new FileOutputStream(xml);
+			try {
+				generateReport(formatter.createVisitor(output));
+			} catch (final IOException e) {
+				xml.deleteOnExit();
+				throw e;
+			} finally {
+				output.close();
+			}
+		}
+	}
+
+	private void generateReport(final IReportVisitor visitor)
+			throws IOException {
+		visitor.visitInfo(infoStore.getInfos(), dataStore.getContents());
+
+		// Populate the report structure with the bundle coverage information.
+		// Call visitGroup if you need groups in your report.
+		visitor.visitBundle(
+				coverage,
+				new DirectorySourceFileLocator(options.getSource(), options
+						.getSourceEncoding(), options.getTabWidth()));
+
+		// Signal end of structure information to allow report to write all
+		// information out
+		visitor.visitEnd();
+
+	}
+
+	private void loadCoverage() throws IOException {
+		final InputStream input = new FileInputStream(inputFile);
+		try {
+			final ExecutionDataReader reader = new ExecutionDataReader(input);
+			dataStore = new ExecutionDataStore();
+			infoStore = new SessionInfoStore();
+
+			reader.setExecutionDataVisitor(dataStore);
+			reader.setSessionInfoVisitor(infoStore);
+
+			while (reader.read()) {
+				// Just read until we're done.
+			}
+
+			final CoverageBuilder coverageBuilder = new CoverageBuilder();
+			final Analyzer analyzer = new Analyzer(dataStore, coverageBuilder);
+			analyzer.analyzeAll(classes);
+
+			coverage = coverageBuilder.getBundle(title);
+		} finally {
+			input.close();
+		}
+	}
+
+	/**
+	 * @param args
+	 *            the command-line arguments.
+	 */
+	public static void main(final String[] args) {
+		final ReportOptions options = new ReportOptions();
+		final CmdLineParser parser = new CmdLineParser(options);
+		try {
+			parser.parseArgument(args);
+		} catch (final CmdLineException e) {
+			System.err.println(e.getLocalizedMessage());
+			parser.printUsage(System.err);
+			System.exit(1);
+		}
+
+		try {
+			new Report(options).run();
+		} catch (final IOException e) {
+			System.err.println("Failed: " + e.getLocalizedMessage());
+			System.exit(1);
+		}
+	}
+
+}

--- a/org.jacoco.cli/src/org/jacoco/cli/ReportOptions.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/ReportOptions.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    John Keeping - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.cli;
+
+import java.io.File;
+
+import org.kohsuke.args4j.Option;
+
+/**
+ * Options for the "report" command.
+ */
+public class ReportOptions {
+
+	@Option(name = "-input", required = true, usage = "the JaCoCo execution data")
+	private File input;
+
+	@Option(name = "-classes", required = true, usage = "directory containing the classes which were instrumented - NOTE: this must point at the original, non-instrumented class files")
+	private File classes;
+
+	@Option(name = "-source", required = true, usage = "directory containing the source .java files")
+	private File source;
+
+	@Option(name = "-title", required = true, usage = "title for the report")
+	private String title;
+
+	@Option(name = "-csv", usage = "file for generating a CSV report")
+	private File csv;
+
+	@Option(name = "-html", usage = "directory for generating an HTML report")
+	private File html;
+
+	@Option(name = "-xml", usage = "file for generating an XML report")
+	private File xml;
+
+	@Option(name = "-source-encoding", usage = "encoding of the source files (default: utf-8)")
+	private String sourceEncoding = "utf-8";
+
+	@Option(name = "-tabwidth", usage = "width of a TAB in the source files (default: 4)")
+	private int tabWidth = 4;
+
+	/**
+	 * Gets the input JaCoCo execution data file.
+	 * 
+	 * @return the input execution data file
+	 */
+	public File getInput() {
+		return input;
+	}
+
+	/**
+	 * Gets the path to the original class files.
+	 * 
+	 * @return the path to the class files
+	 */
+	public File getClasses() {
+		return classes;
+	}
+
+	/**
+	 * Gets the path to the Java source.
+	 * 
+	 * @return the path to the source directory
+	 */
+	public File getSource() {
+		return source;
+	}
+
+	/**
+	 * Gets the title for the coverage report.
+	 * 
+	 * @return the report title
+	 */
+	public String getTitle() {
+		return title;
+	}
+
+	/**
+	 * Gets the path for the CSV format report, if there is one.
+	 * 
+	 * @return the path for the CSV report, or {@code null} to omit this format
+	 */
+	public File getCsv() {
+		return csv;
+	}
+
+	/**
+	 * Gets the path for the HTML format report, if there is one.
+	 * 
+	 * @return the path for the HTML report, or {@code null} to omit this format
+	 */
+	public File getHtml() {
+		return html;
+	}
+
+	/**
+	 * Gets the path for the XML format report, if there is one.
+	 * 
+	 * @return the path for the XML report, or {@code null} to omit this format
+	 */
+	public File getXml() {
+		return xml;
+	}
+
+	/**
+	 * Gets the encoding of the source files.
+	 * 
+	 * @return the source encoding
+	 */
+	public String getSourceEncoding() {
+		return sourceEncoding;
+	}
+
+	/**
+	 * Gets the width of a TAB character in the source files.
+	 * 
+	 * @return the tab width
+	 */
+	public int getTabWidth() {
+		return tabWidth;
+	}
+
+}


### PR DESCRIPTION
These tools help people who are using a build system other than Ant/Maven, as discussed in issue #50.

To that end, I also include a commit adding some OSGi metadata to the runtime agent JAR.  This allows that JAR to be stored in a bundle repository and downloaded from there during the build.
