### PR TITLE
Support analysis of pack200 jars in Jacoco analyzer

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
@@ -17,10 +17,13 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.jar.JarInputStream;
+import java.util.jar.Pack200;
+import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.jacoco.core.internal.ContentTypeDetector;
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Test;
 
@@ -113,6 +116,34 @@ public class ContentTypeDetectorTest {
 		zip.close();
 		initData(buffer.toByteArray());
 		assertEquals(ContentTypeDetector.ZIPFILE, detector.getType());
+		assertContent();
+	}
+
+	@Test
+	public void testPack200File() throws IOException {
+		final ByteArrayOutputStream zipbuffer = new ByteArrayOutputStream();
+		final ZipOutputStream zip = new ZipOutputStream(zipbuffer);
+		zip.putNextEntry(new ZipEntry("hello.txt"));
+		zip.write("Hello Zip!".getBytes());
+		zip.close();
+
+		final ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
+		Pack200.newPacker().pack(
+				new JarInputStream(new ByteArrayInputStream(
+						zipbuffer.toByteArray())), pack200buffer);
+		initData(pack200buffer.toByteArray());
+		assertEquals(ContentTypeDetector.PACK200FILE, detector.getType());
+		assertContent();
+	}
+
+	@Test
+	public void testGZipFile() throws IOException {
+		final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		final OutputStream gz = new GZIPOutputStream(buffer);
+		gz.write("Hello gz!".getBytes());
+		gz.close();
+		initData(buffer.toByteArray());
+		assertEquals(ContentTypeDetector.GZFILE, detector.getType());
 		assertContent();
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Pack200;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import org.jacoco.core.test.TargetLoader;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Pack200Streams}.
+ */
+public class Pack200StreamsTest {
+
+	@Test
+	public void testPack() throws IOException {
+		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
+		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
+		zipout.putNextEntry(new ZipEntry("Test.class"));
+		zipout.write(TargetLoader.getClassDataAsBytes(getClass()));
+		zipout.finish();
+
+		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
+		Pack200Streams.pack(jarbuffer.toByteArray(), new NoCloseOutputStream(
+				pack200buffer));
+
+		jarbuffer.reset();
+		Pack200.newUnpacker().unpack(
+				new ByteArrayInputStream(pack200buffer.toByteArray()),
+				new JarOutputStream(jarbuffer));
+
+		ZipInputStream zipin = new ZipInputStream(new ByteArrayInputStream(
+				jarbuffer.toByteArray()));
+		assertEquals("Test.class", zipin.getNextEntry().getName());
+		assertNull(zipin.getNextEntry());
+	}
+
+	@Test
+	public void testUnpack() throws IOException {
+		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
+		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
+		zipout.putNextEntry(new ZipEntry("Test.class"));
+		zipout.write(TargetLoader.getClassDataAsBytes(getClass()));
+		zipout.finish();
+
+		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
+		Pack200.newPacker().pack(
+				new JarInputStream(new ByteArrayInputStream(
+						jarbuffer.toByteArray())), pack200buffer);
+
+		InputStream result = Pack200Streams.unpack(new NoCloseInputStream(
+				new ByteArrayInputStream(pack200buffer.toByteArray())));
+
+		ZipInputStream zipin = new ZipInputStream(result);
+		assertEquals("Test.class", zipin.getNextEntry().getName());
+		assertNull(zipin.getNextEntry());
+	}
+
+	static class NoCloseInputStream extends FilterInputStream {
+		public NoCloseInputStream(InputStream in) {
+			super(in);
+		}
+
+		@Override
+		public void close() throws IOException {
+			fail();
+		}
+	}
+
+	static class NoCloseOutputStream extends FilterOutputStream {
+		public NoCloseOutputStream(OutputStream out) {
+			super(out);
+		}
+
+		@Override
+		public void close() throws IOException {
+			fail();
+		}
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
@@ -31,6 +31,12 @@ public class ContentTypeDetector {
 	/** File type ZIP archive */
 	public static final int ZIPFILE = 0x504b0304;
 
+	/** File type GZIP compressed Data */
+	public static final int GZFILE = 0x1f8b0000;
+
+	/** File type Pack200 archive */
+	public static final int PACK200FILE = 0xcafed00d;
+
 	private static final int BUFFER_SIZE = 8;
 
 	private final InputStream in;
@@ -59,9 +65,12 @@ public class ContentTypeDetector {
 	}
 
 	private static int determineType(final InputStream in) throws IOException {
-		switch (readInt(in)) {
+		final int header = readInt(in);
+		switch (header) {
 		case ZIPFILE:
 			return ZIPFILE;
+		case PACK200FILE:
+			return PACK200FILE;
 		case CLASSFILE:
 			// also verify version to distinguish from Mach Object files:
 			switch (readInt(in)) {
@@ -74,6 +83,9 @@ public class ContentTypeDetector {
 			case Opcodes.V1_7:
 				return CLASSFILE;
 			}
+		}
+		if ((header & 0xffff0000) == GZFILE) {
+			return GZFILE;
 		}
 		return UNKNOWN;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.core.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Pack200;
+
+/**
+ * Internal wrapper for the weird Pack200 Java API to allow usage with streams.
+ */
+public final class Pack200Streams {
+
+	/**
+	 * Unpack a stream in Pack200 format into a stream in JAR/ZIP format.
+	 * 
+	 * @param input
+	 *            stream in Pack200 format
+	 * @return stream in JAR/ZIP format
+	 * @throws IOException
+	 *             in case of errors with the streams
+	 */
+	public static InputStream unpack(final InputStream input)
+			throws IOException {
+		final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		final JarOutputStream jar = new JarOutputStream(buffer);
+		Pack200.newUnpacker().unpack(new NoCloseInput(input), jar);
+		jar.finish();
+		return new ByteArrayInputStream(buffer.toByteArray());
+	}
+
+	/**
+	 * Packs a buffer in JAR/ZIP format into a stream in Pack200 format.
+	 * 
+	 * @param source
+	 *            source in JAR/ZIP format
+	 * @param output
+	 *            stream in Pack200 format
+	 * @throws IOException
+	 *             in case of errors with the streams
+	 */
+	public static void pack(final byte[] source, final OutputStream output)
+			throws IOException {
+		final JarInputStream jar = new JarInputStream(new ByteArrayInputStream(
+				source));
+		Pack200.newPacker().pack(jar, output);
+	}
+
+	private static class NoCloseInput extends FilterInputStream {
+		protected NoCloseInput(final InputStream in) {
+			super(in);
+		}
+
+		@Override
+		public void close() throws IOException {
+			// do not close the underlying stream
+		}
+	}
+
+	private Pack200Streams() {
+	}
+
+}

--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -485,8 +485,8 @@
 
 <ul>
   <li><code>classfiles</code>: Container element for Ant resources and resource
-    collections that can specify Java class files, ZIP archive files (jar, war,
-    ear etc.) or folders containing class files. Archives and folders are
+    collections that can specify Java class files, archive files (jar, war, ear
+    etc. or Pack200) or folders containing class files. Archives and folders are
     searched recursively for class files.</li>
   <li><code>sourcefiles</code>: Optional container element for Ant resources and
     resource collections that specify corresponding source files. If source
@@ -719,8 +719,9 @@
   This task is used for <a href="offline.html">offline instrumentation</a> of
   class files. The task takes a set of files and writes instrumented
   versions to a specified location. The task takes any file type as input. Java
-  class files are instrumented. Archives are searched recursively for class files
-  which then get instrumented. All other files are copied without modification.
+  class files are instrumented. Archives (jar, war, ear etc. or Pack200) are
+  searched recursively for class files which then get instrumented. All other
+  files are copied without modification.
 </p>
 
 <pre class="source lang-xml linenums">

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,11 @@
 
 <h2>Trunk Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>New Features</h3>
+<ul>
+  <li>Support for archives in Pack200 format (GitHub #91).</li>
+</ul>
+
 <h3>Fixed Bugs</h3>
 <ul>
   <li>Fixed inconsistent stackmap frames when instrumenting class files produced


### PR DESCRIPTION
This request is originally inspired by this issue: https://github.com/jacoco/eclemma/issues/49 . Allowing pack200'd bundles in Jacoco analyzer would allow to generate reports when jars are pack200.
This would force people to use the pack200'd jar as input rather than the classfile, but I think it's an acceptable and clean improvement.
