### PR TITLE
Adds report of test code with maven plugin by default.

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-without-testcode</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>ExampleTest*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <debug>true</debug>
+          <debuglevel>none</debuglevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/src/main/java/Example.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+public class Example {
+
+  public void sayHello() {
+    System.out.println("Hello world");
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/src/test/java/ExampleTest.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import org.junit.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void test() {
+    new Example().sayHello();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/verify.bsh
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+File html = new File( basedir, "target/site/jacoco/default/ExampleTest.html" );
+if ( html.isFile() ) {
+    throw new RuntimeException( "Test code coverage was not exluded in html." );
+}
+
+String csv = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.csv" ) );
+if ( csv.indexOf( ",ExampleTest," ) >= 0 ) {
+    throw new RuntimeException( "Test code coverage was not exluded in csv." );
+}
+
+String xml = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.xml" ) );
+if ( xml.indexOf( "<class name=\"ExampleTest\">" ) >= 0 ) {
+    throw new RuntimeException( "Test code coverage was not exluded in xml." );
+}

--- a/jacoco-maven-plugin.test/it/it-site/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-site/verify.bsh
@@ -31,3 +31,18 @@ File csvReportFile = new File( basedir, "target/site/jacoco/jacoco.csv" );
 if ( !csvReportFile.isFile() ) {
     throw new RuntimeException( "CSV report was not created" );
 }
+
+String html = FileUtils.fileRead( new File( basedir, "target/site/jacoco/default/ExampleTest.html" ) );
+if ( html.indexOf( "<span class=\"el_class\">ExampleTest</span>" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in html." );
+}
+
+String csv = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.csv" ) );
+if ( csv.indexOf( ",ExampleTest," ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in csv." );
+}
+
+String xml = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.xml" ) );
+if ( xml.indexOf( "<class name=\"ExampleTest\">" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in xml." );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
@@ -57,17 +57,47 @@ public final class BundleCreator {
 			final ExecutionDataStore executionDataStore) throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
 		final Analyzer analyzer = new Analyzer(executionDataStore, builder);
-		final File classesDir = new File(this.project.getBuild()
-				.getOutputDirectory());
 
-		@SuppressWarnings("unchecked")
-		final List<File> filesToAnalyze = FileUtils.getFiles(classesDir,
-				fileFilter.getIncludes(), fileFilter.getExcludes());
-
-		for (final File file : filesToAnalyze) {
+		for (final File file : getFilesToAnalyze()) {
 			analyzer.analyzeAll(file);
 		}
 
 		return builder.getBundle(this.project.getName());
+	}
+
+	/**
+	 * Get files to analyze in classes and test-classes directories.
+	 * 
+	 * @return list of files.
+	 * @throws IOException
+	 *             if class files can't be read
+	 */
+	private List<File> getFilesToAnalyze() throws IOException {
+		final List<File> filesToAnalyze = getFilesToAnalyze(this.project
+				.getBuild().getOutputDirectory());
+		final List<File> testFilesToAnalyze = getFilesToAnalyze(this.project
+				.getBuild().getTestOutputDirectory());
+		filesToAnalyze.addAll(testFilesToAnalyze);
+
+		return filesToAnalyze;
+	}
+
+	/**
+	 * Get files to analyze in specified directories.
+	 * 
+	 * @param directory
+	 *            is searched.
+	 * @return list of files.
+	 * @throws IOException
+	 *             if class files can't be read
+	 */
+	private List<File> getFilesToAnalyze(final String directory)
+			throws IOException {
+		@SuppressWarnings("unchecked")
+		final List<File> filesToAnalyze = FileUtils.getFiles(
+				new File(directory), fileFilter.getIncludes(),
+				fileFilter.getExcludes());
+
+		return filesToAnalyze;
 	}
 }


### PR DESCRIPTION
JaCoCo maven plugin outputs coverage report with 'report' goal.
Now its report DOES NOT report coverage for test code.
Otherwise EclEMMA reports them.

I think test code coverage is needed to know if test code run enough.
So by default, as same as EclEMMA, I think they should include test code coverage.
If someone don't need them, they can use configuration of 'excludes' in 'report' goal.
