### PR TITLE
Adds to generate the report of test code with maven plugin.

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-with-testcode/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-with-testcode/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-with-testcode</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <reportTestcode>true</reportTestcode>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <debug>true</debug>
+          <debuglevel>none</debuglevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-with-testcode/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-report-with-testcode/src/main/java/Example.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+public class Example {
+
+  public void sayHello() {
+    System.out.println("Hello world");
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-with-testcode/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-with-testcode/src/test/java/ExampleTest.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import org.junit.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void test() {
+    new Example().sayHello();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-with-testcode/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-with-testcode/verify.bsh
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String html = FileUtils.fileRead( new File( basedir, "target/site/jacoco/default/ExampleTest.html" ) );
+if ( html.indexOf( "<span class=\"el_class\">ExampleTest</span>" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in html." );
+}
+
+String csv = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.csv" ) );
+if ( csv.indexOf( ",ExampleTest," ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in csv." );
+}
+
+String xml = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.xml" ) );
+if ( xml.indexOf( "<class name=\"ExampleTest\">" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in xml." );
+}

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-without-testcode</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <debug>true</debug>
+          <debuglevel>none</debuglevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/src/main/java/Example.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+public class Example {
+
+  public void sayHello() {
+    System.out.println("Hello world");
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/src/test/java/ExampleTest.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import org.junit.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void test() {
+    new Example().sayHello();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-without-testcode/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-without-testcode/verify.bsh
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+File html = new File( basedir, "target/site/jacoco/default/ExampleTest.html" );
+if ( html.isFile() ) {
+    throw new RuntimeException( "Test code coverage was not exluded in html." );
+}
+
+String csv = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.csv" ) );
+if ( csv.indexOf( ",ExampleTest," ) >= 0 ) {
+    throw new RuntimeException( "Test code coverage was not exluded in csv." );
+}
+
+String xml = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.xml" ) );
+if ( xml.indexOf( "<class name=\"ExampleTest\">" ) >= 0 ) {
+    throw new RuntimeException( "Test code coverage was not exluded in xml." );
+}

--- a/jacoco-maven-plugin.test/it/it-site-with-testcode/invoker.properties
+++ b/jacoco-maven-plugin.test/it/it-site-with-testcode/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean test site
+
+# maven-site-plugin 3.0 requires at least Maven 2.2.0
+invoker.maven.version = 2.2.0+

--- a/jacoco-maven-plugin.test/it/it-site-with-testcode/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-site-with-testcode/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-site-with-testcode</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.0</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <reportTestcode>true</reportTestcode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/jacoco-maven-plugin.test/it/it-site-with-testcode/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-site-with-testcode/src/main/java/Example.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+public class Example {
+
+  public void sayHello() {
+    System.out.println("Hello world");
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-site-with-testcode/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-site-with-testcode/src/test/java/ExampleTest.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import org.junit.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void test() {
+    new Example().sayHello();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-site-with-testcode/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-site-with-testcode/verify.bsh
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String html_index = FileUtils.fileRead( new File( basedir, "target/site/jacoco/default/index.html" ) );
+if ( html_index.indexOf( "<a href=\"ExampleTest.html\" class=\"el_class\">ExampleTest</a>" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in index.html." );
+}
+
+String html_testcode = FileUtils.fileRead( new File( basedir, "target/site/jacoco/default/ExampleTest.html" ) );
+if ( html_testcode.indexOf( "<a href=\"ExampleTest.java.html#L14\" class=\"el_method\">ExampleTest()</a>" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage html." );
+}
+
+File html_testcode_src = new File( basedir, "target/site/jacoco/default/ExampleTest.html" );
+if ( !html_testcode_src.isFile() ) {
+    throw new RuntimeException( "No test code source html." );
+}
+
+String csv = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.csv" ) );
+if ( csv.indexOf( ",ExampleTest," ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in csv." );
+}
+
+String xml = FileUtils.fileRead( new File( basedir, "target/site/jacoco/jacoco.xml" ) );
+if ( xml.indexOf( "<class name=\"ExampleTest\">" ) < 0 ) {
+    throw new RuntimeException( "No test code coverage in xml." );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
@@ -87,6 +87,14 @@ public class ReportMojo extends AbstractMavenReport {
 	private File dataFile;
 
 	/**
+	 * Report the coverage of test code.
+	 * 
+	 * @parameter expression="${project.build.reportTestcode}"
+	 *            default-value="false"
+	 */
+	private boolean reportTestcode;
+
+	/**
 	 * A list of class files to include in the report. May use wildcard
 	 * characters (* and ?). When not specified everything will be included.
 	 * 
@@ -258,7 +266,7 @@ public class ReportMojo extends AbstractMavenReport {
 		final FileFilter fileFilter = new FileFilter(this.getIncludes(),
 				this.getExcludes());
 		final BundleCreator creator = new BundleCreator(this.getProject(),
-				fileFilter);
+				fileFilter, reportTestcode);
 		final IBundleCoverage bundle = creator.createBundle(executionDataStore);
 
 		final SourceFileCollection locator = new SourceFileCollection(
@@ -344,9 +352,28 @@ public class ReportMojo extends AbstractMavenReport {
 
 	private List<File> getCompileSourceRoots() {
 		final List<File> result = new ArrayList<File>();
-		for (final Object path : getProject().getCompileSourceRoots()) {
+		result.addAll(getSourceRoots(getProject().getCompileSourceRoots()));
+		if (reportTestcode) {
+			result.addAll(getSourceRoots(getProject()
+					.getTestCompileSourceRoots()));
+		}
+
+		return result;
+	}
+
+	/**
+	 * Gets sources roots.
+	 * 
+	 * @param root
+	 *            is root of source.
+	 * @return list of source files.
+	 */
+	private List<File> getSourceRoots(final List<?> root) {
+		final List<File> result = new ArrayList<File>();
+		for (final Object path : root) {
 			result.add(resolvePath((String) path));
 		}
+
 		return result;
 	}
 }


### PR DESCRIPTION
I requested #94 and had some comment. (And #96 , #99 were already rejected.)
I re-implement a test code coverage reporting. It's disable by default.
Test code coverages are included if reportTestcode option in pom.xml is true.
