### PR TITLE
Provide Context Information when Exception happen in Analyzer or Instrumenter

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
@@ -11,13 +11,6 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
-import org.jacoco.core.instr.Instrumenter;
-import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -25,6 +18,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.IOUtil;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 
 /**
  * Performs offline instrumentation. Note that after execution of test you must
@@ -59,8 +59,8 @@ public class InstrumentMojo extends AbstractJacocoMojo {
 
 		final List<String> fileNames;
 		try {
-			fileNames = new FileFilter(this.getIncludes(),
-					this.getExcludes()).getFileNames(classesDir);
+			fileNames = new FileFilter(this.getIncludes(), this.getExcludes())
+					.getFileNames(classesDir);
 		} catch (final IOException e1) {
 			throw new MojoExecutionException(
 					"Unable to get list of files to instrument.", e1);
@@ -78,7 +78,7 @@ public class InstrumentMojo extends AbstractJacocoMojo {
 					FileUtils.copyFile(source, backup);
 					input = new FileInputStream(backup);
 					output = new FileOutputStream(source);
-					instrumenter.instrument(input, output);
+					instrumenter.instrument(input, output, source.getPath());
 				} catch (final IOException e2) {
 					throw new MojoExecutionException(
 							"Unable to instrument file.", e2);

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -139,7 +139,7 @@ public class CoverageTransformerTest {
 		}
 		recorder.assertException(IllegalClassFormatException.class,
 				"Error while instrumenting class org.jacoco.Sample.",
-				NullPointerException.class);
+				IOException.class);
 		recorder.clear();
 	}
 

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/CoverageTransformer.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/CoverageTransformer.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.jacoco.agent.rt.internal;
 
-import static java.lang.String.format;
-
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
@@ -86,10 +84,10 @@ public class CoverageTransformer implements ClassFileTransformer {
 				// reference as probes might have changed.
 				runtime.disconnect(classBeingRedefined);
 			}
-			return instrumenter.instrument(classfileBuffer);
+			return instrumenter.instrument(classfileBuffer, classname);
 		} catch (final Exception ex) {
 			final IllegalClassFormatException wrapper = new IllegalClassFormatException(
-					format("Error while instrumenting class %s.", classname));
+					ex.getMessage());
 			wrapper.initCause(ex);
 			// Report this, as the exception is ignored by the JVM:
 			logger.logExeption(wrapper);

--- a/org.jacoco.ant/src/org/jacoco/ant/InstrumentTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/InstrumentTask.java
@@ -88,7 +88,8 @@ public class InstrumentTask extends Task {
 			try {
 				input = resource.getInputStream();
 				output = new FileOutputStream(file);
-				return instrumenter.instrumentAll(input, output);
+				return instrumenter.instrumentAll(input, output,
+						resource.getName());
 			} finally {
 				FileUtils.close(input);
 				FileUtils.close(output);

--- a/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
@@ -568,7 +568,7 @@ public class ReportTask extends Task {
 				analyzer.analyzeAll(((FileResource) resource).getFile());
 			} else {
 				final InputStream in = resource.getInputStream();
-				analyzer.analyzeAll(in);
+				analyzer.analyzeAll(in, resource.getName());
 				in.close();
 			}
 		}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/AnalysisTimeScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/AnalysisTimeScenario.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.jacoco.core.test.perf;
 
+import java.util.concurrent.Callable;
+
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.ICoverageVisitor;
@@ -33,7 +35,7 @@ public class AnalysisTimeScenario extends TimedScenario {
 	}
 
 	@Override
-	protected Runnable getInstrumentedRunnable() throws Exception {
+	protected Callable<Void> getInstrumentedCallable() throws Exception {
 		final byte[] bytes = TargetLoader.getClassDataAsBytes(target);
 		final ExecutionDataStore executionData = new ExecutionDataStore();
 		ICoverageVisitor visitor = new ICoverageVisitor() {
@@ -41,11 +43,12 @@ public class AnalysisTimeScenario extends TimedScenario {
 			}
 		};
 		final Analyzer analyzer = new Analyzer(executionData, visitor);
-		return new Runnable() {
-			public void run() {
+		return new Callable<Void>() {
+			public Void call() throws Exception {
 				for (int i = 0; i < count; i++) {
-					analyzer.analyzeClass(bytes);
+					analyzer.analyzeClass(bytes, target.getName());
 				}
+				return null;
 			}
 		};
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/ExecuteInstrumentedCodeScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/ExecuteInstrumentedCodeScenario.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.jacoco.core.test.perf;
 
+import java.util.concurrent.Callable;
+
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.LoggerRuntime;
@@ -24,16 +26,17 @@ import org.objectweb.asm.ClassReader;
  */
 public class ExecuteInstrumentedCodeScenario extends TimedScenario {
 
-	private final Class<? extends Runnable> target;
+	private final Class<? extends Callable<Void>> target;
 
 	protected ExecuteInstrumentedCodeScenario(String description,
-			Class<? extends Runnable> target) {
+			Class<? extends Callable<Void>> target) {
 		super(description);
 		this.target = target;
 	}
 
 	@Override
-	protected Runnable getInstrumentedRunnable() throws Exception {
+	@SuppressWarnings("unchecked")
+	protected Callable<Void> getInstrumentedCallable() throws Exception {
 		ClassReader reader = new ClassReader(TargetLoader.getClassData(target));
 		IRuntime runtime = new LoggerRuntime();
 		runtime.startup(new RuntimeData());
@@ -41,11 +44,11 @@ public class ExecuteInstrumentedCodeScenario extends TimedScenario {
 		final byte[] instrumentedBuffer = instr.instrument(reader);
 		final TargetLoader loader = new TargetLoader(target, instrumentedBuffer);
 
-		return (Runnable) loader.newTargetInstance();
+		return (Callable<Void>) loader.newTargetInstance();
 	}
 
 	@Override
-	protected Runnable getReferenceRunnable() throws Exception {
+	protected Callable<Void> getReferenceCallable() throws Exception {
 		return target.newInstance();
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/InstrumentationTimeScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/InstrumentationTimeScenario.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.jacoco.core.test.perf;
 
+import java.util.concurrent.Callable;
+
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.LoggerRuntime;
 import org.jacoco.core.test.TargetLoader;
@@ -31,14 +33,15 @@ public class InstrumentationTimeScenario extends TimedScenario {
 	}
 
 	@Override
-	protected Runnable getInstrumentedRunnable() throws Exception {
+	protected Callable<Void> getInstrumentedCallable() throws Exception {
 		final byte[] bytes = TargetLoader.getClassDataAsBytes(target);
 		final Instrumenter instr = new Instrumenter(new LoggerRuntime());
-		return new Runnable() {
-			public void run() {
+		return new Callable<Void>() {
+			public Void call() throws Exception {
 				for (int i = 0; i < count; i++) {
-					instr.instrument(bytes);
+					instr.instrument(bytes, "TestTarget");
 				}
+				return null;
 			}
 		};
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/TimedScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/TimedScenario.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.jacoco.core.test.perf;
 
+import java.util.concurrent.Callable;
+
 /**
  * Base class for execution time test scenarios.
  */
@@ -25,8 +27,8 @@ public abstract class TimedScenario implements IPerfScenario {
 	}
 
 	public void run(final IPerfOutput output) throws Exception {
-		final long time = getMinimumTime(getInstrumentedRunnable());
-		final Runnable refRunnable = getReferenceRunnable();
+		final long time = getMinimumTime(getInstrumentedCallable());
+		final Callable<Void> refRunnable = getReferenceCallable();
 		final long reftime;
 		if (refRunnable == null) {
 			reftime = IPerfOutput.NO_REFERENCE;
@@ -42,8 +44,9 @@ public abstract class TimedScenario implements IPerfScenario {
 	 * 
 	 * @param subject
 	 * @return minimum execution time in nano seconds
+	 * @throws Exception
 	 */
-	private long getMinimumTime(final Runnable subject) {
+	private long getMinimumTime(final Callable<Void> subject) throws Exception {
 		long min = Long.MAX_VALUE;
 		for (int i = 0; i < RUNS; i++) {
 			final long t = getTime(subject);
@@ -52,15 +55,16 @@ public abstract class TimedScenario implements IPerfScenario {
 		return min;
 	}
 
-	private long getTime(final Runnable subject) {
+	private long getTime(final Callable<Void> subject) throws Exception {
 		long start = System.nanoTime();
-		subject.run();
+		subject.call();
 		return System.nanoTime() - start;
 	}
 
-	protected abstract Runnable getInstrumentedRunnable() throws Exception;
+	protected abstract Callable<Void> getInstrumentedCallable()
+			throws Exception;
 
-	protected Runnable getReferenceRunnable() throws Exception {
+	protected Callable<Void> getReferenceCallable() throws Exception {
 		return null;
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/targets/Target01.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/targets/Target01.java
@@ -11,21 +11,24 @@
  *******************************************************************************/
 package org.jacoco.core.test.perf.targets;
 
+import java.util.concurrent.Callable;
+
 /**
  * Plain method calls.
  */
-public class Target01 implements Runnable {
+public class Target01 implements Callable<Void> {
 
 	@SuppressWarnings("unused")
 	private int c;
 
 	// 4 ^ 0 = 1 times
-	public void run() {
+	public Void call() throws Exception {
 		m1();
 		m1();
 		m1();
 		m1();
 		c++; // some side effect, otherwise the JIT will remove the method
+		return null;
 	}
 
 	// 4 ^ 1 = 4 times

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/targets/Target02.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/targets/Target02.java
@@ -11,17 +11,20 @@
  *******************************************************************************/
 package org.jacoco.core.test.perf.targets;
 
+import java.util.concurrent.Callable;
+
 /**
  * Simple Loop.
  */
-public class Target02 implements Runnable {
+public class Target02 implements Callable<Void> {
 
-	public void run() {
+	public Void call() throws Exception {
 		@SuppressWarnings("unused")
 		int count = 0;
 		for (int i = 0; i < 10000000; i++) {
 			count++;
 		}
+		return null;
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/targets/Target03.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/targets/Target03.java
@@ -12,6 +12,7 @@
 package org.jacoco.core.test.perf.targets;
 
 import java.util.Random;
+import java.util.concurrent.Callable;
 
 /**
  * "Game of Life" implementation as a more reference scenario. Obviously the
@@ -19,7 +20,7 @@ import java.util.Random;
  * runner targets one class only. Also one could think about more efficient
  * implementations which again is not the focus here.
  */
-public class Target03 implements Runnable {
+public class Target03 implements Callable<Void> {
 
 	private final int width;
 
@@ -130,12 +131,13 @@ public class Target03 implements Runnable {
 		return sb.toString();
 	}
 
-	public void run() {
+	public Void call() throws Exception {
 		clear();
 		randomFill(123, width * height / 2);
 		for (int i = 0; i < 20; i++) {
 			tick();
 		}
+		return null;
 	}
 
 	// Demo

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ClassFileVersionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ClassFileVersionsTest.java
@@ -25,6 +25,8 @@ import static org.objectweb.asm.Opcodes.V1_5;
 import static org.objectweb.asm.Opcodes.V1_6;
 import static org.objectweb.asm.Opcodes.V1_7;
 
+import java.io.IOException;
+
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
@@ -41,46 +43,46 @@ import org.objectweb.asm.Opcodes;
 public class ClassFileVersionsTest {
 
 	@Test
-	public void test_1_1() {
+	public void test_1_1() throws IOException {
 		testVersion(V1_1, false);
 	}
 
 	@Test
-	public void test_1_2() {
+	public void test_1_2() throws IOException {
 		testVersion(V1_2, false);
 	}
 
 	@Test
-	public void test_1_3() {
+	public void test_1_3() throws IOException {
 		testVersion(V1_3, false);
 	}
 
 	@Test
-	public void test_1_4() {
+	public void test_1_4() throws IOException {
 		testVersion(V1_4, false);
 	}
 
 	@Test
-	public void test_1_5() {
+	public void test_1_5() throws IOException {
 		testVersion(V1_5, false);
 	}
 
 	@Test
-	public void test_1_6() {
+	public void test_1_6() throws IOException {
 		testVersion(V1_6, true);
 	}
 
 	@Test
-	public void test_1_7() {
+	public void test_1_7() throws IOException {
 		testVersion(V1_7, true);
 	}
 
-	private void testVersion(int version, boolean frames) {
+	private void testVersion(int version, boolean frames) throws IOException {
 		final byte[] original = createClass(version);
 
 		IRuntime runtime = new SystemPropertiesRuntime();
 		Instrumenter instrumenter = new Instrumenter(runtime);
-		byte[] instrumented = instrumenter.instrument(original);
+		byte[] instrumented = instrumenter.instrument(original, "TestTarget");
 
 		assertFrames(instrumented, frames);
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
@@ -76,7 +76,7 @@ public class FramesTest {
 		IRuntime runtime = new SystemPropertiesRuntime();
 		Instrumenter instrumenter = new Instrumenter(runtime);
 		source = calculateFrames(source);
-		byte[] actual = instrumenter.instrument(source);
+		byte[] actual = instrumenter.instrument(source, "TestTarget");
 		byte[] expected = calculateFrames(actual);
 
 		assertEquals(dump(expected), dump(actual));

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -34,10 +34,19 @@
       by certain tools like ProGuard (GitHub #85).</li>
 </ul>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>More context information when exceptions occur during analysis or
+      instrumentation (GitHub #104).</li>
+</ul>
+
+
 <h3>API Changes</h3>
 <ul>
   <li>The configuration of the Maven check goal has been reworked to support
       checks on any element type (GitHub #106).</li>
+  <li><code>Analyzer</code> and <code>Instrumenter</code> expect resource name
+      as additional parameter for better error messages (GitHub #104).</li>
 </ul>
 
 

--- a/org.jacoco.examples/src/org/jacoco/examples/CoreTutorial.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/CoreTutorial.java
@@ -119,8 +119,8 @@ public final class CoreTutorial {
 		// The Instrumenter creates a modified version of our test target class
 		// that contains additional probes for execution data recording:
 		final Instrumenter instr = new Instrumenter(runtime);
-		final byte[] instrumented = instr
-				.instrument(getTargetClass(targetName));
+		final byte[] instrumented = instr.instrument(
+				getTargetClass(targetName), targetName);
 
 		// Now we're ready to run our instrumented class and need to startup the
 		// runtime first:
@@ -148,7 +148,7 @@ public final class CoreTutorial {
 		// information:
 		final CoverageBuilder coverageBuilder = new CoverageBuilder();
 		final Analyzer analyzer = new Analyzer(executionData, coverageBuilder);
-		analyzer.analyzeClass(getTargetClass(targetName));
+		analyzer.analyzeClass(getTargetClass(targetName), targetName);
 
 		// Let's dump some metrics and line coverage information:
 		for (final IClassCoverage cc : coverageBuilder.getClasses()) {


### PR DESCRIPTION
Hi,

I consistently get the following exception when running Jacoco against my (commercial) project. What can I do to help you correct this bug without sending you my source code? Can you add more logging and have me re-run the operation?

``` java
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.jacoco:jacoco-maven-plugin:0.6.2.201302030002:report (report) on project server.web: Execution report of goal org.jacoco:jacoco-maven-plugin:0.6.2.201302030002:report failed: 48188
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:225)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution report of goal org.jacoco:jacoco-maven-plugin:0.6.2.201302030002:report failed: 48188
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:110)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    ... 19 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: 48188
    at org.objectweb.asm.ClassReader.readClass(Unknown Source)
    at org.objectweb.asm.ClassReader.accept(Unknown Source)
    at org.objectweb.asm.ClassReader.accept(Unknown Source)
    at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:94)
    at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:115)
    at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:155)
    at org.jacoco.core.analysis.Analyzer.analyzeArchive(Analyzer.java:135)
    at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:158)
    at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:183)
    at org.jacoco.maven.BundleCreator.createBundle(BundleCreator.java:67)
    at org.jacoco.maven.ReportMojo.createReport(ReportMojo.java:262)
    at org.jacoco.maven.ReportMojo.executeReport(ReportMojo.java:235)
    at org.jacoco.maven.ReportMojo.execute(ReportMojo.java:220)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
    ... 20 more
```
