### PR TITLE
Fixing offline execution of jacoco-maven-plugin integration tests

### DIFF
--- a/jacoco-maven-plugin.test/it/it-site/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-site/pom.xml
@@ -37,7 +37,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.2</version>
       </plugin>
     </plugins>
   </build>

--- a/jacoco-maven-plugin.test/it/setup-parent/pom.xml
+++ b/jacoco-maven-plugin.test/it/setup-parent/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.1</version>
+      <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -47,7 +47,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.8.1</version>
+          <version>2.9</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.3.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Setting the same dependency and plugin versions as the build in order to enable offline execution of integration tests.
