### PR TITLE
dump mojo to signal remote process running in tcpserver mode

### DIFF
--- a/jacoco-maven-plugin.test/it/it-dump/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-dump/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+    Charles Honton
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-dump</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+              <goal>dump</goal>
+            </goals>
+            <configuration>
+              <output>tcpserver</output>
+              <port>0</port>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <maximum>0.1</maximum>
+                    </limit>
+                    <limit>
+                      <counter>CLASS</counter>
+                      <value>MISSEDCOUNT</value>
+                      <maximum>2</maximum>
+                      <minimum>2</minimum>
+                      </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>          
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>Launch</argument>
+            <argument>${argLine}</argument>
+          </arguments>
+        </configuration>
+      </plugin>      
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-dump/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-dump/src/main/java/Example.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Chas Honton - initial implementation
+ *
+ *******************************************************************************/
+public class Example {
+
+	private static final long TEN_MINUTES = 10 * 1000 * 60;
+
+	public static void main(final String[] args) {
+		System.out.println(System.currentTimeMillis()+": Hello ...");
+		try {
+			Thread.sleep(TEN_MINUTES);
+		} catch (final InterruptedException e) {
+			e.printStackTrace();
+		}
+		System.out.println(System.currentTimeMillis()+": ... world");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-dump/src/main/java/Launch.java
+++ b/jacoco-maven-plugin.test/it/it-dump/src/main/java/Launch.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Chas Honton - initial implementation
+ *
+ *******************************************************************************/
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+/**
+ * Class to launch a java process
+ */
+public class Launch {
+
+	/**
+	 * Launch Example in another process. Do not wait for Process to exit
+	 * 
+	 * @param arguments
+	 *            A single argument - the vm javaagent argument
+	 * @throws Exception
+	 */
+	public static void main(final String[] arguments) throws Exception {
+		final File javaHome = new File(System.getProperty("java.home"));
+		final File javaBin = new File(new File(javaHome, "bin"), "java");
+
+		final String javaPath = javaBin.getCanonicalPath();
+		final String javaAgent = arguments[0];
+		final String classpath = System.getProperty("java.class.path");
+
+		System.err.println("launching: " + javaPath + ' ' + javaAgent + ' '
+				+ "-cp" + ' ' + classpath + ' ' + "Example");
+		final ProcessBuilder builder = new ProcessBuilder(javaPath, javaAgent,
+				"-cp", classpath, "Example");
+
+		builder.redirectErrorStream(true);
+		final Process process = builder.start();
+		process.getOutputStream().close();
+		final InputStream is = process.getInputStream();
+		final Thread streamPump = new Thread() {
+			@Override
+			public void run() {
+				copy(is, System.out);
+			}
+		};
+		streamPump.setDaemon(true);
+		streamPump.start();
+	}
+
+	private static void copy(final InputStream is, final PrintStream out) {
+		try {
+			for (;;) {
+				final int c = is.read();
+				if (c < 0) {
+					break;
+				}
+				out.append((char) c);
+			}
+		} catch (final IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-dump/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-dump/verify.bsh
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+if ( buildLog.indexOf( "All coverage checks have been met." ) < 0 ) {
+    throw new RuntimeException( "Coverage checks were not met." );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ClientCollector.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ClientCollector.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Chas Honton - initial implementation
+ *
+ *******************************************************************************/
+
+package org.jacoco.maven;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.jacoco.core.data.ExecutionDataWriter;
+import org.jacoco.core.runtime.RemoteControlReader;
+import org.jacoco.core.runtime.RemoteControlWriter;
+
+/**
+ * A tcpclient dump collector
+ */
+public class ClientCollector {
+
+	private final String address;
+	private final int port;
+	private final File destFile;
+	private final boolean append;
+
+	ClientCollector(final String address, final int port, final File destFile,
+			final boolean append) {
+		this.address = address;
+		this.port = port;
+		this.destFile = destFile;
+		this.append = append;
+	}
+
+	void dump() throws IOException, MojoExecutionException {
+
+		final Socket socket = createClientSocket();
+
+		final RemoteControlWriter remoteWriter = new RemoteControlWriter(
+				socket.getOutputStream());
+		final RemoteControlReader remoteReader = new RemoteControlReader(
+				socket.getInputStream());
+
+		final OutputStream output = createFileOutputStream();
+		try {
+			final ExecutionDataWriter outputWriter = new ExecutionDataWriter(
+					output);
+			remoteReader.setSessionInfoVisitor(outputWriter);
+			remoteReader.setExecutionDataVisitor(outputWriter);
+
+			remoteWriter.visitDumpCommand(true, false);
+			remoteReader.read();
+
+			socket.close();
+		} finally {
+			output.close();
+		}
+	}
+
+	private Socket createClientSocket() throws MojoExecutionException {
+		final InetSocketAddress endpoint = getSocketAddress();
+		try {
+			final Socket client = new Socket();
+			client.connect(endpoint);
+			return client;
+		} catch (final IOException e) {
+			throw new MojoExecutionException("Can not open client socket "
+					+ endpoint, e);
+		}
+	}
+
+	InetSocketAddress getSocketAddress() throws MojoExecutionException {
+		try {
+			final InetAddress inetAddress = InetAddress.getByName(address);
+			final InetSocketAddress endpoint = new InetSocketAddress(
+					inetAddress, port);
+			return endpoint;
+		} catch (final UnknownHostException e) {
+			throw new MojoExecutionException("Can not resolve " + address, e);
+		}
+	}
+
+	FileOutputStream createFileOutputStream() throws MojoExecutionException {
+		try {
+			final FileOutputStream fs = new FileOutputStream(destFile, append);
+			fs.getChannel().lock();
+			return fs;
+		} catch (final FileNotFoundException e) {
+			throw new MojoExecutionException("Can not find " + destFile, e);
+		} catch (final IOException e) {
+			throw new MojoExecutionException("Can not lock " + destFile, e);
+		}
+	}
+
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Chas Honton - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Start a jacoco tcp server collector
+ * 
+ * @goal dump
+ * 
+ * @phase post-integration-test
+ */
+public class DumpMojo extends AbstractJacocoMojo {
+
+	/**
+	 * Project properties
+	 * 
+	 * @parameter expression="${project.properties}"
+	 * @required
+	 * @readonly
+	 */
+	protected Properties projectProperties;
+
+	/**
+	 * Path to the output file for execution data.
+	 * 
+	 * @parameter expression="${jacoco.destFile}"
+	 *            default-value="${project.build.directory}/jacoco.exec"
+	 */
+	private File destFile;
+
+	/**
+	 * If set to true and the execution data file already exists, coverage data
+	 * is appended to the existing file. If set to false, an existing execution
+	 * data file will be replaced.
+	 * 
+	 * @parameter expression="${jacoco.append}" default-value="true"
+	 */
+	private boolean append;
+
+	/**
+	 * IP address or hostname of the jacoco tcpserver collector.
+	 * 
+	 * @parameter expression="${jacoco.address}" default-value="127.0.0.1"
+	 */
+	private String address;
+
+	/**
+	 * Port of the jacoco tcpserver collector. If multiple JaCoCo agents should
+	 * run on the same machine, different ports have to be specified. If this
+	 * value is 0, the property setup by the prepare-agent goal will be parsed
+	 * to determine the os allocated port.
+	 * 
+	 * @parameter expression="${jacoco.port}" default-value="6300"
+	 */
+	private int port;
+
+	/**
+	 * Specify the property which contains settings for JaCoCo Agent. If not
+	 * specified, then "argLine" will be used. The value of this property is
+	 * used when portNumber is zero to find the previously assigned port number
+	 * .
+	 * 
+	 * @parameter expression="${jacoco.propertyName}" default-value="argLine"
+	 */
+	private String propertyName;
+
+	@Override
+	public void executeMojo() throws MojoExecutionException {
+		try {
+			final ClientCollector client = new ClientCollector(address,
+					getPort(), destFile, append);
+			client.dump();
+		} catch (final IOException e) {
+			throw new MojoExecutionException("Error in dump", e);
+		}
+	}
+
+	private int getPort() throws MojoExecutionException {
+		if (port != 0) {
+			return port;
+		}
+		// get value saved by prepare-agent goal
+		final Object value = projectProperties.get(propertyName + ".port");
+		if (!(value instanceof Integer)) {
+			throw new MojoExecutionException("Property '" + propertyName
+					+ "' (" + value + ") does not specify port");
+		}
+		return ((Integer) value).intValue();
+	}
+}


### PR DESCRIPTION
As requested, 
- with only the new feature in revision history
- no single inheritance abstract class
- no dependency on argLine
