### PR TITLE
New feature to add in support to exclude scala-type mixins from the cove...

### DIFF
--- a/jacoco-maven-plugin.test/it/it-excludesMixins/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-excludesMixins/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>jacoco</groupId>
+		<artifactId>setup-parent</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>it-includesMixins</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.10.0</version>
+        </dependency>
+    </dependencies>
+    
+	<build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+                <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>pre-test</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<excludeMixins>true</excludeMixins>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>${argLine}</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-excludesMixins/src/main/scala/Example.scala
+++ b/jacoco-maven-plugin.test/it/it-excludesMixins/src/main/scala/Example.scala
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+class Example extends ExampleTrait {
+  def sayHello() {
+    println("Hello world")
+  }
+}

--- a/jacoco-maven-plugin.test/it/it-excludesMixins/src/main/scala/ExampleTrait.scala
+++ b/jacoco-maven-plugin.test/it/it-excludesMixins/src/main/scala/ExampleTrait.scala
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+trait ExampleTrait {
+  def thisIsMixedIn() {
+    println("Hello world")
+  }
+}

--- a/jacoco-maven-plugin.test/it/it-excludesMixins/src/test/scala/ExampleTest.scala
+++ b/jacoco-maven-plugin.test/it/it-excludesMixins/src/test/scala/ExampleTest.scala
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+import org.junit.Test
+
+class GreetingTest {
+
+  @Test
+  def test() {
+    new Example().sayHello
+  }
+}

--- a/jacoco-maven-plugin.test/it/it-excludesMixins/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-excludesMixins/verify.bsh
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String htmlReport = FileUtils.fileRead( new File( basedir, "target/site/jacoco/default/Example.html" ) );
+if ( htmlReport.indexOf( "class=\"el_method\">thisIsMixedIn()" ) > -1 ) {
+    throw new RuntimeException( "Mixin results should NOT have been included in the coverage report." );
+}

--- a/jacoco-maven-plugin.test/it/it-includesMixins/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-includesMixins/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>jacoco</groupId>
+		<artifactId>setup-parent</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>it-includesMixins</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.10.0</version>
+        </dependency>
+    </dependencies>
+    
+	<build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+                <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>pre-test</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<excludeMixins>false</excludeMixins>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>${argLine}</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-includesMixins/src/main/scala/Example.scala
+++ b/jacoco-maven-plugin.test/it/it-includesMixins/src/main/scala/Example.scala
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+class Example extends ExampleTrait {
+  def sayHello() {
+    println("Hello world")
+  }
+}

--- a/jacoco-maven-plugin.test/it/it-includesMixins/src/main/scala/ExampleTrait.scala
+++ b/jacoco-maven-plugin.test/it/it-includesMixins/src/main/scala/ExampleTrait.scala
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+trait ExampleTrait {
+  def thisIsMixedIn() {
+    println("Hello world")
+  }
+}

--- a/jacoco-maven-plugin.test/it/it-includesMixins/src/test/scala/ExampleTest.scala
+++ b/jacoco-maven-plugin.test/it/it-includesMixins/src/test/scala/ExampleTest.scala
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+import org.junit.Test
+
+class GreetingTest {
+
+  @Test
+  def test() {
+    new Example().sayHello
+  }
+}

--- a/jacoco-maven-plugin.test/it/it-includesMixins/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-includesMixins/verify.bsh
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2013 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String htmlReport = FileUtils.fileRead( new File( basedir, "target/site/jacoco/default/Example.html" ) );
+if ( htmlReport.indexOf( "class=\"el_method\">thisIsMixedIn()" ) < 0 ) {
+    throw new RuntimeException( "Mixin results should have been included in the coverage report." );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
@@ -21,12 +21,13 @@ import org.codehaus.plexus.util.FileUtils;
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IBundleCoverage;
+import org.jacoco.core.analysis.ICoverageVisitor;
 import org.jacoco.core.data.ExecutionDataStore;
 
 /**
  * Creates an IBundleCoverage.
  */
-public final class BundleCreator {
+public class BundleCreator {
 
 	private final MavenProject project;
 	private final FileFilter fileFilter;
@@ -45,6 +46,20 @@ public final class BundleCreator {
 	}
 
 	/**
+	 * 
+	 * Factory method for creating an Analyzer
+	 * 
+	 * @param executionDataStore
+	 * @param coverageVisitor
+	 * @return an Analyzer
+	 */
+	protected Analyzer createAnalyzer(
+			final ExecutionDataStore executionDataStore,
+			final ICoverageVisitor coverageVisitor) {
+		return new Analyzer(executionDataStore, coverageVisitor);
+	}
+
+	/**
 	 * Create an IBundleCoverage for the given ExecutionDataStore.
 	 * 
 	 * @param executionDataStore
@@ -56,7 +71,7 @@ public final class BundleCreator {
 	public IBundleCoverage createBundle(
 			final ExecutionDataStore executionDataStore) throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
-		final Analyzer analyzer = new Analyzer(executionDataStore, builder);
+		final Analyzer analyzer = createAnalyzer(executionDataStore, builder);
 		final File classesDir = new File(this.project.getBuild()
 				.getOutputDirectory());
 


### PR DESCRIPTION
Pull request to add in support to exclude the types of mixins that the scala compiler emits in bytecode from coverage reports (Issue #139). The change is pretty non-invasive: there is a new flag added to the jacoco:report goal called "excludeMixins". If it is not set, then it defaults to "false", and the behavior of the report goal is identical to its current behavior. If this flag is configured to "true", then any IMethodCoverages that are mixed-in from a scala trait are ignored in the coverage report. These mixed-in methods can be identified because their line numbers are identical to the line number for a constructor of the class that mixes them in.
I have also included 2 integration tests to verify that this flag behaves as indicated for true and false values of the excludeMixins flag.
Thanks for the great work you are doing on jacoco!
---Tim---
