### PR TITLE
Add default prefix to the Maven execution IDs in jacoco examples.

### DIFF
--- a/org.jacoco.examples/build/pom-offline.xml
+++ b/org.jacoco.examples/build/pom-offline.xml
@@ -46,20 +46,26 @@
         <version>@project.version@</version>
         <executions>
           <execution>
+            <id>default-instrument</id>
             <goals>
               <goal>instrument</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-restore-instrumented-classes</id>
+            <goals>
               <goal>restore-instrumented-classes</goal>
             </goals>
           </execution>
           <execution>
-            <id>report</id>
+            <id>default-report</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>
           </execution>
           <execution>
-            <id>check</id>
+            <id>default-check</id>
             <goals>
               <goal>check</goal>
             </goals>

--- a/org.jacoco.examples/build/pom.xml
+++ b/org.jacoco.examples/build/pom.xml
@@ -39,20 +39,20 @@
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>prepare-agent</id>
+            <id>default-prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
-            <id>report</id>
+            <id>default-report</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>
           </execution>
           <execution>
-            <id>check</id>
+            <id>default-check</id>
             <goals>
               <goal>check</goal>
             </goals>


### PR DESCRIPTION
As discussed in https://groups.google.com/d/msg/jacoco/NuJc2YgTsSk/X9ccG4iL7oYJ.
Further information on Maven execution IDs:
- http://maven.apache.org/guides/mini/guide-default-execution-ids.html
- http://docs.codehaus.org/display/MAVENUSER/Default+Plugin+Execution+IDs

On my machine a run of `mvn clean verify` did succeed.
