### PR TITLE
Replace duplicate declaration of xml-maven-plugin by two executions and providing ids.

### DIFF
--- a/org.jacoco.doc/pom.xml
+++ b/org.jacoco.doc/pom.xml
@@ -242,63 +242,59 @@
         <artifactId>xml-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>default-transform</id>
             <goals>
               <goal>transform</goal>
             </goals>
+            <configuration>
+              <transformationSets>
+                <transformationSet>
+                  <dir>../jacoco-maven-plugin/target/generated-site/xdoc</dir>
+                  <includes>
+                    <include>*.xml</include>
+                  </includes>
+                  <stylesheet>xsl/maven-goal.xsl</stylesheet>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                      <targetExtension>.html</targetExtension>
+                    </fileMapper>
+                  </fileMappers>
+                  <parameters>
+                    <parameter>
+                      <name>qualified.bundle.version</name>
+                      <value>${qualified.bundle.version}</value>
+                    </parameter>
+                    <parameter>
+                      <name>jacoco.home.url</name>
+                      <value>${jacoco.home.url}</value>
+                    </parameter>
+                    <parameter>
+                      <name>copyright.years</name>
+                      <value>${copyright.years}</value>
+                    </parameter>
+                  </parameters>
+                </transformationSet>
+              </transformationSets>
+            </configuration>
           </execution>
-        </executions>
-        <configuration>
-          <transformationSets>
-            <transformationSet>
-              <dir>../jacoco-maven-plugin/target/generated-site/xdoc</dir>
-              <includes>
-                <include>*.xml</include>
-              </includes>
-              <stylesheet>xsl/maven-goal.xsl</stylesheet>
-              <fileMappers>
-                <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
-                  <targetExtension>.html</targetExtension>
-                </fileMapper>
-              </fileMappers>
-              <parameters>
-                <parameter>
-                  <name>qualified.bundle.version</name>
-                  <value>${qualified.bundle.version}</value>
-                </parameter>
-                <parameter>
-                  <name>jacoco.home.url</name>
-                  <value>${jacoco.home.url}</value>
-                </parameter>
-                <parameter>
-                  <name>copyright.years</name>
-                  <value>${copyright.years}</value>
-                </parameter>
-              </parameters>
-            </transformationSet>
-          </transformationSets>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>xml-maven-plugin</artifactId>
-        <executions>
           <execution>
+            <id>default-validate</id>
             <goals>
               <goal>validate</goal>
             </goals>
+            <configuration>
+              <validationSets>
+                <validationSet>
+                  <dir>.</dir>
+                  <includes>
+                    <include>docroot/**/*.html</include>
+                    <include>target/generated-resources/xml/xslt/*.html</include>
+                  </includes>
+                </validationSet>
+              </validationSets>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <validationSets>
-            <validationSet>
-              <dir>.</dir>
-              <includes>
-                <include>docroot/**/*.html</include>
-                <include>target/generated-resources/xml/xslt/*.html</include>
-              </includes>
-            </validationSet>
-          </validationSets>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Subject mostly says it:
- Pull the second execution up.
- Define ids for both executions.
- Move configurations into the execution element.
