### PR TITLE
Move the socket initialization to outer scope.

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
@@ -103,11 +103,9 @@ public class DumpMojo extends AbstractJacocoMojo {
 		try {
 			final ExecFileLoader loader = new ExecFileLoader();
 
-			Socket socket = null;
+			final Socket socket = tryConnect();
 			try {
-
-				// 1. Open socket connection
-				socket = tryConnect();
+				// 1. Get streams from socket
 				final RemoteControlWriter remoteWriter = new RemoteControlWriter(
 						socket.getOutputStream());
 				final RemoteControlReader remoteReader = new RemoteControlReader(
@@ -122,9 +120,7 @@ public class DumpMojo extends AbstractJacocoMojo {
 				remoteReader.read();
 
 			} finally {
-				if (socket != null) {
-					socket.close();
-				}
+				socket.close();
 			}
 
 			// 3. Write execution data to file

--- a/org.jacoco.ant/src/org/jacoco/ant/DumpTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/DumpTask.java
@@ -130,13 +130,12 @@ public class DumpTask extends Task {
 		}
 
 		try {
+
 			final ExecFileLoader loader = new ExecFileLoader();
 
-			Socket socket = null;
+			final Socket socket = tryConnect();
 			try {
-
-				// 1. Open socket connection
-				socket = tryConnect();
+				// 1. Get streams from socket
 				final RemoteControlWriter remoteWriter = new RemoteControlWriter(
 						socket.getOutputStream());
 				final RemoteControlReader remoteReader = new RemoteControlReader(
@@ -151,9 +150,7 @@ public class DumpTask extends Task {
 				remoteReader.read();
 
 			} finally {
-				if (socket != null) {
-					socket.close();
-				}
+				socket.close();
 			}
 
 			// 3. Write execution data to file
@@ -163,7 +160,6 @@ public class DumpTask extends Task {
 				loader.save(destfile, append);
 			}
 
-			socket.close();
 
 		} catch (final IOException e) {
 			throw new BuildException("Unable to dump coverage data", e,


### PR DESCRIPTION
This guarentees that socket is not null. Additionally remove the second `socket.close()` in the `DumpTask`. 
