### PR TITLE
Fix build failure on Windows

### DIFF
--- a/jacoco-maven-plugin.test/it/it-customize-agent/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-customize-agent/verify.bsh
@@ -23,6 +23,9 @@ String agentOptions = "destfile=" + basedir + File.separator + "target" + File.s
     + ",address=localhost"
     + ",port=9999"
     + ",classdumpdir=" + basedir + File.separator + "target" + File.separator + "classdumps";
+
+//backslashes will be escaped
+agentOptions = agentOptions.replace("\\","\\\\");
 String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
 if ( buildLog.indexOf( agentOptions ) < 0 ) {
     throw new RuntimeException( "Property was not configured, expected " + agentOptions );

--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -108,7 +108,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>2605000</maxsize>
+                  <maxsize>2610000</maxsize>
                   <minsize>2100000</minsize>
                   <files>
                     <file>${project.build.directory}/jacoco-${qualified.bundle.version}.zip</file>

--- a/org.jacoco.examples.test/src/org/jacoco/examples/ConsoleOutput.java
+++ b/org.jacoco.examples.test/src/org/jacoco/examples/ConsoleOutput.java
@@ -47,7 +47,7 @@ public class ConsoleOutput extends ExternalResource {
 	}
 
 	public static Matcher<String> containsLine(String line) {
-		return containsString(String.format("%s\n", line));
+		return containsString(String.format("%s%n", line));
 	}
 
 	public static Matcher<String> isEmpty() {


### PR DESCRIPTION
(1) it-customize-agent is failing on windows because it failing to taking in account escaping of backslashes
(2) Unit test ClassInfoTest, CoreTutorialTest and ExecDumpTest were failing as ConsoleOutput.containsLine wasn't considering the platform new line charcher
(3) Needed to increase allowance for max file size, As the windows build was failing with error message: size (2605888) too large. Max. is 2605000
