### PR TITLE
Add configuration option to replace argLine property.

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -53,6 +53,14 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	 */
 	protected String propertyName;
 	/**
+	 * If set to true, the existing property value is overwritten and not
+	 * appended.
+	 *
+	 * @parameter expression="${jacoco.propertyOverride}" default-value="false"
+	 * @since 0.6.5
+	 */
+	protected boolean propertyOverride;
+	/**
 	 * If set to true and the execution data file already exists, coverage data
 	 * is appended to the existing file. If set to false, an existing execution
 	 * data file will be replaced.
@@ -140,7 +148,8 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 		final Properties projectProperties = getProject().getProperties();
 		final String oldValue = projectProperties.getProperty(name);
 		final String newValue = createAgentOptions().prependVMArguments(
-				oldValue, getAgentJarFile());
+				propertyOverride ? null : oldValue,
+				getAgentJarFile());
 		getLog().info(name + " set to " + newValue);
 		projectProperties.setProperty(name, newValue);
 	}


### PR DESCRIPTION
This adds a new configuration option, "propertyOverride" which allows
full replacement of the argLine property. The current behaviour (keeping the
old value) is not desirable if the property is not actually argLine itself
but some other property which holds a default value. This change allows using

```
  <properties>
      <myProperty>default-value</myProperty>
  </properties>

...

  <plugin>
     ... jacoco plugin ...
    <configuration>
        <propertyName>myProperty</propertyName>
        <propertyOverride>true</propertyOverride>
    </configuration>
  </plugin>
```

and have the value be either the default-value (if the prepare-agent
goal is not run) or the agent line (if the prepare-agent goal is run)
instead of the agent line with the default-value appended.
