### PR TITLE
Update Analyzer.java

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -191,6 +191,8 @@ public class Analyzer {
 			for (final File f : file.listFiles()) {
 				count += analyzeAll(f);
 			}
+		} else if (file.length() == 0l) {
+			// ignore the file
 		} else {
 			final InputStream in = new FileInputStream(file);
 			try {


### PR DESCRIPTION
Using jacoco through gradle I see this error:
Caused by: java.util.zip.ZipException: invalid bit length repeat
        at org.jacoco.core.internal.ContentTypeDetector.readInt(ContentTypeDetector.java:94)
        at org.jacoco.core.internal.ContentTypeDetector.determineType(ContentTypeDetector.java:68)
        at org.jacoco.core.internal.ContentTypeDetector.<init>(ContentTypeDetector.java:63)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:161)
        at org.jacoco.core.analysis.Analyzer.analyzeZip(Analyzer.java:235)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:167)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:197)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.core.analysis.Analyzer.analyzeAll(Analyzer.java:192)
        at org.jacoco.ant.ReportTask.createBundle(ReportTask.java:567)
        at org.jacoco.ant.ReportTask.createReport(ReportTask.java:545)
        at org.jacoco.ant.ReportTask.execute(ReportTask.java:492)
        ... 64 more

It seems that jacoco tries to detect file type for an empty file. This prevents the error.
