### PR TITLE
GitHub #44: (Regression) Agent Mojo should set empty property, if execution was skipped

### DIFF
--- a/jacoco-maven-plugin.test/it/it-multi-module/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-multi-module/verify.bsh
@@ -22,6 +22,10 @@ if ( dump2.isFile() ) {
     throw new RuntimeException( "Should not be executed for module 'skip-child', but dump found : " + dump2 );
 }
 
+if ( !buildLog.contains( "argLine set to empty" ) ) {
+    throw new RuntimeException( "Property not set to empty when skipping." );
+}
+
 File file = new File( basedir, "child/target/jacoco.exec" );
 if ( !file.isFile() )
 {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -145,6 +145,14 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 		projectProperties.setProperty(name, newValue);
 	}
 
+	@Override
+	protected void skipMojo() {
+		final String name = getEffectivePropertyName();
+		final Properties projectProperties = getProject().getProperties();
+		getLog().info(name + " set to empty");
+		projectProperties.setProperty(name, "");
+	}
+
 	File getAgentJarFile() {
 		final Artifact jacocoAgentArtifact = pluginArtifactMap
 				.get(AGENT_ARTIFACT_NAME);


### PR DESCRIPTION
This is a patch for a regression on GitHub #44 which doesn't seem to be working since 0.6.4 including 0.6.5-SNAPSHOT.
