### PR TITLE
Added support for instrument dependency classes by extracting them from dependency jars provided on pom file

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
@@ -11,12 +11,18 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import java.util.List;
-
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Base class for JaCoCo Mojos.
@@ -31,7 +37,33 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 	 */
 	private MavenProject project;
 
-	/**
+    /**
+     * @component
+     */
+    private ArtifactResolver resolver;
+
+    /**
+     * Path to local repository
+     *
+     * @parameter default-value="${localRepository}"
+     */
+    private ArtifactRepository localRepository;
+
+    /**
+     * Flag to enable multi-module project coverage
+     *
+     * @parameter default-value="false"
+     */
+    private boolean isMultiModule;
+
+    /**
+     * Patter for classes copied if multi-module option is enabled.
+     *
+     * @parameter
+     */
+    private String packagePattern;
+
+    /**
 	 * A list of class files to include in instrumentation/analysis/reports. May
 	 * use wildcard characters (* and ?). When not specified everything will be
 	 * included.
@@ -112,4 +144,40 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 		return excludes;
 	}
 
+    /**
+     * @return true if project is multi-module project, false if not
+     */
+    public final boolean isMultiModuleProject() {
+        return isMultiModule;
+    }
+
+    /**
+     * In most of cases the user wants only classes of project without external jars
+     *
+     * @return package patter
+     */
+    public final String getPackagePattern() {
+        return packagePattern;
+    }
+
+
+    /**
+     * Get path of dependency jar
+     *
+     * @param artifact  Dependency artifact
+     * @return          path to dependency jar located into local repository. Return null if it was not found.
+     */
+    public String getDependencyJarPath(Artifact artifact)
+    {
+        try {
+            resolver.resolve(artifact, new ArrayList(), localRepository);
+            return artifact.getFile().getPath();
+        } catch (ArtifactResolutionException e) {
+            getLog().error(e);
+        } catch (ArtifactNotFoundException e) {
+            getLog().error(e);
+        }
+
+        return null;
+    }
 }

--- a/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
@@ -11,20 +11,19 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
+import org.jacoco.maven.util.FileUtil;
+
+import java.io.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Performs offline instrumentation. Note that after execution of test you must
@@ -60,7 +59,30 @@ public class InstrumentMojo extends AbstractJacocoMojo {
 			return;
 		}
 
-		final List<String> fileNames;
+
+        /**
+         * Copy dependency classes if project is multi-module and package patter is not null
+         */
+        if(isMultiModuleProject() && (getPackagePattern() != null))
+        {
+            Set artifacts = getProject().getDependencyArtifacts();
+            for (Iterator artifactIterator = artifacts.iterator(); artifactIterator.hasNext();) {
+                Artifact artifact = (Artifact) artifactIterator.next();
+                if(artifact.getGroupId().contains(getPackagePattern()))
+                {
+                    getLog().info("Found dependency: "+artifact.getArtifactId());
+                    String dependencyJarPath = getDependencyJarPath(artifact);
+                    if(dependencyJarPath != null)
+                    {
+                        getLog().info("Jar found in: "+dependencyJarPath);
+                        FileUtil.extractClassesFromJar(getProject(), dependencyJarPath);
+                    }
+                }
+            }
+        }
+
+
+        final List<String> fileNames;
 		try {
 			fileNames = new FileFilter(this.getIncludes(), this.getExcludes())
 					.getFileNames(classesDir);

--- a/jacoco-maven-plugin/src/org/jacoco/maven/RestoreMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/RestoreMojo.java
@@ -11,12 +11,16 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import java.io.File;
-import java.io.IOException;
-
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.FileUtils;
+import org.jacoco.maven.util.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
 
 /**
  * Restores original classes as they were before offline instrumentation.
@@ -41,6 +45,25 @@ public class RestoreMojo extends AbstractJacocoMojo {
 		} catch (final IOException e) {
 			throw new MojoFailureException("Unable to restore classes.", e);
 		}
+
+        /**
+         * Delete dependency classes if project is multi-module and package patter is not null
+         */
+        if(isMultiModuleProject() && (getPackagePattern() != null))
+        {
+            Set artifacts = getProject().getDependencyArtifacts();
+            for (Iterator artifactIterator = artifacts.iterator(); artifactIterator.hasNext();) {
+                Artifact artifact = (Artifact) artifactIterator.next();
+                if(artifact.getGroupId().contains(getPackagePattern()))
+                {
+                    getLog().info("Found dependency: "+artifact.getArtifactId());
+                    String dependencyJarPath = getDependencyJarPath(artifact);
+                    if(dependencyJarPath != null) {
+                        FileUtil.deleteDependencyFile(getProject(), dependencyJarPath);
+                    }
+                }
+            }
+        }
 	}
 
 }

--- a/jacoco-maven-plugin/src/org/jacoco/maven/util/FileUtil.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/util/FileUtil.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2014 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Andrey Klimachev - support for multi-module maven projects.
+ *
+ *******************************************************************************/
+
+package org.jacoco.maven.util;
+
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Utility functions related to files.
+ */
+public final class FileUtil {
+
+    /**
+     * Creates a new instance of {@link FileUtil}
+     */
+    private FileUtil() {}
+
+
+    /**
+     * Extract jar content into build output directory.
+     *
+     * @param project   Maven project
+     * @param jarPath   Path to jar file.
+     */
+    public static void extractClassesFromJar(MavenProject project, String jarPath)
+    {
+        try {
+            JarFile jar = new JarFile(jarPath);
+
+            Enumeration enum1 = jar.entries();
+            while (enum1.hasMoreElements()) {
+
+                JarEntry file = (JarEntry) enum1.nextElement();
+                File f = new File(project.getBuild().getOutputDirectory() + java.io.File.separator + file.getName());
+                if (file.isDirectory()) {
+                    f.mkdir();
+                    continue;
+                }
+                InputStream is = jar.getInputStream(file);
+                FileOutputStream fos = new FileOutputStream(f);
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = is.read(buffer)) != -1) {
+                    fos.write(buffer, 0, read);
+                }
+                fos.close();
+                is.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Delete copied content from built output directory.
+     *
+     * @param project   Maven project
+     * @param jarPath   Path to jar file.
+     */
+    public static void deleteDependencyFile(MavenProject project, String jarPath)
+    {
+        try {
+            JarFile jar = new JarFile(jarPath);
+
+            Enumeration enum1 = jar.entries();
+            while (enum1.hasMoreElements()) {
+
+                JarEntry file = (JarEntry) enum1.nextElement();
+                if(file.getName().endsWith(".class"))
+                {
+                    File f = new File(project.getBuild().getOutputDirectory() + java.io.File.separator + file.getName());
+                    if (!file.isDirectory() && f.exists()) {
+                        f.delete();
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This is a small change on the Jacoco maven plugin that allows collecting code coverage not only for the module being tested but also for its dependencies. It accomplishes this by extracting compiled classes from the JAR files. 

The functionality is enabled by flag `isMultiModule`. The flag `packagePattern` indicates which packages will be instrumented. One example of this configuration follows:

```
<groupId>org.jacoco</groupId>
<artifactId>jacoco-maven-plugin</artifactId>
<version>0.6.5-SNAPSHOT</version>
<configuration>
  <isMultiModule>true</isMultiModule>
  <packagePattern>com.mycompany</packagePattern>
</configuration>
```

For example, the module **B** has a dependency on module **A** declared on its POM file. What will happen in this case? On the instrumentation goal Jacoco will try to parse dependent JAR files and check if the groupId matches the provided `packagePattern`. When that happens the JAR will be extracted into the `/target/classes` folder and the coverage will be generated. On the restore-instrumented-classes goal the copied classes will be deleted.
