### PR TITLE
Add 'includebootclasspath' boolean option in order to allow instrumentat...

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
@@ -50,6 +50,7 @@ public class AgentOptionsTest {
 		assertEquals(6300, options.getPort());
 		assertNull(options.getClassDumpDir());
 		assertFalse(options.getJmx());
+		assertFalse(options.getIncludeBootclasspath());
 
 		assertEquals("", options.toString());
 	}
@@ -81,6 +82,7 @@ public class AgentOptionsTest {
 		properties.put("port", "1234");
 		properties.put("classdumpdir", "target/dump");
 		properties.put("jmx", "true");
+		properties.put("includebootclasspath", "true");
 
 		AgentOptions options = new AgentOptions(properties);
 
@@ -96,6 +98,7 @@ public class AgentOptionsTest {
 		assertEquals(1234, options.getPort());
 		assertEquals("target/dump", options.getClassDumpDir());
 		assertTrue(options.getJmx());
+		assertTrue(options.getIncludeBootclasspath());
 	}
 
 	@Test
@@ -333,6 +336,19 @@ public class AgentOptionsTest {
 		AgentOptions options = new AgentOptions();
 		options.setJmx(true);
 		assertTrue(options.getJmx());
+	}
+
+	@Test
+	public void testGetIncludeBootclsspath() {
+		AgentOptions options = new AgentOptions("includebootclasspath=true");
+		assertTrue(options.getIncludeBootclasspath());
+	}
+
+	@Test
+	public void testSetIncludeBootclsspath() {
+		AgentOptions options = new AgentOptions();
+		options.setIncludeBootclasspath(true);
+		assertTrue(options.getIncludeBootclasspath());
 	}
 
 	@Test

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -84,6 +84,12 @@ public final class AgentOptions {
 	public static final String DUMPONEXIT = "dumponexit";
 
 	/**
+	 * Specifies whether the agent will accept to instrument classes from the
+	 * bootclasspath. Default is <code>false</code>.
+	 */
+	public static final String INLUDEBOOTCLASSPATH = "bootclasspath";
+
+	/**
 	 * Specifies the output mode. Default is {@link OutputMode#file}.
 	 * 
 	 * @see OutputMode#file
@@ -166,7 +172,8 @@ public final class AgentOptions {
 
 	private static final Collection<String> VALID_OPTIONS = Arrays.asList(
 			DESTFILE, APPEND, INCLUDES, EXCLUDES, EXCLCLASSLOADER, SESSIONID,
-			DUMPONEXIT, OUTPUT, ADDRESS, PORT, CLASSDUMPDIR, JMX);
+			DUMPONEXIT, OUTPUT, ADDRESS, PORT, CLASSDUMPDIR, JMX,
+			INLUDEBOOTCLASSPATH);
 
 	private final Map<String, String> options;
 
@@ -371,6 +378,26 @@ public final class AgentOptions {
 	 */
 	public void setDumpOnExit(final boolean dumpOnExit) {
 		setOption(DUMPONEXIT, dumpOnExit);
+	}
+
+	/**
+	 * Retruns whether classes from the bootclasspath should be considered for
+	 * instrumentation.
+	 * @return <code>true</code> if classes from the bootclasspath should be
+	 * considered for instrumentation.
+	 */
+	public boolean getIncludeBootclasspath() {
+		return getOption(INLUDEBOOTCLASSPATH, false);
+	}
+
+	/**
+	 * Sets whether classes from the bootclasspath should be considered for
+	 * instrumentation.
+	 * @param includeBootclasspath <code>true</code> if classes from the
+	 * bootclasspath should be considered for instrumentation.
+	 */
+	public void setIncludeBootclasspath(final boolean includeBootclasspath) {
+		setOption(INLUDEBOOTCLASSPATH, includeBootclasspath);
 	}
 
 	/**


### PR DESCRIPTION
Add `includebootclasspath` boolean option in order to allow instrumentation of bootclasspath classes.

This can be useful in projects that produce artifacts that need to live in the bootclasspath.
