### PR TITLE
Added 'verbose' mode for the check goal/task

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -9,6 +9,7 @@
  *    Evgeny Mandrikov - initial API and implementation
  *    Kyle Lieber - implementation of CheckMojo
  *    Marc Hoffmann - redesign using report APIs
+ *    Håvard Nesvold - initial implementation of 'verbose' mode
  *
  *******************************************************************************/
 package org.jacoco.maven;
@@ -20,12 +21,12 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jacoco.core.analysis.IBundleCoverage;
-import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.tools.ExecFileLoader;
 import org.jacoco.report.IReportVisitor;
+import org.jacoco.report.JavaNames;
+import org.jacoco.report.check.CheckResult;
 import org.jacoco.report.check.ICheckerOutput;
-import org.jacoco.report.check.Limit;
 import org.jacoco.report.check.Rule;
 import org.jacoco.report.check.RulesChecker;
 
@@ -213,16 +214,16 @@ public class CheckMojo extends AbstractJacocoMojo implements ICheckerOutput {
 		return loader.getExecutionDataStore();
 	}
 
-	public void onViolation(final ICoverageNode node, final Rule rule,
-			final Limit limit, final String message) {
-		this.getLog().warn(message);
-		violations = true;
-	}
-
-    public void onConformance(final ICoverageNode node, final Rule rule,
-                              final Limit limit, final String message) {
-        if (verbose) {
-            this.getLog().info(message);
+    @Override
+    public void onResult(final CheckResult result) {
+        String message = result.createMessage();
+        if (result.getResult() == CheckResult.Result.OK) {
+            if (verbose) {
+                this.getLog().info(message);
+            }
+        } else {
+            this.getLog().warn(message);
+            violations = true;
         }
     }
 

--- a/org.jacoco.report.test/src/org/jacoco/report/check/BundleCheckerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/BundleCheckerTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.IClassCoverage;
-import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
@@ -57,7 +56,7 @@ public class BundleCheckerTest implements ICheckerOutput {
 		addRule(ElementType.BUNDLE);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for bundle Test: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage("Rule violated for BUNDLE Test: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -65,7 +64,7 @@ public class BundleCheckerTest implements ICheckerOutput {
 		addRule(ElementType.PACKAGE);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for package org.jacoco.example: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage("Rule violated for PACKAGE org.jacoco.example: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -73,7 +72,7 @@ public class BundleCheckerTest implements ICheckerOutput {
 		addRule(ElementType.SOURCEFILE);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for source file org/jacoco/example/FooClass.java: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage("Rule violated for SOURCEFILE org/jacoco/example/FooClass.java: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -81,7 +80,7 @@ public class BundleCheckerTest implements ICheckerOutput {
 		addRule(ElementType.CLASS);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for class org.jacoco.example.FooClass: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage("Rule violated for CLASS org.jacoco.example.FooClass: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -89,7 +88,7 @@ public class BundleCheckerTest implements ICheckerOutput {
 		addRule(ElementType.METHOD);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for method org.jacoco.example.FooClass.fooMethod(): instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage("Rule violated for METHOD org.jacoco.example.FooClass.fooMethod(): instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -155,14 +154,14 @@ public class BundleCheckerTest implements ICheckerOutput {
 		assertEquals(Collections.singletonList(expected), violationMessages);
 	}
 
-	public void onViolation(ICoverageNode node, Rule rule, Limit limit,
-			String message) {
-		violationMessages.add(message);
-	}
-
     @Override
-    public void onConformance(ICoverageNode node, Rule rule, Limit limit, String message) {
-        conformanceMessages.add(message);
+    public void onResult(CheckResult result) {
+        String message = result.createMessage();
+        if (result.getResult() == CheckResult.Result.OK) {
+            conformanceMessages.add(message);
+        } else {
+            violationMessages.add(message);
+        }
     }
 
 }

--- a/org.jacoco.report.test/src/org/jacoco/report/check/CheckResultTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/CheckResultTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2014 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Håvard Nesvold - initial implementation
+ *
+ *******************************************************************************/
+package org.jacoco.report.check;
+
+import org.jacoco.core.analysis.CoverageNodeImpl;
+import org.jacoco.core.analysis.ICoverageNode;
+import org.jacoco.core.internal.analysis.CounterImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CheckResultTest {
+
+    private ICoverageNode node;
+    private Limit limit;
+    private String elementName;
+
+    @Before
+    public void setup() {
+        node = new TestNode() {
+            {
+                instructionCounter = CounterImpl.getInstance(1000, 0);
+            }
+        };
+        limit = new Limit();
+        elementName = "Foo2";
+    }
+
+    @Test
+    public void testOKMessage() {
+        CheckResult result = CheckResult.ok(node, limit, elementName);
+
+        assertEquals("Rule conforms for CLASS Foo2: instructions covered ratio is 0.0", result.createMessage());
+    }
+
+    @Test
+    public void testTooLowMessage() {
+        limit.setMinimum("0.30");
+
+        CheckResult result = CheckResult.tooLow(node, limit, elementName);
+
+        assertEquals("Rule violated for CLASS Foo2: instructions covered ratio is 0.00, but expected minimum is 0.30", result.createMessage());
+    }
+
+    @Test
+    public void testTooHighMessage() {
+        limit.setMaximum("0.70");
+
+        CheckResult result = CheckResult.tooHigh(node, limit, elementName);
+
+        assertEquals("Rule violated for CLASS Foo2: instructions covered ratio is 0.00, but expected maximum is 0.70", result.createMessage());
+    }
+
+    private static class TestNode extends CoverageNodeImpl {
+        public TestNode() {
+            super(ElementType.CLASS, "Foo");
+        }
+    }
+
+}

--- a/org.jacoco.report.test/src/org/jacoco/report/check/LimitTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/LimitTest.java
@@ -12,7 +12,6 @@
 package org.jacoco.report.check;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -20,6 +19,7 @@ import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICounter.CounterValue;
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.report.JavaNames;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class LimitTest {
 		limit.setMaximum("-1");
 		assertEquals(CounterValue.TOTALCOUNT, limit.getValue());
 		assertEquals(
-				"instructions total count is 0, but expected maximum is -1",
+				"Rule violated for CLASS Foo: instructions total count is 0, but expected maximum is -1",
 				limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -59,7 +59,7 @@ public class LimitTest {
 		limit.setMaximum("-1");
 		assertEquals(CounterValue.MISSEDCOUNT, limit.getValue());
 		assertEquals(
-				"instructions missed count is 0, but expected maximum is -1",
+				"Rule violated for CLASS Foo: instructions missed count is 0, but expected maximum is -1",
 				limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -69,7 +69,7 @@ public class LimitTest {
 		limit.setMaximum("-1");
 		assertEquals(CounterValue.COVEREDCOUNT, limit.getValue());
 		assertEquals(
-				"instructions covered count is 0, but expected maximum is -1",
+				"Rule violated for CLASS Foo: instructions covered count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -79,7 +79,7 @@ public class LimitTest {
 		limit.setMaximum("-1");
 		assertEquals(CounterValue.MISSEDRATIO, limit.getValue());
 		assertEquals(
-				"instructions missed ratio is 0, but expected maximum is -1",
+				"Rule violated for CLASS Foo: instructions missed ratio is 0, but expected maximum is -1",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.COUNTER_0_1;
@@ -93,7 +93,7 @@ public class LimitTest {
 		limit.setMaximum("-1");
 		assertEquals(CounterValue.COVEREDRATIO, limit.getValue());
 		assertEquals(
-				"instructions covered ratio is 0, but expected maximum is -1",
+				"Rule violated for CLASS Foo: instructions covered ratio is 0, but expected maximum is -1",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.COUNTER_1_0;
@@ -108,7 +108,7 @@ public class LimitTest {
 		limit.setMaximum("-1");
 		assertEquals(CounterEntity.INSTRUCTION, limit.getEntity());
 		assertEquals(
-				"instructions total count is 0, but expected maximum is -1",
+				"Rule violated for CLASS Foo: instructions total count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -118,7 +118,7 @@ public class LimitTest {
 		limit.setCounter(CounterEntity.BRANCH.name());
 		limit.setMaximum("-1");
 		assertEquals(CounterEntity.BRANCH, limit.getEntity());
-		assertEquals("branches total count is 0, but expected maximum is -1",
+		assertEquals("Rule violated for CLASS Foo: branches total count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -128,17 +128,17 @@ public class LimitTest {
 		limit.setCounter(CounterEntity.LINE.name());
 		limit.setMaximum("-1");
 		assertEquals(CounterEntity.LINE, limit.getEntity());
-		assertEquals("lines total count is 0, but expected maximum is -1",
+		assertEquals("Rule violated for CLASS Foo: lines total count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
 	@Test
-	public void testComlexity() {
+	public void testComplexity() {
 		limit.setValue(CounterValue.TOTALCOUNT.name());
 		limit.setCounter(CounterEntity.COMPLEXITY.name());
 		limit.setMaximum("-1");
 		assertEquals(CounterEntity.COMPLEXITY, limit.getEntity());
-		assertEquals("complexity total count is 0, but expected maximum is -1",
+		assertEquals("Rule violated for CLASS Foo: complexity total count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -148,7 +148,7 @@ public class LimitTest {
 		limit.setCounter(CounterEntity.CLASS.name());
 		limit.setMaximum("-1");
 		assertEquals(CounterEntity.CLASS, limit.getEntity());
-		assertEquals("classes total count is 0, but expected maximum is -1",
+		assertEquals("Rule violated for CLASS Foo: classes total count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -158,7 +158,7 @@ public class LimitTest {
 		limit.setCounter(CounterEntity.METHOD.name());
 		limit.setMaximum("-1");
 		assertEquals(CounterEntity.METHOD, limit.getEntity());
-		assertEquals("methods total count is 0, but expected maximum is -1",
+		assertEquals("Rule violated for CLASS Foo: methods total count is 0, but expected maximum is -1",
                 limitCheckViolationMessage(new TestNode()));
 	}
 
@@ -173,11 +173,11 @@ public class LimitTest {
 
 	@Test
 	public void testNoLimits() {
-		assertFalse(limit.check(new TestNode() {
+		assertEquals(CheckResult.Result.OK, limit.check(new TestNode() {
             {
                 instructionCounter = CounterImpl.getInstance(1000, 0);
             }
-        }).isViolation());
+        }).getResult());
 	}
 
 	@Test
@@ -191,34 +191,34 @@ public class LimitTest {
 	public void testMin1() {
 		limit.setMinimum("0.35");
 		assertEquals("0.35", limit.getMinimum());
-		assertFalse(limit.check(new TestNode() {
+		assertEquals(CheckResult.Result.OK, limit.check(new TestNode() {
             {
                 instructionCounter = CounterImpl.getInstance(65, 35);
             }
-        }).isViolation());
+        }).getResult());
 	}
 
     @Test
-    public void testReportMessage() {
+    public void testMessageWhenConformant() {
         limit.setMinimum("0.35");
         assertEquals("0.35", limit.getMinimum());
-        assertEquals("instructions covered ratio is 0.35",
+        assertEquals("Rule conforms for CLASS Foo: instructions covered ratio is 0.35",
                 limit.check(new TestNode() {
             {
                 instructionCounter = CounterImpl.getInstance(65, 35);
             }
-        }).getMessage());
+        }).createMessage());
     }
 
 	@Test
 	public void testMin2() {
 		limit.setMinimum("0.35");
 		assertEquals("0.35", limit.getMinimum());
-		assertFalse(limit.check(new TestNode() {
+		assertEquals(CheckResult.Result.OK, limit.check(new TestNode() {
             {
                 instructionCounter = CounterImpl.getInstance(64, 36);
             }
-        }).isViolation());
+        }).getResult());
 	}
 
 	@Test
@@ -226,7 +226,7 @@ public class LimitTest {
 		limit.setMinimum("0.3500");
 		assertEquals("0.3500", limit.getMinimum());
 		assertEquals(
-				"instructions covered ratio is 0.3400, but expected minimum is 0.3500",
+				"Rule violated for CLASS Foo: instructions covered ratio is 0.3400, but expected minimum is 0.3500",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.getInstance(66, 34);
@@ -239,7 +239,7 @@ public class LimitTest {
 		limit.setMinimum("0.35");
 		assertEquals("0.35", limit.getMinimum());
 		assertEquals(
-				"instructions covered ratio is 0.34, but expected minimum is 0.35",
+				"Rule violated for CLASS Foo: instructions covered ratio is 0.34, but expected minimum is 0.35",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.getInstance(65001,
@@ -254,7 +254,7 @@ public class LimitTest {
 		limit.setValue(CounterValue.MISSEDCOUNT.name());
 		assertEquals("10000", limit.getMinimum());
 		assertEquals(
-				"instructions missed count is 9990, but expected minimum is 10000",
+				"Rule violated for CLASS Foo: instructions missed count is 9990, but expected minimum is 10000",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.getInstance(9990, 0);
@@ -267,7 +267,7 @@ public class LimitTest {
 		limit.setMinimum("12345");
 		assertEquals("12345", limit.getMinimum());
 		assertEquals(
-				"instructions covered ratio is 0, but expected minimum is 12345",
+				"Rule violated for CLASS Foo: instructions covered ratio is 0, but expected minimum is 12345",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.getInstance(1, 999);
@@ -287,22 +287,22 @@ public class LimitTest {
 		limit.setMaximum("12345678");
 		limit.setValue(CounterValue.MISSEDCOUNT.name());
 		assertEquals("12345678", limit.getMaximum());
-		assertFalse(limit.check(new TestNode() {
+		assertEquals(CheckResult.Result.OK, limit.check(new TestNode() {
             {
                 instructionCounter = CounterImpl.getInstance(12345678, 0);
             }
-        }).isViolation());
+        }).getResult());
 	}
 
 	@Test
 	public void testMax2() {
 		limit.setMaximum("0.999");
 		assertEquals("0.999", limit.getMaximum());
-		assertFalse(limit.check(new TestNode() {
+		assertEquals(CheckResult.Result.OK, limit.check(new TestNode() {
             {
                 instructionCounter = CounterImpl.getInstance(1, 99);
             }
-        }).isViolation());
+        }).getResult());
 	}
 
 	@Test
@@ -310,7 +310,7 @@ public class LimitTest {
 		limit.setMaximum("0.999");
 		assertEquals("0.999", limit.getMaximum());
 		assertEquals(
-				"instructions covered ratio is 1.000, but expected maximum is 0.999",
+				"Rule violated for CLASS Foo: instructions covered ratio is 1.000, but expected maximum is 0.999",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.getInstance(0, 1);
@@ -323,7 +323,7 @@ public class LimitTest {
 		limit.setMaximum("0.999");
 		assertEquals("0.999", limit.getMaximum());
 		assertEquals(
-				"instructions covered ratio is 1.000, but expected maximum is 0.999",
+				"Rule violated for CLASS Foo: instructions covered ratio is 1.000, but expected maximum is 0.999",
 				limitCheckViolationMessage(new TestNode() {
                     {
                         instructionCounter = CounterImpl.getInstance(999,
@@ -334,10 +334,10 @@ public class LimitTest {
 
     private String limitCheckViolationMessage(TestNode testNode) {
         String message = null;
-        Limit.CheckResult checkResult = limit.check(testNode);
+        CheckResult checkResult = limit.check(testNode);
         if (checkResult != null) {
-            assertTrue(checkResult.isViolation());
-            message = checkResult.getMessage();
+            assertTrue(checkResult.getResult() == CheckResult.Result.TOO_HIGH || checkResult.getResult() == CheckResult.Result.TOO_LOW);
+            message = checkResult.createMessage();
         }
         return message;
     }

--- a/org.jacoco.report.test/src/org/jacoco/report/check/RulesCheckerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/RulesCheckerTest.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jacoco.core.analysis.ICounter.CounterValue;
-import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.report.ILanguageNames;
 import org.jacoco.report.ReportStructureTestDriver;
@@ -53,7 +52,7 @@ public class RulesCheckerTest implements ICheckerOutput {
 		checker.setRules(Arrays.asList(rule));
 		driver.sendGroup(checker.createVisitor(this));
 		assertEquals(
-				Arrays.asList("Rule violated for bundle bundle: instructions missed count is 10, but expected maximum is 5"),
+				Arrays.asList("Rule violated for BUNDLE bundle: instructions missed count is 10, but expected maximum is 5"),
                 violationMessages);
 	}
 
@@ -93,18 +92,18 @@ public class RulesCheckerTest implements ICheckerOutput {
 
 		driver.sendGroup(checker.createVisitor(this));
 		assertEquals(
-				Arrays.asList("Rule violated for class MyClass: instructions missed count is 10, but expected maximum is 5"),
+				Arrays.asList("Rule violated for CLASS MyClass: instructions missed count is 10, but expected maximum is 5"),
                 violationMessages);
 	}
 
-	public void onViolation(ICoverageNode node, Rule rule, Limit limit,
-			String message) {
-		violationMessages.add(message);
-	}
-
     @Override
-    public void onConformance(ICoverageNode node, Rule rule, Limit limit, String message) {
-        conformanceMessages.add(message);
+    public void onResult(CheckResult result) {
+        String message = result.createMessage();
+        if (result.getResult() == CheckResult.Result.OK) {
+            conformanceMessages.add(message);
+        } else {
+            violationMessages.add(message);
+        }
     }
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/check/BundleChecker.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/BundleChecker.java
@@ -79,7 +79,7 @@ class BundleChecker {
 
 	public void checkBundle(final IBundleCoverage bundleCoverage) {
 		final String name = bundleCoverage.getName();
-		checkRules(bundleCoverage, bundleRules, "bundle", name);
+		checkRules(bundleCoverage, bundleRules, name);
 		if (traversePackages) {
 			for (final IPackageCoverage p : bundleCoverage.getPackages()) {
 				check(p);
@@ -89,7 +89,7 @@ class BundleChecker {
 
 	private void check(final IPackageCoverage packageCoverage) {
 		final String name = names.getPackageName(packageCoverage.getName());
-		checkRules(packageCoverage, packageRules, "package", name);
+		checkRules(packageCoverage, packageRules, name);
 		if (traverseClasses) {
 			for (final IClassCoverage c : packageCoverage.getClasses()) {
 				check(c);
@@ -105,7 +105,7 @@ class BundleChecker {
 	private void check(final IClassCoverage classCoverage) {
 		final String name = names
 				.getQualifiedClassName(classCoverage.getName());
-		checkRules(classCoverage, classRules, "class", name);
+		checkRules(classCoverage, classRules, name);
 		if (traverseMethods) {
 			for (final IMethodCoverage m : classCoverage.getMethods()) {
 				check(m, classCoverage.getName());
@@ -116,41 +116,33 @@ class BundleChecker {
 	private void check(final ISourceFileCoverage sourceFile) {
 		final String name = sourceFile.getPackageName() + "/"
 				+ sourceFile.getName();
-		checkRules(sourceFile, sourceFileRules, "source file", name);
+		checkRules(sourceFile, sourceFileRules, name);
 	}
 
 	private void check(final IMethodCoverage method, final String className) {
 		final String name = names.getQualifiedMethodName(className,
 				method.getName(), method.getDesc(), method.getSignature());
-		checkRules(method, methodRules, "method", name);
+		checkRules(method, methodRules, name);
 	}
 
 	private void checkRules(final ICoverageNode node,
-			final Collection<Rule> rules, final String typename,
+			final Collection<Rule> rules,
 			final String elementname) {
-		for (final Rule rule : rules) {
+        for (final Rule rule : rules) {
 			if (rule.matches(elementname)) {
 				for (final Limit limit : rule.getLimits()) {
-					checkLimit(node, typename, elementname, rule, limit);
+					checkLimit(node, limit, elementname);
 				}
 			}
 		}
 	}
 
-	private void checkLimit(final ICoverageNode node, final String elementtype,
-			final String typename, final Rule rule, final Limit limit) {
-		final Limit.CheckResult result = limit.check(node);
+	private void checkLimit(final ICoverageNode node, final Limit limit, String elementName) {
+		final CheckResult result = limit.check(node, elementName);
         if (result == null) {
             return;
         }
-		if (result.isViolation()) {
-			output.onViolation(node, rule, limit, String.format(
-					"Rule violated for %s %s: %s", elementtype, typename,
-					result.getMessage()));
-		} else {
-            output.onConformance(node, rule, limit,
-                    String.format("Rule conforms for %s %s: %s", elementtype, typename, result.getMessage()));
-        }
+        output.onResult(result);
 	}
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/check/CheckResult.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/CheckResult.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2014 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Håvard Nesvold - Initial implementation.
+ *
+ *******************************************************************************/
+package org.jacoco.report.check;
+
+import org.jacoco.core.analysis.ICoverageNode;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Value object containing the results from a single coverage check.
+ */
+public final class CheckResult {
+
+    public static enum Result {
+        OK, TOO_LOW, TOO_HIGH
+    }
+
+    private final ICoverageNode node;
+    private final String elementName;
+    private final Limit limit;
+    private final Result result;
+
+    private CheckResult(final ICoverageNode node,
+                       final Limit limit,
+                       final String elementName,
+                       final Result result) {
+
+        this.node = node;
+        this.limit = limit;
+        this.elementName = elementName;
+        this.result = result;
+    }
+
+    public static CheckResult tooLow(final ICoverageNode node, final Limit limit, final String elementName) {
+        return new CheckResult(node, limit, elementName, Result.TOO_LOW);
+    }
+
+    public static CheckResult tooHigh(final ICoverageNode node, final Limit limit, final String elementName) {
+        return new CheckResult(node, limit, elementName, Result.TOO_HIGH);
+    }
+
+    public static CheckResult ok(final ICoverageNode node, final Limit limit, final String elementName) {
+        return new CheckResult(node, limit, elementName, Result.OK);
+    }
+
+    public String createMessage() {
+        final BigDecimal value = BigDecimal.valueOf(node.getCounter(limit.getEntity()).getValue(limit.getValue()));
+        String message;
+        if (result == Result.OK) {
+            message = String.format("Rule conforms for %s %s: %s %s is %s",
+                    node.getElementType(),
+                    elementName,
+                    limit.getEntityName(),
+                    limit.getValueName(),
+                    value.toPlainString());
+        } else {
+            String minimumOrMaximum;
+            BigDecimal ref;
+            RoundingMode roundingMode;
+            if (result == Result.TOO_LOW) {
+                ref = new BigDecimal(limit.getMinimum());
+                roundingMode = RoundingMode.FLOOR;
+                minimumOrMaximum = "minimum";
+            } else if (result == Result.TOO_HIGH) {
+                roundingMode = RoundingMode.CEILING;
+                ref = new BigDecimal(limit.getMaximum());
+                minimumOrMaximum = "maximum";
+            } else {
+                throw new IllegalStateException("Unsupported result: " + result);
+            }
+            BigDecimal rounded = value.setScale(ref.scale(), roundingMode);
+            message = String.format("Rule violated for %s %s: %s %s is %s, but expected %s is %s",
+                    node.getElementType(),
+                    elementName,
+                    limit.getEntityName(),
+                    limit.getValueName(),
+                    rounded.toPlainString(),
+                    minimumOrMaximum,
+                    ref.toPlainString());
+        }
+        return message;
+    }
+    
+    public Result getResult() {
+        return result;
+    }
+
+}

--- a/org.jacoco.report/src/org/jacoco/report/check/ICheckerOutput.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/ICheckerOutput.java
@@ -7,44 +7,23 @@
  *
  * Contributors:
  *    Marc R. Hoffmann - initial API and implementation
+ *    Håvard Nesvold - refactored to also accommodate output from successful checks
  *    
  *******************************************************************************/
 package org.jacoco.report.check;
 
-import org.jacoco.core.analysis.ICoverageNode;
-
 /**
- * Call-back interface which is used to report rule violations / conformance to.
+ * Call-back interface which is used to report rule checks to.
  * 
  */
 public interface ICheckerOutput {
 
-	/**
-	 * Called for every rule violation.
-	 * 
-	 * @param node
-	 *            node which violates a rule
-	 * @param rule
-	 *            rule which is violated
-	 * @param limit
-	 *            limit which is violated
-	 * @param message
-	 *            readable message describing this violation
-	 */
-	void onViolation(ICoverageNode node, Rule rule, Limit limit, String message);
-
     /**
-     * Called for every conformant rule
+     * Called for every check;
      *
-     * @param node
-     *            node which conforms to a rule
-     * @param rule
-     *            rule which has been checked
-     * @param limit
-     *            limit which is upheld
-     * @param message
-     *            readable message describing the checked rule
+     * @param result
+     *            the result of the checked rule.
      */
-    void onConformance(ICoverageNode node, Rule rule, Limit limit, String message);
+    void onResult(CheckResult result);
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/check/Limit.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/Limit.java
@@ -12,7 +12,6 @@
 package org.jacoco.report.check;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -148,59 +147,31 @@ public class Limit {
 		this.maximum = maximum == null ? null : new BigDecimal(maximum);
 	}
 
-	CheckResult check(final ICoverageNode node) {
+    CheckResult check(final ICoverageNode node) {
+        return check(node, node.getName());
+    }
+
+	CheckResult check(final ICoverageNode node, final String elementName) {
 		final double d = node.getCounter(entity).getValue(value);
 		if (Double.isNaN(d)) {
 			return null;
 		}
 		final BigDecimal bd = BigDecimal.valueOf(d);
 		if (minimum != null && minimum.compareTo(bd) > 0) {
-			return new CheckResult(true, violationMessage("minimum", bd, minimum, RoundingMode.FLOOR));
+            return CheckResult.tooLow(node, this, elementName);
 		}
 		if (maximum != null && maximum.compareTo(bd) < 0) {
-			return new CheckResult(true, violationMessage("maximum", bd, maximum, RoundingMode.CEILING));
+			return CheckResult.tooHigh(node, this, elementName);
 		}
-		return new CheckResult(false, reportMessage(bd));
+		return CheckResult.ok(node, this, elementName);
 	}
 
-	private String violationMessage(final String minmax, final BigDecimal v,
-                                    final BigDecimal ref, final RoundingMode mode) {
-		final BigDecimal rounded = v.setScale(ref.scale(), mode);
-		return String.format("%s %s is %s, but expected %s is %s",
-				getEntityName(), getValueName(),
-				rounded.toPlainString(), minmax, ref.toPlainString());
-	}
-
-    private String reportMessage(final BigDecimal v) {
-        return String.format("%s %s is %s", getEntityName(), getValueName(), v.toPlainString());
-    }
-
-    private String getEntityName() {
+    String getEntityName() {
         return ENTITY_NAMES.get(entity);
     }
 
-    private String getValueName() {
+    String getValueName() {
         return VALUE_NAMES.get(value);
-    }
-
-    public static class CheckResult {
-
-        private final boolean violation;
-        private final String message;
-
-        private CheckResult(boolean violation, String message) {
-            this.violation = violation;
-            this.message = message;
-        }
-
-        public boolean isViolation() {
-            return violation;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
     }
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/check/RulesChecker.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/RulesChecker.java
@@ -63,6 +63,13 @@ public class RulesChecker {
 		this.languageNames = languageNames;
 	}
 
+    /**
+     * @return The implementation for language name display for message formatting.
+     */
+    public ILanguageNames getLanguageNames() {
+        return languageNames;
+    }
+
 	/**
 	 * Creates a new visitor to process the configured checks.
 	 * 


### PR DESCRIPTION
```
    - Each limit check now potentially reports the current coverage for that particular metric even when there are no violations.
    - verbose is by default 'false' for the maven plugin. The equivalent for ant is running with the -v (verbose) flag set.
```
