### PR TITLE
jacoco-maven-plugin and maven-surefire-plugin conflict on ${argLine}

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
@@ -26,13 +26,23 @@ import java.io.File;
  * </ul>
  * 
  * <p>
- * Note that these properties must not be overwritten by the test configuration,
- * otherwise the JaCoCo agent cannot be attached. If you need custom parameters
- * please append them. For example:
+ * If your project already uses the argLine to configure the
+ * surefire-maven-plugin, be sure that argLine defined as a property, rather
+ * than as part of the plugin configuration. For example:
  * </p>
  * 
  * <pre>
- *   &lt;argLine&gt;${argLine} -your -extra -arguments&lt;/argLine&gt;
+ *   &lt;properties&gt;
+ *     &lt;argLine&gt;-your -extra -arguments&lt;/argLine&gt;
+ *   &lt;/properties&gt;
+ *   ...
+ *   &lt;plugin&gt;
+ *     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
+ *     &lt;artifactId&gt;maven-surefire-plugin&lt;/artifactId&gt;
+ *     &lt;configuration&gt;
+ *       &lt;!-- Do not define argLine here! --&gt;
+ *     &lt;/configuration&gt;
+ *   &lt;/plugin&gt;
  * </pre>
  * 
  * <p>


### PR DESCRIPTION
This problem is reproducible with maven-surefire-plugin version 2.17 and jacoco-maven-plugin versions 0.7.1.201405082137 and 0.7.2.201409121644. However it functions perfectly OK with 0.6.4.201312101107.

Configure surefire like
```
                <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-surefire-plugin</artifactId>
                    <configuration>
                        <argLine>${argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
                    </configuration>
                </plugin>
```
and it will result in 
```
[INFO] --- jacoco-maven-plugin:0.7.1.201405082137:prepare-agent (jacoco-initialize) @ automated-deployment-system ---
[INFO] argLine set to -javaagent:/work/m2_repo/org/jacoco/org.jacoco.agent/0.7.1.201405082137/org.jacoco.agent-0.7.1.201405082137-runtime.jar=destfile=/work/jenkins_data/jobs/nightly-build-automated-deployment-system/workspace/target/jacoco.exec -ea
[INFO] 
[INFO] --- jacoco-maven-plugin:0.7.1.201405082137:report (jacoco-site) @ automated-deployment-system ---
[INFO] Skipping JaCoCo execution due to missing execution data file:/work/jenkins_data/jobs/nightly-build-automated-deployment-system/workspace/target/jacoco.exec
.....
[INFO] [10:35:38.754] Project coverage is set to 0% as no JaCoCo execution data has been dumped: /work/jenkins_data/jobs/nightly-build-automated-deployment-system/workspace/rpm/target/jacoco.exec
```
in logs

