### PR TITLE
documentation fix: use descriptor instead of description

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/analysis/IMethodCoverage.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/IMethodCoverage.java
@@ -18,9 +18,9 @@ package org.jacoco.core.analysis;
 public interface IMethodCoverage extends ISourceNode {
 
 	/**
-	 * Returns the parameter description of the method.
+	 * Returns the descriptor of the method.
 	 * 
-	 * @return parameter description
+	 * @return descriptor
 	 */
 	public String getDesc();
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
@@ -61,7 +61,7 @@ public class MethodAnalyzer extends MethodProbesVisitor {
 	 * @param name
 	 *            method name
 	 * @param desc
-	 *            description of the method
+	 *            method descriptor
 	 * @param signature
 	 *            optional parameterized signature
 	 * 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageImpl.java
@@ -30,7 +30,7 @@ public class MethodCoverageImpl extends SourceNodeImpl implements
 	 * @param name
 	 *            name of the method
 	 * @param desc
-	 *            parameter description
+	 *            method descriptor
 	 * @param signature
 	 *            generic signature or <code>null</code>
 	 */

--- a/org.jacoco.report/src/org/jacoco/report/ILanguageNames.java
+++ b/org.jacoco.report/src/org/jacoco/report/ILanguageNames.java
@@ -59,7 +59,7 @@ public interface ILanguageNames {
 	 * @param vmmethodname
 	 *            vm name of the method
 	 * @param vmdesc
-	 *            vm parameter description of the method
+	 *            vm method descriptor
 	 * @param vmsignature
 	 *            vm signature of the method (may be <code>null</code>)
 	 * @return language specific notation for the method
@@ -75,7 +75,7 @@ public interface ILanguageNames {
 	 * @param vmmethodname
 	 *            vm name of the method
 	 * @param vmdesc
-	 *            vm parameter description of the method
+	 *            vm method descriptor
 	 * @param vmsignature
 	 *            vm signature of the method (may be <code>null</code>)
 	 * @return language specific notation for the method

--- a/org.jacoco.report/src/org/jacoco/report/xml/report.dtd
+++ b/org.jacoco.report/src/org/jacoco/report/xml/report.dtd
@@ -51,7 +51,7 @@
 <!ELEMENT method (counter*)>
   <!-- method name -->
   <!ATTLIST method name CDATA #REQUIRED>
-  <!-- method parameter description -->
+  <!-- method descriptor -->
   <!ATTLIST method desc CDATA #REQUIRED>
   <!-- first source line number of this method -->
   <!ATTLIST method line CDATA #IMPLIED>


### PR DESCRIPTION
Use "descriptor" where appropriate (instead of "description")
