### PR TITLE
Introduce additional probes for INVOKE opcodes

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -93,7 +93,7 @@ public class AnalyzerTest {
 		final byte[] bytes = TargetLoader
 				.getClassDataAsBytes(AnalyzerTest.class);
 		executionData.get(Long.valueOf(CRC64.checksum(bytes)),
-				"org/jacoco/core/analysis/AnalyzerTest", 100);
+				"org/jacoco/core/analysis/AnalyzerTest", 300);
 		analyzer.analyzeClass(bytes, "Test");
 		assertFalse(classes.get("org/jacoco/core/analysis/AnalyzerTest")
 				.isNoMatch());

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -270,7 +270,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	public void testJumpToFirstNotCovered() {
 		createJumpToFirst();
 		runMethodAnalzer();
-		assertEquals(2, nextProbeId);
 
 		assertLine(1001, 3, 0, 2, 0);
 		assertLine(1002, 1, 0, 0, 0);
@@ -281,7 +280,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		createJumpToFirst();
 		probes[0] = true;
 		runMethodAnalzer();
-		assertEquals(2, nextProbeId);
 
 		assertLine(1001, 0, 3, 1, 1);
 		assertLine(1002, 1, 0, 0, 0);
@@ -293,7 +291,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[0] = true;
 		probes[1] = true;
 		runMethodAnalzer();
-		assertEquals(2, nextProbeId);
 
 		assertLine(1001, 0, 3, 0, 2);
 		assertLine(1002, 0, 1, 0, 0);
@@ -335,7 +332,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	public void testTableSwitchNotCovered() {
 		createTableSwitch();
 		runMethodAnalzer();
-		assertEquals(4, nextProbeId);
 
 		assertLine(1001, 2, 0, 3, 0);
 		assertLine(1002, 2, 0, 0, 0);
@@ -352,7 +348,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[0] = true;
 		probes[3] = true;
 		runMethodAnalzer();
-		assertEquals(4, nextProbeId);
 
 		assertLine(1001, 0, 2, 2, 1);
 		assertLine(1002, 0, 2, 0, 0);
@@ -369,7 +364,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[2] = true;
 		probes[3] = true;
 		runMethodAnalzer();
-		assertEquals(4, nextProbeId);
 
 		assertLine(1001, 0, 2, 2, 1);
 		assertLine(1002, 2, 0, 0, 0);
@@ -388,7 +382,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[2] = true;
 		probes[3] = true;
 		runMethodAnalzer();
-		assertEquals(4, nextProbeId);
 
 		assertLine(1001, 0, 2, 0, 3);
 		assertLine(1002, 0, 2, 0, 0);
@@ -427,7 +420,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	public void testTableSwitchMergeNotCovered() {
 		createTableSwitchMerge();
 		runMethodAnalzer();
-		assertEquals(5, nextProbeId);
 
 		assertLine(1001, 2, 0, 0, 0);
 		assertLine(1002, 2, 0, 3, 0);
@@ -442,7 +434,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[0] = true;
 		probes[4] = true;
 		runMethodAnalzer();
-		assertEquals(5, nextProbeId);
 
 		assertLine(1001, 0, 2, 0, 0);
 		assertLine(1002, 0, 2, 2, 1);
@@ -458,7 +449,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[3] = true;
 		probes[4] = true;
 		runMethodAnalzer();
-		assertEquals(5, nextProbeId);
 
 		assertLine(1001, 0, 2, 0, 0);
 		assertLine(1002, 0, 2, 2, 1);
@@ -474,7 +464,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[3] = true;
 		probes[4] = true;
 		runMethodAnalzer();
-		assertEquals(5, nextProbeId);
 
 		assertLine(1001, 0, 2, 0, 0);
 		assertLine(1002, 0, 2, 2, 1);
@@ -492,7 +481,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[3] = true;
 		probes[4] = true;
 		runMethodAnalzer();
-		assertEquals(5, nextProbeId);
 
 		assertLine(1001, 0, 2, 0, 0);
 		assertLine(1002, 0, 2, 0, 3);
@@ -528,7 +516,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	public void testTryCatchBlockNotCovered() {
 		createTryCatchBlock();
 		runMethodAnalzer();
-		assertEquals(3, nextProbeId);
 		assertEquals(CounterImpl.getInstance(5, 0),
 				result.getInstructionCounter());
 
@@ -544,7 +531,6 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[1] = true;
 		probes[2] = true;
 		runMethodAnalzer();
-		assertEquals(3, nextProbeId);
 		assertEquals(CounterImpl.getInstance(0, 5),
 				result.getInstructionCounter());
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -279,6 +279,7 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	public void testJumpToFirstCovered1() {
 		createJumpToFirst();
 		probes[0] = true;
+		probes[1] = true;
 		runMethodAnalzer();
 
 		assertLine(1001, 0, 3, 1, 1);
@@ -290,6 +291,7 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		createJumpToFirst();
 		probes[0] = true;
 		probes[1] = true;
+		probes[2] = true;
 		runMethodAnalzer();
 
 		assertLine(1001, 0, 3, 0, 2);
@@ -530,6 +532,7 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		probes[0] = true;
 		probes[1] = true;
 		probes[2] = true;
+		probes[3] = true;
 		runMethodAnalzer();
 		assertEquals(CounterImpl.getInstance(0, 5),
 				result.getInstructionCounter());

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodProbesAdapterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodProbesAdapterTest.java
@@ -57,6 +57,13 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		}
 
 		@Override
+		public void visitMethodInsnWithProbe(int opcode, String owner,
+				String name, String desc, boolean itf, int probeId) {
+			rec("visitMethodInsnWithProbe", Integer.valueOf(opcode), owner,
+					name, desc, Boolean.valueOf(itf), Integer.valueOf(probeId));
+		}
+
+		@Override
 		public void visitInsnWithProbe(int opcode, int probeId) {
 			rec("visitInsnWithProbe", Integer.valueOf(opcode),
 					Integer.valueOf(probeId));
@@ -88,7 +95,6 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		private void rec(String name, Object... args) {
 			printer.text.add(name + Arrays.asList(args));
 		}
-
 	}
 
 	@Before

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -70,13 +70,13 @@ public class ExceptionsTest extends ValidationTestBase {
 				ICounter.FULLY_COVERED);
 
 		// 6. Finally Block Without Exception Thrown
-		// Finally block is yellow as the exception path is missing.
+		// Finally block is partly covered as the exception path is missing.
 		assertLine("noExceptionFinally.beforeBlock", ICounter.FULLY_COVERED);
 		assertLine("noExceptionFinally.tryBlock", ICounter.FULLY_COVERED);
 		assertLine("noExceptionFinally.finallyBlock", ICounter.PARTLY_COVERED);
 
 		// 7. Finally Block With Implicit Exception
-		// Finally block is yellow as the non-exception path is missing.
+		// Finally block is partly covered as the non-exception path is missing.
 		assertLine("implicitExceptionFinally.beforeBlock",
 				ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionFinally.before", ICounter.NOT_COVERED);

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -34,10 +34,8 @@ public class ExceptionsTest extends ValidationTestBase {
 	public void testCoverageResult() {
 
 		// 1. Implicit Exception
-		// Currently no coverage at all, as we don't see when a block aborts
-		// somewhere in the middle.
-		assertLine("implicitException.before", ICounter.NOT_COVERED);
-		assertLine("implicitException.exception", ICounter.NOT_COVERED);
+		assertLine("implicitException.before", ICounter.FULLY_COVERED);
+		assertLine("implicitException.exception", ICounter.FULLY_COVERED);
 		assertLine("implicitException.after", ICounter.NOT_COVERED);
 
 		// 2. Explicit Exception
@@ -51,12 +49,11 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("noExceptionTryCatch.catchBlock", ICounter.NOT_COVERED);
 
 		// 4. Try/Catch Block With Exception Thrown Implicitly
-		// As always with implicit exceptions we don't see when a block aborts
-		// somewhere in the middle.
 		assertLine("implicitExceptionTryCatch.beforeBlock",
 				ICounter.FULLY_COVERED);
-		assertLine("implicitExceptionTryCatch.before", ICounter.NOT_COVERED);
-		assertLine("implicitExceptionTryCatch.exception", ICounter.NOT_COVERED);
+		assertLine("implicitExceptionTryCatch.before", ICounter.FULLY_COVERED);
+		assertLine("implicitExceptionTryCatch.exception",
+				ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionTryCatch.after", ICounter.NOT_COVERED);
 		assertLine("implicitExceptionTryCatch.catchBlock",
 				ICounter.FULLY_COVERED);
@@ -79,8 +76,8 @@ public class ExceptionsTest extends ValidationTestBase {
 		// Finally block is partly covered as the non-exception path is missing.
 		assertLine("implicitExceptionFinally.beforeBlock",
 				ICounter.FULLY_COVERED);
-		assertLine("implicitExceptionFinally.before", ICounter.NOT_COVERED);
-		assertLine("implicitExceptionFinally.exception", ICounter.NOT_COVERED);
+		assertLine("implicitExceptionFinally.before", ICounter.FULLY_COVERED);
+		assertLine("implicitExceptionFinally.exception", ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionFinally.after", ICounter.NOT_COVERED);
 		assertLine("implicitExceptionFinally.finallyBlock",
 				ICounter.PARTLY_COVERED);

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
@@ -207,21 +207,29 @@ public class MethodAnalyzer extends MethodProbesVisitor {
 
 	@Override
 	public void visitProbe(final int probeId) {
-		addProbe(probeId);
+		addProbeWithBranch(probeId);
 		lastInsn = null;
+	}
+
+	@Override
+	public void visitMethodInsnWithProbe(final int opcode, final String owner,
+			final String name, final String desc, final boolean itf,
+			final int probeId) {
+		visitInsn();
+		addProbeWithoutBranch(probeId);
 	}
 
 	@Override
 	public void visitJumpInsnWithProbe(final int opcode, final Label label,
 			final int probeId, final IFrame frame) {
 		visitInsn();
-		addProbe(probeId);
+		addProbeWithBranch(probeId);
 	}
 
 	@Override
 	public void visitInsnWithProbe(final int opcode, final int probeId) {
 		visitInsn();
-		addProbe(probeId);
+		addProbeWithBranch(probeId);
 	}
 
 	@Override
@@ -253,7 +261,7 @@ public class MethodAnalyzer extends MethodProbesVisitor {
 			if (id == LabelInfo.NO_PROBE) {
 				jumps.add(new Jump(lastInsn, label));
 			} else {
-				addProbe(id);
+				addProbeWithBranch(id);
 			}
 			LabelInfo.setDone(label);
 		}
@@ -283,11 +291,19 @@ public class MethodAnalyzer extends MethodProbesVisitor {
 		coverage.incrementMethodCounter();
 	}
 
-	private void addProbe(final int probeId) {
-		lastInsn.addBranch();
+	private void addProbeWithBranch(final int probeId) {
+		addBranch();
+		addProbeWithoutBranch(probeId);
+	}
+
+	private void addProbeWithoutBranch(final int probeId) {
 		if (probes != null && probes[probeId]) {
 			coveredProbes.add(lastInsn);
 		}
+	}
+
+	private void addBranch() {
+		lastInsn.addBranch();
 	}
 
 	private static class Jump {
@@ -300,5 +316,4 @@ public class MethodAnalyzer extends MethodProbesVisitor {
 			this.target = target;
 		}
 	}
-
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
@@ -91,6 +91,13 @@ public final class MethodProbesAdapter extends MethodVisitor {
 		}
 	}
 
+	@Override
+	public void visitMethodInsn(final int opcode, final String owner,
+			final String name, final String desc, final boolean itf) {
+		probesVisitor.visitMethodInsnWithProbe(opcode, owner, name, desc, itf,
+				idGenerator.nextId());
+	}
+
 	private int jumpPopCount(final int opcode) {
 		switch (opcode) {
 		case Opcodes.GOTO:
@@ -152,5 +159,4 @@ public final class MethodProbesAdapter extends MethodVisitor {
 	private IFrame frame(final int popCount) {
 		return FrameSnapshot.create(analyzer, popCount);
 	}
-
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesVisitor.java
@@ -14,6 +14,7 @@ package org.jacoco.core.internal.flow;
 import org.jacoco.core.JaCoCo;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 /**
  * A {@link MethodVisitor} with additional methods to get probe insertion
@@ -74,6 +75,33 @@ public abstract class MethodProbesVisitor extends MethodVisitor {
 	@SuppressWarnings("unused")
 	public void visitJumpInsnWithProbe(final int opcode, final Label label,
 			final int probeId, final IFrame frame) {
+	}
+
+	/**
+	 * Visits a method instruction. A method instruction is an instruction that
+	 * invokes a method. A probe with the given id should be inserted in a way
+	 * that it is executed whenever the method instruction is executed.
+	 * 
+	 * @param opcode
+	 *            the opcode of the instruction to be visited. This opcode is
+	 *            either INVOKEVIRTUAL, INVOKESPECIAL, INVOKESTATIC or
+	 *            INVOKEINTERFACE.
+	 * @param owner
+	 *            the internal name of the method's owner class (see
+	 *            {@link Type#getInternalName() getInternalName}).
+	 * @param name
+	 *            the method's name.
+	 * @param desc
+	 *            the method's descriptor (see {@link Type Type}).
+	 * @param itf
+	 *            if the method's owner class is an interface.
+	 * @param probeId
+	 *            id of the probe
+	 */
+	@SuppressWarnings("unused")
+	public void visitMethodInsnWithProbe(final int opcode, final String owner,
+			final String name, final String desc, final boolean itf,
+			final int probeId) {
 	}
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/MethodInstrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/MethodInstrumenter.java
@@ -54,6 +54,14 @@ class MethodInstrumenter extends MethodProbesVisitor {
 	}
 
 	@Override
+	public void visitMethodInsnWithProbe(final int opcode, final String owner,
+			final String name, final String desc, final boolean itf,
+			final int probeId) {
+		probeInserter.insertProbe(probeId);
+		mv.visitMethodInsn(opcode, owner, name, desc, itf);
+	}
+
+	@Override
 	public void visitJumpInsnWithProbe(final int opcode, final Label label,
 			final int probeId, final IFrame frame) {
 		if (opcode == Opcodes.GOTO) {
@@ -179,5 +187,4 @@ class MethodInstrumenter extends MethodProbesVisitor {
 			insertIntermediateProbe(l, frame);
 		}
 	}
-
 }


### PR DESCRIPTION
Introduce additional probes for INVOKE opcodes

As outlined on the mailing list, the additional probes provide better coverage results at the cost of higher runtime. I implemented the probes so that the exception paths are not counted as branches, so that the results do not indicate worse branch coverage than without these changes.

I volunteer to also update the documentation if this pull request is accepted otherwise.