### PR TITLE
Conflict between jmockit and jacoco

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -25,6 +25,9 @@
   <li>For offline instrumemtation agent configuration supports system properties
       replacements. Implementation based on pull request of GitHub user 'debugger'
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/262">#262</a>).</li>
+  <li>Exclude dynamically generated classes from instrumentation for better
+      interoperability with JMockit, analysis contributed by Rogério Liesenfeld
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/272">#272</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>


### PR DESCRIPTION
Related to #35 but it seems to still happen.

This project reproduces the issue: https://github.com/henri-tremblay/jacocomockit

When the line in the readme is executed, you will get this exception:
`java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the schema (add/remove fields)`

jmockit 1.14 and jacoco 0.7.2.201409121644 is used
