### PR TITLE
Html formatter of report ant task only supports basic locales

### DIFF
--- a/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.xml
@@ -64,7 +64,7 @@
 		<jacoco:instrument destdir="${instr.dir}">
 			<fileset dir="${lib.dir}" includes="*.jar"/>
 		</jacoco:instrument>
-		<au:assertLogContains text="Instrumented 13 classes to ${temp.dir}"/>
+		<au:assertLogContains text="Instrumented 14 classes to ${temp.dir}"/>
 
 		<unzip src="${instr.dir}/test.jar" dest="${instr.dir}"/>
 		<au:assertFileDoesntExist file="${instr.dir}/META-INF/TEST.RSA" />
@@ -85,7 +85,7 @@
 		<jacoco:instrument destdir="${instr.dir}" removesignatures="false">
 			<fileset dir="${lib.dir}" includes="*.jar"/>
 		</jacoco:instrument>
-		<au:assertLogContains text="Instrumented 13 classes to ${temp.dir}"/>
+		<au:assertLogContains text="Instrumented 14 classes to ${temp.dir}"/>
 
 		<unzip src="${instr.dir}/test.jar" dest="${instr.dir}"/>
 		<au:assertFileExists file="${instr.dir}/META-INF/TEST.RSA" />
@@ -96,7 +96,7 @@
 		<jacoco:instrument destdir="${temp.dir}">
 			<fileset dir="${org.jacoco.ant.instrumentTaskTest.classes.dir}" includes="**/*.class"/>
 		</jacoco:instrument>
-		<au:assertLogContains text="Instrumented 13 classes to ${temp.dir}"/>
+		<au:assertLogContains text="Instrumented 14 classes to ${temp.dir}"/>
 		<au:assertFileExists file="${temp.dir}/org/jacoco/ant/InstrumentTaskTest.class" />
 
 		<echo file="${temp.dir}/jacoco-agent.properties">destfile=test.exec</echo>
@@ -113,7 +113,7 @@
 		<jacoco:instrument destdir="${temp.dir}">
 			<fileset dir="${org.jacoco.ant.instrumentTaskTest.classes.dir}" includes="**/*.class"/>
 		</jacoco:instrument>
-		<au:assertLogContains text="Instrumented 13 classes to ${temp.dir}"/>
+		<au:assertLogContains text="Instrumented 14 classes to ${temp.dir}"/>
 		<au:assertFileExists file="${temp.dir}/org/jacoco/ant/InstrumentTaskTest.class" />
 
 		<java classname="org.jacoco.ant.TestTarget" failonerror="true" fork="true">

--- a/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskLocaleTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskLocaleTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.ant;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the locale conversion built into {@link ReportTask}.
+ */
+public class ReportTaskLocaleTest {
+
+	@Test
+	public void testNone() {
+		Locale locale = ReportTask.parseLocale("");
+
+		assertEquals("", locale.getLanguage());
+		assertEquals("", locale.getCountry());
+		assertEquals("", locale.getVariant());
+	}
+
+	@Test
+	public void testLanguage() {
+		Locale locale = ReportTask.parseLocale("fr");
+
+		assertEquals("fr", locale.getLanguage());
+		assertEquals("", locale.getCountry());
+		assertEquals("", locale.getVariant());
+	}
+
+	@Test
+	public void testLanguageCountry() {
+		Locale locale = ReportTask.parseLocale("fr_FR");
+
+		assertEquals("fr", locale.getLanguage());
+		assertEquals("FR", locale.getCountry());
+		assertEquals("", locale.getVariant());
+	}
+
+	@Test
+	public void testLanguageCountryVariant() {
+		Locale locale = ReportTask.parseLocale("de_CH_Matte");
+
+		assertEquals("de", locale.getLanguage());
+		assertEquals("CH", locale.getCountry());
+		assertEquals("Matte", locale.getVariant());
+	}
+
+}

--- a/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.StringTokenizer;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -221,8 +222,8 @@ public class ReportTask extends Task {
 		 * @param locale
 		 *            text locale
 		 */
-		public void setLocale(final Locale locale) {
-			this.locale = locale;
+		public void setLocale(final String locale) {
+			this.locale = parseLocale(locale);
 		}
 
 		@Override
@@ -598,6 +599,23 @@ public class ReportTask extends Task {
 					"To enable source code annotation class files for bundle '%s' have to be compiled with debug information.",
 					node.getName()), Project.MSG_WARN);
 		}
+	}
+
+	/**
+	 * Splits a given underscore "_" separated string and creates a Locale. This
+	 * method is implemented as the method Locale.forLanguageTag() was not
+	 * available in Java 5.
+	 * 
+	 * @param locale
+	 *            String representation of a Locate
+	 * @return Locale instance
+	 */
+	static Locale parseLocale(final String locale) {
+		final StringTokenizer st = new StringTokenizer(locale, "_");
+		final String language = st.hasMoreTokens() ? st.nextToken() : "";
+		final String country = st.hasMoreTokens() ? st.nextToken() : "";
+		final String variant = st.hasMoreTokens() ? st.nextToken() : "";
+		return new Locale(language, country, variant);
 	}
 
 }

--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -657,7 +657,9 @@
     </tr>
     <tr>
       <td><code>locale</code></td>
-      <td>Locale specified as ISO code (en, fr, jp, ...) used for number formating.</td>
+      <td>Locale specified as ISO code (en, fr, jp, ...) used for number
+      formating. Locale country and variant can be separated with an underscore
+      (de_CH).</td>
       <td><i>platform locale</i></td>
     </tr>
   </tbody>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -24,6 +24,8 @@
 <ul>
   <li>Added lifecycle-mapping-metadata.xml for M2E
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/203">#203</a>).</li>
+  <li>Allow locales with country and variant for Ant report task
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/289">#289</a>).</li>
 </ul>
 
 <h2>Release 0.7.4 (2015/02/26)</h2>


### PR DESCRIPTION
The html elemet of the jacoco report ant task supports the 'locale' attribute. Unfortunately, there's currently no way to configure a Locale for a specific country, since ant seems to convert the String from the ant file to a Locale by invoking the constructor with one String argument, which only allows selection of language, but not of country.
To allow any Locale to be configured, you could e.g. invoke Locale#forLanguageTag.

To test this, you can use e.g. 'de' (German) and 'de-CH' (German (Switzerland)), which use different number formats, even though the language is the same.