### PR TITLE
destfile agent parameter should be absolute also for default value

### DIFF
--- a/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
@@ -18,6 +18,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.jacoco.agent.AgentJar;
 import org.jacoco.core.runtime.AgentOptions;
+import org.jacoco.core.runtime.AgentOptions.OutputMode;
 
 /**
  * Base class for all coverage tasks that require agent options
@@ -25,6 +26,8 @@ import org.jacoco.core.runtime.AgentOptions;
 public class AbstractCoverageTask extends Task {
 
 	private final AgentOptions agentOptions;
+
+	private File destfile;
 
 	private boolean enabled;
 
@@ -34,6 +37,7 @@ public class AbstractCoverageTask extends Task {
 	protected AbstractCoverageTask() {
 		super();
 		agentOptions = new AgentOptions();
+		destfile = new File(AgentOptions.DEFAULT_DESTFILE);
 		enabled = true;
 	}
 
@@ -55,23 +59,14 @@ public class AbstractCoverageTask extends Task {
 	}
 
 	/**
-	 * Gets the currently configured agent options for this task
-	 * 
-	 * @return Configured agent options
-	 */
-	public AgentOptions getAgentOptions() {
-		return agentOptions;
-	}
-
-	/**
-	 * Sets the location to write coverage execution data. Default is current
-	 * working directory
+	 * Sets the location to write coverage execution data to. Default is
+	 * <code>jacoco.exec</code>.
 	 * 
 	 * @param file
-	 *            Location to write coverage execution data
+	 *            Location to write coverage execution data to
 	 */
 	public void setDestfile(final File file) {
-		agentOptions.setDestfile(file.getAbsolutePath());
+		destfile = file;
 	}
 
 	/**
@@ -211,7 +206,14 @@ public class AbstractCoverageTask extends Task {
 	 * @return JVM Argument to pass to new VM
 	 */
 	protected String getLaunchingArgument() {
-		return getAgentOptions().getVMArgument(getAgentFile());
+		return prepareAgentOptions().getVMArgument(getAgentFile());
+	}
+
+	private AgentOptions prepareAgentOptions() {
+		if (OutputMode.file.equals(agentOptions.getOutput())) {
+			agentOptions.setDestfile(destfile.getAbsolutePath());
+		}
+		return agentOptions;
 	}
 
 	private File getAgentFile() {

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
@@ -37,7 +37,7 @@ public class AgentOptionsTest {
 	@Test
 	public void testDefaults() {
 		AgentOptions options = new AgentOptions();
-		assertEquals("jacoco.exec", options.getDestfile());
+		assertEquals(AgentOptions.DEFAULT_DESTFILE, options.getDestfile());
 		assertTrue(options.getAppend());
 		assertEquals("*", options.getIncludes());
 		assertEquals("", options.getExcludes());
@@ -47,8 +47,8 @@ public class AgentOptionsTest {
 		assertNull(options.getSessionId());
 		assertTrue(options.getDumpOnExit());
 		assertEquals(AgentOptions.OutputMode.file, options.getOutput());
-		assertNull(options.getAddress());
-		assertEquals(6300, options.getPort());
+		assertEquals(AgentOptions.DEFAULT_ADDRESS, options.getAddress());
+		assertEquals(AgentOptions.DEFAULT_PORT, options.getPort());
 		assertNull(options.getClassDumpDir());
 		assertFalse(options.getJmx());
 

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -39,6 +39,11 @@ public final class AgentOptions {
 	public static final String DESTFILE = "destfile";
 
 	/**
+	 * Default value for the "destfile" agent option.
+	 */
+	public static final String DEFAULT_DESTFILE = "jacoco.exec";
+
+	/**
 	 * Specifies whether execution data should be appended to the output file.
 	 * Default is <code>true</code>.
 	 */
@@ -247,7 +252,7 @@ public final class AgentOptions {
 	 * @return output file location
 	 */
 	public String getDestfile() {
-		return getOption(DESTFILE, "jacoco.exec");
+		return getOption(DESTFILE, DEFAULT_DESTFILE);
 	}
 
 	/**

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -28,6 +28,14 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/289">#289</a>).</li>
 </ul>
 
+<h3>Fixed Bugs</h3>
+<ul>
+  <li>For the Ant tasks <code>coverage</code> and <code>agent</code> the
+      <code>destfile</code> attribute is now passed as an absolute path also in
+      the default case
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/301">#301</a>).</li>
+</ul>
+
 <h2>Release 0.7.4 (2015/02/26)</h2>
 
 <h3>Fixed Bugs</h3>


### PR DESCRIPTION
Hello,

At apache lucene we use carrot labs junit4 (http://labs.carrotsearch.com/randomizedtesting-junit4.html) which spawns multiple JVMs to make use of all of our cpus.

The `jacoco:agent` task made this very easy to integrate, but there was one trick, if you try to change the destination file, the setter always converts it to an absolute path (https://github.com/jacoco/jacoco/blob/master/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java#L74). Is this intentional?

It seems a little confusing since the default (jacoco.exec) is actually a relative path, but its impossible to set any relative path other than the default since the setter does this conversion.

For us its important that each jvm get a separate file (the easiest way to do that is a relative path), when we create our report we just provide all of them and everything works. The issue is easy to workaround, we just append the filename directly to the result of `jacoco:agent` ourselves, but it doesn't seem quite right. 

In ant it is easy for someone to convert a relative path to an absolute one in their build script themselves, if they are doing something advanced and really need it.
