### PR TITLE
Combination of append="false" and junit forkMode="perTest" does not work

### DIFF
--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -137,7 +137,10 @@
   In addition the <code>junit</code> task should declare
   <code>forkmode="once"</code> to avoid starting a new JVM for every single test
   case and decreasing execution performance dramatically (unless this is
-  required by the nature of the test cases).
+  required by the nature of the test cases). Note that
+  <code>forkmode="perTest"</code> or <code>forkmode="perBatch"</code> should not
+  be combined with <code>append="false"</code> as the execution data file is
+  overwritten with the execution of every test.
 </p>
 
 <p>


### PR DESCRIPTION
Jacoco (0.6.2) does not work as expected when the following ant configuration is used:

&lt;jacoco:coverage append="false"&gt;
    &lt;junit fork="true" forkMode="perTest"&gt;
       ...
    &lt;/junit&gt;
&lt;/jacoco:coverage&gt;

It seems that jacoco dumps its execution data in that case after the execution of each test and as append="false" silently overrides the data from the previous run. 

The documentation says that one should use forkMode="once" to improve performance, but does not note that the above combination does not work.
