### PR TITLE
ClassCoverageImpl should not be part of API

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CounterComparatorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CounterComparatorTest.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.junit.Test;
 
 /**

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageNodeImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageNodeImplTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.junit.Test;
 
 /**

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/NodeComparatorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/NodeComparatorTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.junit.Test;
 
 /**

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/BundleCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/BundleCoverageImpl.java
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IPackageCoverage;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/CoverageNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/CoverageNodeImpl.java
@@ -9,11 +9,12 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.analysis;
+package org.jacoco.core.internal.analysis;
 
 import java.util.Collection;
 
-import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode;
 
 /**
  * Base implementation for coverage data nodes.

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/PackageCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/PackageCoverageImpl.java
@@ -13,7 +13,6 @@ package org.jacoco.core.internal.analysis;
 
 import java.util.Collection;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.jacoco.core.internal.analysis;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.analysis.ISourceNode;

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,12 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>API Changes</h3>
+<ul>
+  <li>ClassCoverageImpl removed from package <code>org.jacoco.core.analysis</code>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/310">#310</a>).</li>
+</ul>
+
 <h2>Release 0.7.5 (2015/05/24)</h2>
 
 <h3>New Features</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/check/LimitTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/LimitTest.java
@@ -14,10 +14,10 @@ package org.jacoco.report.check;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICounter.CounterValue;
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/NodePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/NodePageTest.java
@@ -16,9 +16,9 @@ import static org.junit.Assert.assertSame;
 
 import java.io.IOException;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.internal.html.HTMLElement;
 import org.junit.Before;
 import org.junit.Test;

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/BarColumnTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/BarColumnTest.java
@@ -19,11 +19,11 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Locale;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.MemoryMultiReportOutput;
 import org.jacoco.report.internal.ReportOutputFolder;
 import org.jacoco.report.internal.html.HTMLDocument;

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/CounterColumnTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/CounterColumnTest.java
@@ -21,11 +21,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Locale;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.MemoryMultiReportOutput;
 import org.jacoco.report.internal.ReportOutputFolder;
 import org.jacoco.report.internal.html.HTMLDocument;

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/LabelColumnTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/LabelColumnTest.java
@@ -16,9 +16,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.MemoryMultiReportOutput;
 import org.jacoco.report.internal.ReportOutputFolder;
 import org.jacoco.report.internal.html.HTMLDocument;

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/PercentageColumnTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/PercentageColumnTest.java
@@ -18,11 +18,11 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.Locale;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.MemoryMultiReportOutput;
 import org.jacoco.report.internal.ReportOutputFolder;
 import org.jacoco.report.internal.html.HTMLDocument;

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/TableTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/TableTest.java
@@ -20,11 +20,11 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.jacoco.core.analysis.CounterComparator;
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
 import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.MemoryMultiReportOutput;
 import org.jacoco.report.internal.ReportOutputFolder;
 import org.jacoco.report.internal.html.HTMLDocument;

--- a/org.jacoco.report/src/org/jacoco/report/internal/AbstractGroupVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/AbstractGroupVisitor.java
@@ -13,9 +13,9 @@ package org.jacoco.report.internal;
 
 import java.io.IOException;
 
-import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.ICoverageNode.ElementType;
+import org.jacoco.core.internal.analysis.CoverageNodeImpl;
 import org.jacoco.report.IReportGroupVisitor;
 import org.jacoco.report.ISourceFileLocator;
 


### PR DESCRIPTION
I don't see any good reasons for this class to be part of API:
* it is used only by other internal classes and tests
* and IMO not supposed to be used directly outside of JaCoCo - there is public interfaces
* was introduced in public package in first JaCoCo version, but I suppose that this was done by mistake
