### PR TITLE
For format version mismatches, report version number in a human friendly way

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -113,7 +113,7 @@ public class ExecutionDataReaderWriterTest {
 		assertEquals(0x01, 0xFF & header[0]);
 		assertEquals(0xC0, 0xFF & header[1]);
 		assertEquals(0xC0, 0xFF & header[2]);
-		final char version = ExecutionDataWriter.FORMAT_VERSION;
+		final char version = ExecutionDataWriter.PADDED_FORMAT_VERSION;
 		assertEquals(version >> 8, 0xFF & header[3]);
 		assertEquals(version & 0xFF, 0xFF & header[4]);
 	}
@@ -141,7 +141,7 @@ public class ExecutionDataReaderWriterTest {
 		buffer.write(ExecutionDataWriter.BLOCK_HEADER);
 		buffer.write(0xC0);
 		buffer.write(0xC0);
-		final char version = ExecutionDataWriter.FORMAT_VERSION - 1;
+		final char version = ExecutionDataWriter.PADDED_FORMAT_VERSION - 1;
 		buffer.write(version >> 8);
 		buffer.write(version & 0xFF);
 		createReader().read();

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
@@ -122,10 +122,12 @@ public class ExecutionDataReader {
 		if (in.readChar() != ExecutionDataWriter.MAGIC_NUMBER) {
 			throw new IOException("Invalid execution data file.");
 		}
-		final char version = in.readChar();
-		if (version != ExecutionDataWriter.FORMAT_VERSION) {
-			throw new IOException(format("Incompatible version %x.",
-					Integer.valueOf(version)));
+		final char padded_version = in.readChar();
+		if (padded_version != ExecutionDataWriter.PADDED_FORMAT_VERSION) {
+			final int version = padded_version
+				- ExecutionDataWriter.FORMAT_VERSION_PAD;
+			throw new IncompatibleExecFileVersionException(
+				ExecutionDataWriter.FORMAT_VERSION, version);
 		}
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
@@ -24,7 +24,14 @@ public class ExecutionDataWriter implements ISessionInfoVisitor,
 		IExecutionDataVisitor {
 
 	/** File format version, will be incremented for each incompatible change. */
-	public static final char FORMAT_VERSION = 0x1007;
+	public static final int FORMAT_VERSION = 0x7;
+
+	/** Padding for the on-disk file format version. */
+	public static final char FORMAT_VERSION_PAD = 0x1000;
+
+	/** On-disk file format version */
+	public static final char PADDED_FORMAT_VERSION =
+		(char) FORMAT_VERSION_PAD + FORMAT_VERSION;
 
 	/** Magic number in header for file format identification. */
 	public static final char MAGIC_NUMBER = 0xC0C0;
@@ -65,7 +72,7 @@ public class ExecutionDataWriter implements ISessionInfoVisitor,
 	private void writeHeader() throws IOException {
 		out.writeByte(BLOCK_HEADER);
 		out.writeChar(MAGIC_NUMBER);
-		out.writeChar(FORMAT_VERSION);
+		out.writeChar(PADDED_FORMAT_VERSION);
 	}
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/data/IncompatibleExecFileVersionException.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/IncompatibleExecFileVersionException.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.core.data;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+
+/**
+ * Signals that execution data in an incompatible version was tried to read.
+ */
+public class IncompatibleExecFileVersionException extends IOException {
+	/** Expected format version */
+	private final int expectedVersion;
+
+	/** Format version found in execution data */
+	private final int actualVersion;
+
+	/**
+	 * Creates a new exception to flag version mismatches in exec data
+	 *
+	 * @param exectedVersion
+	 *            version expected in the exec data
+	 * @param actualVersion
+	 *            version found in the exec data
+	 */
+	public IncompatibleExecFileVersionException(int expectedVersion,
+			int actualVersion) {
+		super(String.format("Failed to read version %d data (This "
+			+ "JaCoCo build can only read/write version %d "
+			+ "data). To read version %d data, use the same JaCoCo "
+			+ "version that got used for writing it.",
+			actualVersion, expectedVersion, actualVersion));
+		this.expectedVersion = expectedVersion;
+		this.actualVersion = actualVersion;
+	}
+
+	/**
+	 * Gets the version expected in the exec data
+	 *
+	 * @return expected version in exec data
+	 */
+	public int getExpectedVersion() {
+		return expectedVersion;
+	}
+
+	/**
+	 * Gets the actual version found in the exec data
+	 *
+	 * @return actual version in exec data
+	 */
+	public int getActualVersion() {
+		return actualVersion;
+	}
+}


### PR DESCRIPTION
Version numbers have been reported as hex string, but without any hex
string marker. So effectively when seeing a mismatch reported around
version '1006', it came down to version '0x1006', which is version
4102 in decimal. Those high format version numbers and mismatch in hex
vs. decimal was confusing.
Hence, we now get rid of the byte-marker 0x1000, and report the format
version as plain decimal.
Thereby, nice low format versions get reported. And the confusion
between (markerless) hex and decimal is gone.

What is 0x1007 format version on-disk, is now reported as version 7.
What is 0x1006 format version on-disk, is now reported as version 6.