### PR TITLE
Fix MBeanClient example

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,12 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>Fixed Bugs</h3>
+<ul>
+  <li>Fix <code>MBeanClient</code> example
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/333">#333</a>).</li>
+</ul>
+
 <h2>Release 0.7.5 (2015/05/24)</h2>
 
 <h3>New Features</h3>

--- a/org.jacoco.examples.test/pom.xml
+++ b/org.jacoco.examples.test/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>org.jacoco.examples</artifactId>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>org.jacoco.agent.rt</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/org.jacoco.examples.test/src/org/jacoco/examples/MBeanClientTest.java
+++ b/org.jacoco.examples.test/src/org/jacoco/examples/MBeanClientTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.examples;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jacoco.agent.rt.IAgent;
+import org.junit.Test;
+
+/**
+ * Tests for {@link MBeanClient}.
+ */
+public class MBeanClientTest {
+
+	@Test
+	public void testMBeanInterfaceCompatibility() {
+		Set<String> expected = getDeclaredMethods(IAgent.class);
+		Set<String> actual = getDeclaredMethods(MBeanClient.IProxy.class);
+		assertEquals(expected, actual);
+	}
+
+	private Set<String> getDeclaredMethods(Class<?> clazz) {
+		Set<String> methods = new HashSet<String>();
+		for (Method m : clazz.getDeclaredMethods()) {
+			methods.add(String.format("%s %s(%s)", m.getReturnType().getName(),
+					m.getName(), Arrays.asList(m.getParameterTypes())));
+		}
+		return methods;
+	}
+
+}

--- a/org.jacoco.examples/src/org/jacoco/examples/MBeanClient.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/MBeanClient.java
@@ -39,36 +39,39 @@ public final class MBeanClient {
 	 */
 	public static void main(final String[] args) throws Exception {
 		// Open connection to the coverage agent:
-		JMXServiceURL url = new JMXServiceURL(SERVICE_URL);
-		JMXConnector jmxc = JMXConnectorFactory.connect(url, null);
-		MBeanServerConnection connection = jmxc.getMBeanServerConnection();
+		final JMXServiceURL url = new JMXServiceURL(SERVICE_URL);
+		final JMXConnector jmxc = JMXConnectorFactory.connect(url, null);
+		final MBeanServerConnection connection = jmxc
+				.getMBeanServerConnection();
 
-		IProxy proxy = (IProxy) MBeanServerInvocationHandler.newProxyInstance(
-				connection, new ObjectName("org.jacoco:type=Runtime"),
-				IProxy.class, false);
+		final IProxy proxy = (IProxy) MBeanServerInvocationHandler
+				.newProxyInstance(connection, new ObjectName(
+						"org.jacoco:type=Runtime"), IProxy.class, false);
 
 		// Retrieve JaCoCo version and session id:
 		System.out.println("Version: " + proxy.getVersion());
 		System.out.println("Session: " + proxy.getSessionId());
 
 		// Retrieve dump and write to file:
-		byte[] dump = proxy.dump(false);
+		final byte[] data = proxy.getExecutionData(false);
 		final FileOutputStream localFile = new FileOutputStream(DESTFILE);
-		localFile.write(dump);
+		localFile.write(data);
 		localFile.close();
 
 		// Close connection:
 		jmxc.close();
 	}
 
-	private interface IProxy {
+	interface IProxy {
 		String getVersion();
 
 		String getSessionId();
 
 		void setSessionId(String id);
 
-		byte[] dump(boolean reset);
+		byte[] getExecutionData(boolean reset);
+
+		void dump(boolean reset);
 
 		void reset();
 	}


### PR DESCRIPTION
* JavaDoc is outdated - there is no "mbean" output mode
* IProxy:
 * method ```byte[] dump(boolean reset)``` should match corresponding method from IAgent, which is ```void dump(boolean reset)```
 * method ``` byte[] getExecutionData(boolean reset)``` should be added
 * to avoid such issues consider execution of example as part of build
