### PR TITLE
jacoco-maven-plugin options for report generation plus external dependencies

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -303,8 +303,8 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 					throws IOException {
 		final FileFilter fileFilter = new FileFilter(this.getIncludes(),
 				this.getExcludes());
-		final BundleCreator creator = new BundleCreator(this.getProject(),
-				fileFilter, getLog(), reportName);
+		final BundleCreator creator = new BundleCreator(fileFilter,
+				getLog(), reportName);
 
 		final IBundleCoverage bundle = creator
 				.createBundleOfDirectory(executionDataStore, directory);

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ArtifactBundleCreator.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ArtifactBundleCreator.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *    Kyle Lieber - implementation of CheckMojo
+ *
+ *******************************************************************************/
+package org.jacoco.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.Log;
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IBundleCoverage;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.lang.String.format;
+
+/**
+ * Creates an IBundleCoverage for a Maven dependency artifact.
+ */
+public final class ArtifactBundleCreator {
+
+	private final Log log;
+	private final String bundleName;
+
+	/**
+	 * Construct a new ArtifactBundleCreator a Bundle name.
+	 *
+	 * @param log
+	 *            the log output
+	 * @param name
+	 *            of the Bundle
+	 */
+	public ArtifactBundleCreator(final Log log, final String name) {
+
+		this.log = log;
+		this.bundleName = name;
+	}
+
+	/**
+	 * Create an IBundleCoverage for the given ExecutionDataStore for the code
+	 * in Maven Artifact.
+	 * 
+	 * @param executionDataStore
+	 *            the execution data
+	 * @param artifact
+	 *            the Maven Artifact of the dependency
+	 * @return the coverage data
+	 * @throws IOException
+	 *             if class files can't be read.
+	 */
+	public IBundleCoverage createBundleOfArtifact(
+			final ExecutionDataStore executionDataStore,
+			final Artifact artifact)
+					throws IOException {
+
+		final CoverageBuilder builder = new CoverageBuilder();
+		final Analyzer analyzer = new Analyzer(executionDataStore, builder);
+		analyzer.analyzeAll(artifact.getFile());
+
+		final IBundleCoverage bundle = builder.getBundle(bundleName);
+		logBundleInfo(bundle, builder.getNoMatchClasses());
+
+		return bundle;
+	}
+
+	private void logBundleInfo(final IBundleCoverage bundle,
+			final Collection<IClassCoverage> nomatch) {
+		log.info(format("Analyzed bundle '%s' with %s classes",
+				bundle.getName(),
+				Integer.valueOf(bundle.getClassCounter().getTotalCount())));
+		if (!nomatch.isEmpty()) {
+			log.warn(format(
+					"Classes in bundle '%s' do no match with execution data. "
+							+ "For report generation the same class files must be used as at runtime.",
+					bundle.getName()));
+			for (final IClassCoverage c : nomatch) {
+				log.warn(format("Execution data for class %s does not match.",
+						c.getName()));
+			}
+		}
+	}
+
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
@@ -12,13 +12,6 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import static java.lang.String.format;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
@@ -28,6 +21,13 @@ import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.data.ExecutionDataStore;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import static java.lang.String.format;
+
 /**
  * Creates an IBundleCoverage.
  */
@@ -36,9 +36,11 @@ public final class BundleCreator {
 	private final MavenProject project;
 	private final FileFilter fileFilter;
 	private final Log log;
+	private final String bundleName;
 
 	/**
-	 * Construct a new BundleCreator given the MavenProject and FileFilter.
+	 * Construct a new BundleCreator given the MavenProject and FileFilter and a
+	 * specific Bundle name.
 	 * 
 	 * @param project
 	 *            the MavenProject
@@ -46,29 +48,35 @@ public final class BundleCreator {
 	 *            the FileFilter
 	 * @param log
 	 *            for log output
+	 * @param name
+	 *            of the Bundle
 	 */
 	public BundleCreator(final MavenProject project,
-			final FileFilter fileFilter, final Log log) {
+			final FileFilter fileFilter, final Log log, final String name) {
 		this.project = project;
 		this.fileFilter = fileFilter;
 		this.log = log;
+		this.bundleName = name;
 	}
 
 	/**
-	 * Create an IBundleCoverage for the given ExecutionDataStore.
+	 * Create an IBundleCoverage for the given ExecutionDataStore for the code
+	 * in directory.
 	 * 
 	 * @param executionDataStore
 	 *            the execution data.
+	 * @param directory
+	 *            the directory containing the classes
 	 * @return the coverage data.
 	 * @throws IOException
 	 *             if class files can't be read
 	 */
-	public IBundleCoverage createBundle(
-			final ExecutionDataStore executionDataStore) throws IOException {
+	public IBundleCoverage createBundleOfDirectory(
+			final ExecutionDataStore executionDataStore, final String directory)
+					throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
 		final Analyzer analyzer = new Analyzer(executionDataStore, builder);
-		final File classesDir = new File(this.project.getBuild()
-				.getOutputDirectory());
+		final File classesDir = new File(directory);
 
 		@SuppressWarnings("unchecked")
 		final List<File> filesToAnalyze = FileUtils.getFiles(classesDir,
@@ -79,7 +87,7 @@ public final class BundleCreator {
 		}
 
 		final IBundleCoverage bundle = builder
-				.getBundle(this.project.getName());
+				.getBundle(bundleName);
 		logBundleInfo(bundle, builder.getNoMatchClasses());
 
 		return bundle;

--- a/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/BundleCreator.java
@@ -13,7 +13,6 @@
 package org.jacoco.maven;
 
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
@@ -33,7 +32,6 @@ import static java.lang.String.format;
  */
 public final class BundleCreator {
 
-	private final MavenProject project;
 	private final FileFilter fileFilter;
 	private final Log log;
 	private final String bundleName;
@@ -41,9 +39,6 @@ public final class BundleCreator {
 	/**
 	 * Construct a new BundleCreator given the MavenProject and FileFilter and a
 	 * specific Bundle name.
-	 * 
-	 * @param project
-	 *            the MavenProject
 	 * @param fileFilter
 	 *            the FileFilter
 	 * @param log
@@ -51,9 +46,8 @@ public final class BundleCreator {
 	 * @param name
 	 *            of the Bundle
 	 */
-	public BundleCreator(final MavenProject project,
-			final FileFilter fileFilter, final Log log, final String name) {
-		this.project = project;
+	public BundleCreator(final FileFilter fileFilter,
+			final Log log, final String name) {
 		this.fileFilter = fileFilter;
 		this.log = log;
 		this.bundleName = name;

--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -13,11 +13,6 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.ICoverageNode;
@@ -28,6 +23,11 @@ import org.jacoco.report.check.IViolationsOutput;
 import org.jacoco.report.check.Limit;
 import org.jacoco.report.check.Rule;
 import org.jacoco.report.check.RulesChecker;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Checks that the code coverage metrics are being met.
@@ -190,10 +190,11 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 		final FileFilter fileFilter = new FileFilter(this.getIncludes(),
 				this.getExcludes());
 		final BundleCreator creator = new BundleCreator(getProject(),
-				fileFilter, getLog());
+				fileFilter, getLog(), getProject().getName());
 		try {
 			final ExecutionDataStore executionData = loadExecutionData();
-			return creator.createBundle(executionData);
+			return creator.createBundleOfDirectory(executionData,
+					getProject().getBuild().getOutputDirectory());
 		} catch (final IOException e) {
 			throw new MojoExecutionException(
 					"Error while reading code coverage: " + e.getMessage(), e);

--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -189,8 +189,8 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 	private IBundleCoverage loadBundle() throws MojoExecutionException {
 		final FileFilter fileFilter = new FileFilter(this.getIncludes(),
 				this.getExcludes());
-		final BundleCreator creator = new BundleCreator(getProject(),
-				fileFilter, getLog(), getProject().getName());
+		final BundleCreator creator = new BundleCreator(fileFilter,
+				getLog(), getProject().getName());
 		try {
 			final ExecutionDataStore executionData = loadExecutionData();
 			return creator.createBundleOfDirectory(executionData,

--- a/jacoco-maven-plugin/src/org/jacoco/maven/MavenSourcesArtifactLocator.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/MavenSourcesArtifactLocator.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Cristiano Costantini
+ *
+ *******************************************************************************/
+package org.jacoco.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.jacoco.report.InputStreamSourceFileLocator;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Locator that searches source files in maven sources jar that are found on the
+ * maven artifact with the classifier sources.
+ */
+class MavenSourcesArtifactLocator extends InputStreamSourceFileLocator {
+
+	private final JarFile sourcesJar;
+
+	public MavenSourcesArtifactLocator(final Artifact artifact,
+			final String encoding)
+					throws IOException {
+		super(encoding, 4);
+		sourcesJar = new JarFile(searchSourcesJar(artifact));
+	}
+
+	private File searchSourcesJar(final Artifact artifact) {
+		File sourcesJar = null;
+		if (artifact != null && artifact.getFile() != null) {
+			final String jarPath = artifact.getFile()
+					.getAbsolutePath();
+
+			if (jarPath.endsWith(".jar")) {
+				sourcesJar = new File(jarPath.substring(0, jarPath.length() - 4)
+						+ "-sources.jar");
+			}
+		}
+		return sourcesJar;
+	}
+
+	@Override
+	protected InputStream getSourceStream(final String path)
+			throws IOException {
+		if (sourcesJar != null) {
+			final JarEntry jarEntry = sourcesJar.getJarEntry(path);
+			if (jarEntry != null) {
+				return sourcesJar.getInputStream(jarEntry);
+			}
+		}
+		return null;
+	}
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportITMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportITMojo.java
@@ -26,6 +26,7 @@ import java.util.Locale;
  * @phase verify
  * @goal report-integration
  * @requiresProject true
+ * @requiresDependencyResolution runtime
  * @threadSafe
  * @since 0.6.4
  */

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
@@ -21,6 +21,7 @@ import java.util.Locale;
  * @phase verify
  * @goal report
  * @requiresProject true
+ * @requiresDependencyResolution runtime
  * @threadSafe
  * @since 0.5.3
  */
@@ -52,7 +53,8 @@ public class ReportMojo extends AbstractReportMojo {
 	@Override
 	public void setReportOutputDirectory(final File reportOutputDirectory) {
 		if (reportOutputDirectory != null
-				&& !reportOutputDirectory.getAbsolutePath().endsWith("jacoco")) {
+				&& !reportOutputDirectory.getAbsolutePath()
+						.endsWith("jacoco")) {
 			outputDirectory = new File(reportOutputDirectory, "jacoco");
 		} else {
 			outputDirectory = reportOutputDirectory;


### PR DESCRIPTION
Hello,
I propose this pull request that provides improved configuration of the jacoco-maven-plugin and capability to include external dependencies in reports. 

## Rationale
I want to find "dead" code and how much external dependencies are used. This is because I want to keep the project clean by minimizing external dependencies. Often, we import an external library which takes many transitive dependencies which are not used, other time a big library is imported for using just a single static utility method. I want to used JaCoCO to detect these situations, but I need coverage report for these external dependencies.

This pull request is different from #336 as I don't focus on reporting other projects from the reactor project; I rather focus on being able to include any external Jar from the dependencies of the project, more similarly to how it is possible to do in EclEmma when you import external session and it allows you to "include binary libraries", see picture:

<img width="522" alt="schermata 2015-10-02 alle 09 51 05" src="https://cloud.githubusercontent.com/assets/2135798/10241681/444a7ffc-68eb-11e5-891b-8bf4df3aa918.png">

The implementation has been inspired from the implementation of the Report Ant task.

## Usage
The plugin can the be configured in this way:
```
<configuration>
	<!-- If you don't want cvs report set it false -->
	<csvReport>false</csvReport>
	<!-- If you don't want xml report set it false -->
	<xmlReport>false</xmlReport>
	<!-- 
		The htmlReport options to true will generate the html report.
		It can be omitted as all reports are true by default to keep 
		comaptibility with previous behaviour.
	-->
	<htmlReport>true</htmlReport>
	<!-- 
		If you want coverage report also for test sources set this to true
	-->
	<includeTests>true</includeTests>

	<!-- 
		If your project for example depends, directly or indirectly, on Google 
		Guava, Apache Common-IO and Jetty, and you want to inspect how much you make use 
		of those libraries, include them in the report like this:
	-->
	<includeArtifacts>
		<!-- format is [groupId]:artifactId -->
		<includeArtifact>com.google.guava:guava</includeArtifact>
		<includeArtifact>org.apache.commons:commons-io</includeArtifact>
		<!-- groupId for org.eclipse.jetty can be omitted if artifactId is unambiguous -->		
		<includeArtifact>:jetty-server</includeArtifact>
	</includeArtifacts>
</configuration>
```


## Description of Changes

### Mojo Configuration
New configuration options have been included in AbstractReportMojo.java:
```
boolean csvReport;
boolean xmlReport;
boolean htmlReport;

boolean includeTests

List<String> includeArtifacts;
```
### Grouped Reporting
The method ```void createReport(final IReportGroupVisitor visitor)```  has been changed to manage reporting of the dependencies in different report bundles. This will only happen in case the condition ```(includeTests || (includeArtifacts != null && includeArtifacts.size() > 0))``` is true, else the report will not be grouped, so to keep the output and behavior consistent with previous version.

### Report of a Dependency Artifact
The method ```private void createDependencyReport(final IReportGroupVisitor visitor, final Artifact artifact)``` has been added to manage the creation of a report bundle for a Maven Artifact.

### Selection of type of Reports
The method ```IReportVisitor createVisitor(final Locale locale)``` has been changed in order to add visitors for specific report types only if the relative configuration option is set to true

### Sources in src/test/java
The method ```List<File> getCompileSourceRoots()``` has been changed to search sources also in src/test/java, as this is required if the option includeTests is set to true.

### Coverage of dependency Artifact
The class ```ArtifactBundleCreator``` has been created in order to manage the coverage of a dependency Artifact. 

*Note*: it is very similar to class ```BundleCreator``` and some refactoring to reduce duplicated code is advised in future.

### Report bundle name in BundleCreator
The class ```BundleCreator``` has been modified in order to take an external name for the report bundle. This is because the BundleCreator is used bot for report on src/main/java and src/test/java, and in this case we want to specify two different names and not using for both ```this.project.getName())```

### Locating sources of external artifacts
The class ```MavenSourcesArtifactLocator``` has been created in order to resolve sources in maven sources jar, using the standard maven convention that the sources are are located in the jar with classifier sources (i.e. myproject-1.0.0-sources.jar will contain sources for myproject-1.0.0.jar)

*Note*: sources are not downloaded if not available in local repo. User must invoke manually the ```mvn dependency:sources``` or use other solutions to download sources.


### Configured Mojo to require dependecies
The mojo option ```@requiresDependencyResolution runtime``` has been added to ReportMojo.java and ReportITMojo.java in order to make it work the method ```getProject().getArtifacts()``` that it is used to find the Jar files in the local repo and use them for report generation (this was an hard issue for me to find and solve :-D ) 

*Note*: Probably it is better to use ```@requiresDependencyResolution test``` to allow resolution also of test dependencies?

## Final notes
Please consider this pull request to become part of the standard distribution of JaCoCo. If you need some refinement such as code quality or code style improvement or other features, please ask and I'll be glad to do my best to improve this pull request and meet your needs.

I didn't implemented any Integration Test, I've developed and tested the patch on a real project of mine and I've never written IT tests for a maven plugin before. I could develop some IT, but please give me suggestion on what to do, what code to use as a template or which existing IT test to modify.

If some comment is not clear, please ask and I'll improve it.

Also, while working on the code, some automatic code format command given while editing the code in Eclipse may have changed the format (indentation and new lines). I've tried to keep the format the same as much as possible, but I have committed some format change anyway. Sorry as I know this makes it harder to compare the diff. 
