### PR TITLE
RuntimeData not thread safe

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
@@ -64,6 +64,20 @@ public class ExecutionDataStoreTest implements IExecutionDataVisitor {
 	}
 
 	@Test
+	public void testReentrantAccept() {
+		final boolean[] probes = new boolean[] { false, false, true };
+		store.put(new ExecutionData(1000, "Sample0", probes));
+		store.put(new ExecutionData(1001, "Sample1", probes));
+		store.accept(new IExecutionDataVisitor() {
+			public void visitClassExecution(ExecutionData data) {
+				store.put(new ExecutionData(1002, "Sample2", probes));
+				ExecutionDataStoreTest.this.visitClassExecution(data);
+			}
+		});
+		assertEquals(2, dataOutput.size());
+	}
+
+	@Test
 	public void testGetContents() {
 		final boolean[] probes = new boolean[] {};
 		final ExecutionData a = new ExecutionData(1000, "A", probes);

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.data;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -154,7 +155,7 @@ public final class ExecutionDataStore implements IExecutionDataVisitor {
 	 * @return current contents
 	 */
 	public Collection<ExecutionData> getContents() {
-		return entries.values();
+		return new ArrayList<ExecutionData>(entries.values());
 	}
 
 	/**
@@ -164,7 +165,7 @@ public final class ExecutionDataStore implements IExecutionDataVisitor {
 	 *            interface to write content to
 	 */
 	public void accept(final IExecutionDataVisitor visitor) {
-		for (final ExecutionData data : entries.values()) {
+		for (final ExecutionData data : getContents()) {
 			visitor.visitClassExecution(data);
 		}
 	}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -33,6 +33,8 @@
 <ul>
   <li>Fix <code>MBeanClient</code> example
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/333">#333</a>).</li>
+  <li>Avoid <code>ConcurrentModificationException</code> during shutdown
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/364">#364</a>).</li>
 </ul>
 
 <h3>API Changes</h3>


### PR DESCRIPTION
Hi guys,

I'm having a problem with RuntimeData and specifically with ExecutionDataStore. The data store has a map: **Map<Long, ExecutionData> entries** which causes a concurrent access a problem with the following exception:

```java
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1429)
	at java.util.HashMap$ValueIterator.next(HashMap.java:1458)
	at org.jacoco.agent.rt.internal_c57fe0e.core.data.ExecutionDataStore.accept(ExecutionDataStore.java:167)
	at org.jacoco.agent.rt.internal_c57fe0e.core.runtime.RuntimeData.collect(RuntimeData.java:87)
	at org.jacoco.agent.rt.internal_c57fe0e.output.MongoDbOutput.writeExecutionData(MongoDbOutput.java:54)
	at org.jacoco.agent.rt.internal_c57fe0e.Agent.shutdown(Agent.java:132)
	at org.jacoco.agent.rt.internal_c57fe0e.Agent$1.run(Agent.java:49)
````
**Note:** MongoDbOutput is a custom created MongoDB sink  

The **RuntimeData** has a comment saying that is thread safe. That's not the case anymore since **ExecutionDataStore** is not thread safe