### PR TITLE
>= 0.7.3 breaks Gradle + JUnit + Robolectric coverage (Android)

### DIFF
--- a/jacoco-maven-plugin.test/it/it-customize-agent/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-customize-agent/pom.xml
@@ -26,12 +26,15 @@
     <jacoco.destFile>${project.build.directory}/coverage.exec</jacoco.destFile>
     <jacoco.append>false</jacoco.append>
     <jacoco.exclClassLoaders>sun.reflect.DelegatingClassLoader:MyClassLoader</jacoco.exclClassLoaders>
+    <jacoco.inclBootstrapClasses>true</jacoco.inclBootstrapClasses>
+    <jacoco.inclNoLocationClasses>true</jacoco.inclNoLocationClasses>
     <jacoco.sessionId>session</jacoco.sessionId>
     <jacoco.dumpOnExit>true</jacoco.dumpOnExit>
     <jacoco.output>file</jacoco.output>
     <jacoco.address>localhost</jacoco.address>
     <jacoco.port>9999</jacoco.port>
     <jacoco.classDumpDir>${project.build.directory}/classdumps</jacoco.classDumpDir>
+    <jacoco.jmx>true</jacoco.jmx>
   </properties>
 
   <build>

--- a/jacoco-maven-plugin.test/it/it-customize-agent/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-customize-agent/verify.bsh
@@ -17,12 +17,15 @@ String agentOptions = "destfile=" + basedir + File.separator + "target" + File.s
     + ",includes=*"
     + ",excludes=java.*:sun.*"
     + ",exclclassloader=sun.reflect.DelegatingClassLoader:MyClassLoader"
+    + ",inclbootstrapclasses=true"
+    + ",inclnolocationclasses=true"
     + ",sessionid=session"
     + ",dumponexit=true"
     + ",output=file"
     + ",address=localhost"
     + ",port=9999"
-    + ",classdumpdir=" + basedir + File.separator + "target" + File.separator + "classdumps";
+    + ",classdumpdir=" + basedir + File.separator + "target" + File.separator + "classdumps"
+    + ",jmx=true";
 
 //backslashes will be escaped
 agentOptions = agentOptions.replace("\\","\\\\");

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -81,6 +81,12 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	 */
 	Boolean inclBootstrapClasses;
 	/**
+	 * Specifies whether classes without source location should be instrumented.
+	 * 
+	 * @parameter property="jacoco.inclNoLocationClasses"
+	 */
+	Boolean inclNoLocationClasses;
+	/**
 	 * A session identifier that is written with the execution data. Without
 	 * this parameter a random identifier is created by the agent.
 	 * 
@@ -188,6 +194,10 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 		}
 		if (inclBootstrapClasses != null) {
 			agentOptions.setInclBootstrapClasses(inclBootstrapClasses
+					.booleanValue());
+		}
+		if (inclNoLocationClasses != null) {
+			agentOptions.setInclNoLocationClasses(inclNoLocationClasses
 					.booleanValue());
 		}
 		if (sessionId != null) {

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -63,51 +63,25 @@ public class CoverageTransformerTest {
 	}
 
 	@Test
-	public void testHasSourceLocationNegative1() {
-		CoverageTransformer t = createTransformer();
-		assertFalse(t.hasSourceLocation(null));
-	}
-
-	@Test
-	public void testHasSourceLocationNegative2() {
-		CoverageTransformer t = createTransformer();
-		ProtectionDomain pd = new ProtectionDomain(null, null);
-		assertFalse(t.hasSourceLocation(pd));
-	}
-
-	@Test
-	public void testHasSourceLocationNegative3() {
-		CoverageTransformer t = createTransformer();
-		CodeSource cs = new CodeSource(null, new Certificate[0]);
-		ProtectionDomain pd = new ProtectionDomain(cs, null);
-		assertFalse(t.hasSourceLocation(pd));
-	}
-
-	@Test
-	public void testHasSourceLocationPositive() {
-		CoverageTransformer t = createTransformer();
-		assertTrue(t.hasSourceLocation(protectionDomain));
-	}
-
-	@Test
 	public void testFilterAgentClass() {
 		CoverageTransformer t = createTransformer();
 		assertFalse(t.filter(classLoader,
-				"org/jacoco/agent/rt/internal/somepkg/SomeClass"));
+				"org/jacoco/agent/rt/internal/somepkg/SomeClass",
+				protectionDomain));
 	}
 
 	@Test
-	public void testFilterIncludesBootstrapClassesPositive() {
+	public void testFilterInclBootstrapClassesPositive() {
 		options.setInclBootstrapClasses(true);
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(null, "java/util/TreeSet"));
+		assertTrue(t.filter(null, "java/util/TreeSet", protectionDomain));
 	}
 
 	@Test
-	public void testFilterIncludesBootstrapClassesNegative() {
+	public void testFilterInclBootstrapClassesNegative() {
 		options.setInclBootstrapClasses(false);
 		CoverageTransformer t = createTransformer();
-		assertFalse(t.filter(null, "java/util/TreeSet"));
+		assertFalse(t.filter(null, "java/util/TreeSet", protectionDomain));
 	}
 
 	@Test
@@ -115,7 +89,7 @@ public class CoverageTransformerTest {
 		options.setInclBootstrapClasses(false);
 		options.setExclClassloader("org.jacoco.agent.SomeWhere$*");
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(classLoader, "org/example/Foo"));
+		assertTrue(t.filter(classLoader, "org/example/Foo", protectionDomain));
 	}
 
 	@Test
@@ -123,7 +97,7 @@ public class CoverageTransformerTest {
 		options.setInclBootstrapClasses(true);
 		options.setExclClassloader("org.jacoco.agent.SomeWhere$*");
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(classLoader, "org/example/Foo"));
+		assertTrue(t.filter(classLoader, "org/example/Foo", protectionDomain));
 	}
 
 	@Test
@@ -133,7 +107,8 @@ public class CoverageTransformerTest {
 		CoverageTransformer t = createTransformer();
 		ClassLoader myClassLoader = new ClassLoader(null) {
 		};
-		assertFalse(t.filter(myClassLoader, "org/example/Foo"));
+		assertFalse(t
+				.filter(myClassLoader, "org/example/Foo", protectionDomain));
 	}
 
 	@Test
@@ -143,42 +118,76 @@ public class CoverageTransformerTest {
 		CoverageTransformer t = createTransformer();
 		ClassLoader myClassLoader = new ClassLoader(null) {
 		};
-		assertFalse(t.filter(myClassLoader, "org/example/Foo"));
+		assertFalse(t
+				.filter(myClassLoader, "org/example/Foo", protectionDomain));
 	}
 
 	@Test
 	public void testFilterIncludedClassPositive() {
 		options.setIncludes("org.jacoco.core.*:org.jacoco.agent.rt.*");
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo"));
+		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo",
+				protectionDomain));
 	}
 
 	@Test
 	public void testFilterIncludedClassNegative() {
 		options.setIncludes("org.jacoco.core.*:org.jacoco.agent.rt.*");
 		CoverageTransformer t = createTransformer();
-		assertFalse(t.filter(classLoader, "org/jacoco/report/Foo"));
+		assertFalse(t.filter(classLoader, "org/jacoco/report/Foo",
+				protectionDomain));
 	}
 
 	@Test
 	public void testFilterExcludedClassPositive() {
 		options.setExcludes("*Test");
 		CoverageTransformer t = createTransformer();
-		assertFalse(t.filter(classLoader, "org/jacoco/core/FooTest"));
+		assertFalse(t.filter(classLoader, "org/jacoco/core/FooTest",
+				protectionDomain));
 	}
 
 	@Test
 	public void testFilterExcludedClassPositiveInner() {
 		options.setExcludes("org.jacoco.example.Foo$Inner");
 		CoverageTransformer t = createTransformer();
-		assertFalse(t.filter(classLoader, "org/jacoco/example/Foo$Inner"));
+		assertFalse(t.filter(classLoader, "org/jacoco/example/Foo$Inner",
+				protectionDomain));
 	}
 
 	@Test
 	public void testFilterExcludedClassNegative() {
 		options.setExcludes("*Test");
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo"));
+		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo",
+				protectionDomain));
+	}
+
+	@Test
+	public void testFilterSourceLocationPositive1() {
+		CoverageTransformer t = createTransformer();
+		assertFalse(t.filter(classLoader, "org/jacoco/core/Foo", null));
+	}
+
+	@Test
+	public void testFilterSourceLocationPositive2() {
+		CoverageTransformer t = createTransformer();
+		ProtectionDomain pd = new ProtectionDomain(null, null);
+		assertFalse(t.filter(classLoader, "org/jacoco/core/Foo", pd));
+	}
+
+	@Test
+	public void testFilterSourceLocationPositive3() {
+		CoverageTransformer t = createTransformer();
+		CodeSource cs = new CodeSource(null, new Certificate[0]);
+		ProtectionDomain pd = new ProtectionDomain(cs, null);
+		assertFalse(t.filter(classLoader, "org/jacoco/core/Foo", pd));
+	}
+
+	@Test
+	public void testFilterSourceLocationNegative() {
+		options.setInclNoLocationClasses(true);
+		CoverageTransformer t = createTransformer();
+		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo", null));
 	}
 
 	@Test

--- a/org.jacoco.ant.test/src/org/jacoco/ant/AgentTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AgentTaskTest.xml
@@ -17,9 +17,10 @@
 			
 	<target name="testCoverageAgent">
 		<jacoco:agent property="jacocoagent" append="false" destfile="test.exec"
-			exclClassLoader="EvilClassLoader" includes="org.example.*"
-		    excludes="*Test" sessionid="testid" dumponexit="false"
-			output="file" address="remotehost" port="1234"
+			exclClassLoader="EvilClassLoader" includes="org.example.*" excludes="*Test"
+			inclbootstrapclasses="true" inclnolocationclasses="true"
+		    sessionid="testid" dumponexit="false"
+			output="file" address="remotehost" port="1234" jmx="true"
 			classdumpdir="target/dump"/>
 		<au:assertPropertySet name="jacocoagent"/>
 		<au:assertPropertyContains name="jacocoagent" value="-javaagent:"/>
@@ -29,11 +30,14 @@
 		<au:assertPropertyContains name="jacocoagent" value="exclclassloader=EvilClassLoader"/>
 		<au:assertPropertyContains name="jacocoagent" value="includes=org.example.*"/>
 		<au:assertPropertyContains name="jacocoagent" value="excludes=*Test"/>
+		<au:assertPropertyContains name="jacocoagent" value="inclbootstrapclasses=true"/>
+		<au:assertPropertyContains name="jacocoagent" value="inclnolocationclasses=true"/>
 		<au:assertPropertyContains name="jacocoagent" value="sessionid=testid"/>
 		<au:assertPropertyContains name="jacocoagent" value="dumponexit=false"/>
 		<au:assertPropertyContains name="jacocoagent" value="output=file"/>
 		<au:assertPropertyContains name="jacocoagent" value="address=remotehost"/>
 		<au:assertPropertyContains name="jacocoagent" value="port=1234"/>
+		<au:assertPropertyContains name="jacocoagent" value="jmx=true"/>
 		<property name="dump.dir" location="target/dump"/>
 		<au:assertPropertyContains name="jacocoagent" value="classdumpdir=${dump.dir}"/>
 	</target>

--- a/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
@@ -126,6 +126,17 @@ public class AbstractCoverageTask extends Task {
 	}
 
 	/**
+	 * Sets whether classes without source location should be instrumented.
+	 * 
+	 * @param include
+	 *            <code>true</code> if classes without source location should be
+	 *            instrumented
+	 */
+	public void setInclNoLocationClasses(final boolean include) {
+		agentOptions.setInclNoLocationClasses(include);
+	}
+
+	/**
 	 * Sets the session identifier. Default is a auto-generated id
 	 * 
 	 * @param id

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
@@ -44,6 +44,7 @@ public class AgentOptionsTest {
 		assertEquals("sun.reflect.DelegatingClassLoader",
 				options.getExclClassloader());
 		assertFalse(options.getInclBootstrapClasses());
+		assertFalse(options.getInclNoLocationClasses());
 		assertNull(options.getSessionId());
 		assertTrue(options.getDumpOnExit());
 		assertEquals(AgentOptions.OutputMode.file, options.getOutput());
@@ -76,6 +77,7 @@ public class AgentOptionsTest {
 		properties.put("excludes", "*Test");
 		properties.put("exclclassloader", "org.jacoco.test.TestLoader");
 		properties.put("inclbootstrapclasses", "true");
+		properties.put("inclnolocationclasses", "true");
 		properties.put("sessionid", "testsession");
 		properties.put("dumponexit", "false");
 		properties.put("output", "tcpserver");
@@ -92,6 +94,7 @@ public class AgentOptionsTest {
 		assertEquals("*Test", options.getExcludes());
 		assertEquals("org.jacoco.test.TestLoader", options.getExclClassloader());
 		assertTrue(options.getInclBootstrapClasses());
+		assertTrue(options.getInclNoLocationClasses());
 		assertEquals("testsession", options.getSessionId());
 		assertFalse(options.getDumpOnExit());
 		assertEquals(AgentOptions.OutputMode.tcpserver, options.getOutput());
@@ -99,6 +102,12 @@ public class AgentOptionsTest {
 		assertEquals(1234, options.getPort());
 		assertEquals("target/dump", options.getClassDumpDir());
 		assertTrue(options.getJmx());
+	}
+
+	@Test
+	public void testEmptyPropertiesOptions() {
+		AgentOptions options = new AgentOptions(new Properties());
+		assertEquals("", options.toString());
 	}
 
 	@Test
@@ -188,19 +197,19 @@ public class AgentOptionsTest {
 	}
 
 	@Test
-	public void testGetIncludeBootstrapClassesTrue() {
+	public void testGetInclBootstrapClassesTrue() {
 		AgentOptions options = new AgentOptions("inclbootstrapclasses=true");
 		assertTrue(options.getInclBootstrapClasses());
 	}
 
 	@Test
-	public void testGetIncludeBootstrapClassesFalse() {
+	public void testGetInclBootstrapClassesFalse() {
 		AgentOptions options = new AgentOptions("inclbootstrapclasses=false");
 		assertFalse(options.getInclBootstrapClasses());
 	}
 
 	@Test
-	public void testSetIncludeBootstrapClassesTrue() {
+	public void testSetInclBootstrapClassesTrue() {
 		AgentOptions options = new AgentOptions();
 		options.setInclBootstrapClasses(true);
 		assertTrue(options.getInclBootstrapClasses());
@@ -208,11 +217,39 @@ public class AgentOptionsTest {
 	}
 
 	@Test
-	public void testSetIncludeBootstrapClassesFalse() {
+	public void testSetInclBootstrapClassesFalse() {
 		AgentOptions options = new AgentOptions();
 		options.setInclBootstrapClasses(false);
 		assertFalse(options.getInclBootstrapClasses());
 		assertEquals("inclbootstrapclasses=false", options.toString());
+	}
+
+	@Test
+	public void testGetInclNoLocationClassesTrue() {
+		AgentOptions options = new AgentOptions("inclnolocationclasses=true");
+		assertTrue(options.getInclNoLocationClasses());
+	}
+
+	@Test
+	public void testGetInclNoLocationClassesFalse() {
+		AgentOptions options = new AgentOptions("inclnolocationclasses=false");
+		assertFalse(options.getInclNoLocationClasses());
+	}
+
+	@Test
+	public void testSetInclNoLocationClassesTrue() {
+		AgentOptions options = new AgentOptions();
+		options.setInclNoLocationClasses(true);
+		assertTrue(options.getInclNoLocationClasses());
+		assertEquals("inclnolocationclasses=true", options.toString());
+	}
+
+	@Test
+	public void testSetInclNoLocationClassesFalse() {
+		AgentOptions options = new AgentOptions();
+		options.setInclNoLocationClasses(false);
+		assertFalse(options.getInclNoLocationClasses());
+		assertEquals("inclnolocationclasses=false", options.toString());
 	}
 
 	@Test
@@ -429,10 +466,12 @@ public class AgentOptionsTest {
 				String.format("-javaagent:%s= a b c",
 						defaultAgentJarFile.toString()), vmArgument);
 	}
-	
-	@Test // issue #358
+
+	@Test
+	// issue #358
 	public void testDestFileWithComma() {
-		AgentOptions options = new AgentOptions("destfile=build/jacoco/foo, bar.exec");
+		AgentOptions options = new AgentOptions(
+				"destfile=build/jacoco/foo, bar.exec");
 		assertEquals("build/jacoco/foo, bar.exec", options.getDestfile());
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -85,6 +85,14 @@ public final class AgentOptions {
 	public static final String INCLBOOTSTRAPCLASSES = "inclbootstrapclasses";
 
 	/**
+	 * Specifies whether also classes without a source location should be
+	 * instrumented. Normally such classes are generated at runtime e.g. by
+	 * mocking frameworks and are therefore excluded by default. Default is
+	 * <code>false</code>.
+	 */
+	public static final String INCLNOLOCATIONCLASSES = "inclnolocationclasses";
+
+	/**
 	 * Specifies a session identifier that is written with the execution data.
 	 * Without this parameter a random identifier is created by the agent.
 	 */
@@ -105,7 +113,7 @@ public final class AgentOptions {
 	 * @see OutputMode#none
 	 */
 	public static final String OUTPUT = "output";
-	
+
 	private static final Pattern OPTION_SPLIT = Pattern.compile(",(?=[a-z]+=)");
 
 	/**
@@ -181,8 +189,8 @@ public final class AgentOptions {
 
 	private static final Collection<String> VALID_OPTIONS = Arrays.asList(
 			DESTFILE, APPEND, INCLUDES, EXCLUDES, EXCLCLASSLOADER,
-			INCLBOOTSTRAPCLASSES, SESSIONID, DUMPONEXIT, OUTPUT, ADDRESS, PORT,
-			CLASSDUMPDIR, JMX);
+			INCLBOOTSTRAPCLASSES, INCLNOLOCATIONCLASSES, SESSIONID, DUMPONEXIT,
+			OUTPUT, ADDRESS, PORT, CLASSDUMPDIR, JMX);
 
 	private final Map<String, String> options;
 
@@ -354,7 +362,8 @@ public final class AgentOptions {
 	 * Returns whether classes from the bootstrap classloader should be
 	 * instrumented.
 	 * 
-	 * @return <code>true</code> if coverage data will be written on VM exit
+	 * @return <code>true</code> if classes from the bootstrap classloader
+	 *         should be instrumented
 	 */
 	public boolean getInclBootstrapClasses() {
 		return getOption(INCLBOOTSTRAPCLASSES, false);
@@ -369,6 +378,27 @@ public final class AgentOptions {
 	 */
 	public void setInclBootstrapClasses(final boolean include) {
 		setOption(INCLBOOTSTRAPCLASSES, include);
+	}
+
+	/**
+	 * Returns whether classes without source location should be instrumented.
+	 * 
+	 * @return <code>true</code> if classes without source location should be
+	 *         instrumented
+	 */
+	public boolean getInclNoLocationClasses() {
+		return getOption(INCLNOLOCATIONCLASSES, false);
+	}
+
+	/**
+	 * Sets whether classes without source location should be instrumented.
+	 * 
+	 * @param include
+	 *            <code>true</code> if classes without source location should be
+	 *            instrumented
+	 */
+	public void setInclNoLocationClasses(final boolean include) {
+		setOption(INCLNOLOCATIONCLASSES, include);
 	}
 
 	/**

--- a/org.jacoco.doc/docroot/doc/agent.html
+++ b/org.jacoco.doc/docroot/doc/agent.html
@@ -125,6 +125,14 @@
       <td><code>false</code></td>
     </tr>
     <tr>
+      <td><code>inclnolocationclasses</code></td>
+      <td>Specifies whether also classes without a source location should be
+          instrumented. Normally such classes are generated at runtime e.g. by
+          mocking frameworks and are therefore excluded by default. 
+      </td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
       <td><code>sessionid</code></td>
       <td>A session identifier that is written with the execution data. Without
           this parameter a random identifier is created by the agent.

--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -216,6 +216,14 @@
       <td><code>false</code></td>
     </tr>
     <tr>
+      <td><code>inclnolocationclasses</code></td>
+      <td>Specifies whether also classes without a source location should be
+          instrumented. Normally such classes are generated at runtime e.g. by
+          mocking frameworks and are therefore excluded by default. 
+      </td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
       <td><code>sessionid</code></td>
       <td>A session identifier that is written with the execution data. Without
           this parameter a random identifier is created by the agent.

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -22,6 +22,9 @@
 
 <h3>New Features</h3>
 <ul>
+  <li>New agent option <code>inclnolocationclasses</code> to support execution
+      environments like Android where no source location is provided with classes
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/288">#288</a>).</li>
   <li>Improved error message in case of incompatible execution data files.
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/319">#319</a>).</li>
   <li>Command line agent options now supports comma in file names. Contributed


### PR DESCRIPTION
Version info:
Gradle 2.2.1
Android Gradle plugin 1.0.1
Robolectric Gradle plugin 0.14.1
JUnit 4.10
Robolectric 2.4

Setting up a simple test using a configuration like:

```groovy
apply plugin: 'jacoco'
jacoco.toolVersion = project.property('jacocoVersion')
```

and running my unit tests with:

    $ ./gradlew -PjacocoVersion=0.7.1.+ clean :testDebug :jacocoTestDebugReport
    ...
    $ ls -l build/jacoco/testDebug.exec
    -rw-r--r--+ 1 jhansche  staff  278218 Feb 26 16:45 build/jacoco/testDebug.exec
    $ strings build/jacoco/testDebug.exec | wc -l
        4325

This all works correctly, and I get a proper JaCoCo report generated.  Changing **nothing else** but the `toolVersion`, however, breaks the execution data that is gathered:

    $ ./gradlew -PjacocoVersion=0.7.4-SNAPSHOT clean :testDebug :jacocoTestDebugReport
    ...
    $ ls -l build/jacoco/testDebug.exec
    -rw-r--r--+ 1 jhansche  staff  36910 Feb 26 16:56 build/jacoco/testDebug.exec
    $ strings build/jacoco/testDebug.exec | wc -l
         639

You can see that the execution data file is much smaller, and contains far fewer strings.  Looking at the "Sessions" link in the top-right of the HTML report lists only *one* class from my application's package (the Android app's `R$styleable` class).  The majority of the classes listed are in one of the `org.gradle`, `org.junit`, or `org.robolectric` packages.  Using 0.7.1, it included all the `android.**` classes, and more importantly, the classes from my application.

However, when I set the `test.jacoco.classDumpFile = file("${project.buildDir}/jacoco/dump")` property, I **do** see most of my application's (tested) classes listed in that directory -- they just don't show up in the execution data file.

One other difference that I notice in the `dump/` directory (for a single example test class):

0.7.1:
build/jacoco/dump//com/example/MyClass.class
build/jacoco/dump//com/example/MyClassTest.class

0.7.4:
build/jacoco/dump//com/example/MyClass.9b700a23ba643d32.class
build/jacoco/dump//com/example/MyClassTest.22115a9aa9d0d3ee.class

I'm in a difficult position as now I am forced to use two different versions of JaCoCo:  0.7.1 with Robolectric+JUnit to get coverage of unit tests on the local JVM;  and 0.7.3+ with Calabash to get coverage of instrumentation tests running on the device's runtime -- I am forced to update to 0.7.3 in order to allow support for the Android ART runtime, as otherwise the instrumented classes cannot be installed on a Lollipop device.

What other information can I provide to help track down what is going wrong here?  If it's not a bug in JaCoCo, then who is to blame? (I realize there is a very long list of potential candidates for where it should be fixed).