### PR TITLE
Finer-grained thresholds for certain classes

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -54,7 +54,19 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 	 * If a limit refers to a ratio the range is from 0.0 to 1.0 where the
 	 * number of decimal places will also determine the precision in error
 	 * messages.
+	 * </p>
 	 * 
+	 * <p>
+	 * If not specified the following defaults are assumed:
+	 * </p>
+	 * 
+	 * <ul>
+	 * <li>rule element: BUNDLE</li>
+	 * <li>limit counter: INSTRUCTION</li>
+	 * <li>limit value: COVEREDRATIO</li>
+	 * </ul>
+	 * 
+	 * <p>
 	 * Note that you <b>must</b> use <tt>implementation</tt> hints for
 	 * <tt>rule</tt> and <tt>limit</tt> when using Maven 2, with Maven 3 you do
 	 * not need to specify the attributes.


### PR DESCRIPTION
I have a problem with JaCoCo  maven plugin configuration when I'm trying to  specify finer-grained thresholds for certain classes within rules.

When we use Cobertura maven plugin, for example, we can specify finer-grained thresholds for certain classes using regular expressions.

For example:

```xml
<regex><pattern>.*.checkstyle.AnnotationUtility</pattern><branchRate>60</branchRate><lineRate>60</lineRate></regex>
```

In accordance with JaCoCo maven plugin [documentation for ```jacoco:check```](http://www.eclemma.org/jacoco/trunk/doc/check-mojo.html), we can also do this if we write the rule for every class with  ``` <include>``` tag in configuration for JaCoCo maven plugin (in pom.xml).

For example:

```xml
<configuration>
    <haltOnFailure>true</haltOnFailure>  // < ---- Halt the build if any of the checks fail
        <rules>
            <rule element="CLASS">
                <includes>
                   <include>com.puppycrawl.tools.checkstyle.AnnotationUtility</include>
                </includes>
                <limits>
                    <limit counter="BRANCH" value="COVEREDRATIO"><minimum>0.60</minimum></limit>
                    <limit counter="LINE" value="COVEREDRATIO"><minimum>0.60</minimum></limit>
               </limits>
            </rule>
        </rules>
</configuration>
```

But ```<include>``` tag doesn't work correctly and if any of the checks fail (coverage less than minimum requirements), haltOnFailure flag doesn't halt the build.

If we specify coverage thresholds for the whole project (for lines, branches, etc) it works fine! The problem appears only when we specify coverage thresholds for certain classes. 