### PR TITLE
Add support for non-java source files which are not organised by package.

### DIFF
--- a/org.jacoco.ant.test/src/org/jacoco/ant/AntFilesLocatorTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AntFilesLocatorTest.java
@@ -59,11 +59,19 @@ public class AntFilesLocatorTest {
 		assertContent(source);
 	}
 
+	@Test
+	public void testCanGetResourceWithWrongSlashes() throws IOException {
+		locator.add(createFile("org/jacoco/example/Test.notjava"));
+		final Reader source = locator.getSourceFile("",
+				"org\\jacoco/example/Test.notjava");
+		assertContent(source);
+	}
+
 	private Resource createFile(String path) throws IOException {
 		final File file = new File(folder.getRoot(), path);
 		file.getParentFile().mkdirs();
-		final Writer writer = new OutputStreamWriter(
-				new FileOutputStream(file), "UTF-8");
+		final Writer writer = new OutputStreamWriter(new FileOutputStream(file),
+				"UTF-8");
 		writer.write("Source");
 		writer.close();
 		return new FileResource(folder.getRoot(), path);

--- a/org.jacoco.ant/src/org/jacoco/ant/AntFilesLocator.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/AntFilesLocator.java
@@ -27,8 +27,7 @@ class AntFilesLocator extends InputStreamSourceFileLocator {
 
 	private final Map<String, Resource> resources;
 
-	public AntFilesLocator(final String encoding,
-			final int tabWidth) {
+	public AntFilesLocator(final String encoding, final int tabWidth) {
 		super(encoding, tabWidth);
 		this.resources = new HashMap<String, Resource>();
 	}
@@ -44,7 +43,8 @@ class AntFilesLocator extends InputStreamSourceFileLocator {
 	}
 
 	@Override
-	protected InputStream getSourceStream(final String path) throws IOException {
+	protected InputStream getSourceStream(String path) throws IOException {
+		path = path.replace('\\', '/');
 		final Resource file = resources.get(path);
 		if (file == null) {
 			return null;

--- a/org.jacoco.report.test/src/org/jacoco/report/InputStreamSourceFileLocatorTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/InputStreamSourceFileLocatorTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 public class InputStreamSourceFileLocatorTest {
 
-	private Map<String, byte[]> sources = new HashMap<String, byte[]>();
+	private final Map<String, byte[]> sources = new HashMap<String, byte[]>();
 
 	class TestLocator extends InputStreamSourceFileLocator {
 
@@ -67,6 +67,29 @@ public class InputStreamSourceFileLocatorTest {
 		ISourceFileLocator locator = new TestLocator("UTF-8", 4);
 		sources.put("Test.java", "ÜÄö".getBytes("UTF-8"));
 		assertContent("ÜÄö", locator.getSourceFile("", "Test.java"));
+	}
+
+	@Test
+	public void testGetNonJavaSourceFile() throws IOException {
+		ISourceFileLocator locator = new TestLocator("UTF-8", 4);
+		sources.put("org/jacoco/example/Test.notjava", "ÜÄö".getBytes("UTF-8"));
+		assertContent("ÜÄö", locator.getSourceFile("some/package/we/dont/know",
+				"org/jacoco/example/Test.notjava"));
+	}
+
+	@Test
+	public void testGetJavaSourceFileNegative() throws IOException {
+		ISourceFileLocator locator = new TestLocator("UTF-8", 4);
+		sources.put("org/jacoco/example/Test.java", "ÜÄö".getBytes("UTF-8"));
+		assertNull(locator.getSourceFile("some/package/we/dont/know",
+				"org/jacoco/example/Test.java"));
+	}
+
+	@Test
+	public void testGetSourceFileDefaultPackageNegative() throws IOException {
+		ISourceFileLocator locator = new TestLocator("UTF-8", 4);
+		sources.put("org/jacoco/example/Test.java", "ÜÄö".getBytes("UTF-8"));
+		assertNull(locator.getSourceFile("", "Test.java"));
 	}
 
 	@Test

--- a/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
@@ -46,7 +46,12 @@ public abstract class InputStreamSourceFileLocator implements
 			throws IOException {
 		final InputStream in;
 		if (packageName.length() > 0) {
-			in = getSourceStream(packageName + "/" + fileName);
+			InputStream temp;
+			temp = getSourceStream(packageName + "/" + fileName);
+			if (temp == null && !fileName.endsWith(".java")) {
+				temp = getSourceStream(fileName);
+			}
+			in = temp;
 		} else {
 			in = getSourceStream(fileName);
 		}


### PR DESCRIPTION
Not all languages on the JVM follow the Java way of organising source files by package. In order to produce line-by-line coverage reports for such languages we need to check source file locations relative to the supplied source directories but not taking account of the java package the class belongs in.