### PR TITLE
Don't write empty probe arrays to exec files

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpClientOutputTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpClientOutputTest.java
@@ -21,8 +21,6 @@ import java.net.Socket;
 import java.util.List;
 
 import org.jacoco.agent.rt.internal.ExceptionRecorder;
-import org.jacoco.agent.rt.internal.output.IAgentOutput;
-import org.jacoco.agent.rt.internal.output.TcpClientOutput;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfo;
 import org.jacoco.core.data.SessionInfoStore;
@@ -93,7 +91,7 @@ public class TcpClientOutputTest {
 
 	@Test
 	public void testWriteExecutionData() throws Exception {
-		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42);
+		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42).getProbes()[0] = true;
 		data.setSessionId("stubid");
 
 		controller.writeExecutionData(false);

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpConnectionTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpConnectionTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
-import org.jacoco.agent.rt.internal.output.TcpConnection;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.ExecutionDataWriter;
 import org.jacoco.core.data.SessionInfo;
@@ -150,7 +149,7 @@ public class TcpConnectionTest extends ExecutorTestBase {
 
 	@Test
 	public void testRemoteDump() throws Exception {
-		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42);
+		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42).getProbes()[0] = true;
 		data.setSessionId("stubid");
 
 		final RemoteControlWriter remoteWriter = new RemoteControlWriter(
@@ -178,7 +177,7 @@ public class TcpConnectionTest extends ExecutorTestBase {
 
 	@Test
 	public void testLocalDump() throws Exception {
-		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42);
+		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42).getProbes()[0] = true;
 		data.setSessionId("stubid");
 
 		new RemoteControlWriter(mockConnection.getSocketB().getOutputStream());

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpServerOutputTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpServerOutputTest.java
@@ -25,7 +25,6 @@ import java.net.UnknownHostException;
 import java.util.List;
 
 import org.jacoco.agent.rt.internal.ExceptionRecorder;
-import org.jacoco.agent.rt.internal.output.TcpServerOutput;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.ExecutionDataWriter;
 import org.jacoco.core.data.SessionInfo;
@@ -85,7 +84,7 @@ public class TcpServerOutputTest {
 
 	@Test
 	public void testWriteExecutionData() throws Exception {
-		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42);
+		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42).getProbes()[0] = true;
 		data.setSessionId("stubid");
 
 		final Socket socket = serverSocket.connect();

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -151,7 +151,7 @@ public class ExecutionDataReaderWriterTest {
 	public void testMissingHeader() throws IOException {
 		buffer.reset();
 		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
-				createData(0)));
+				createData(8)));
 		createReaderWithVisitors().read();
 	}
 
@@ -206,13 +206,13 @@ public class ExecutionDataReaderWriterTest {
 	@Test(expected = IOException.class)
 	public void testNoExecutionDataVisitor() throws IOException {
 		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
-				createData(0)));
+				createData(8)));
 		createReader().read();
 	}
 
 	@Test
 	public void testMinClassId() throws IOException {
-		final boolean[] data = createData(0);
+		final boolean[] data = createData(8);
 		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
 				data));
 		assertFalse(createReaderWithVisitors().read());
@@ -221,7 +221,7 @@ public class ExecutionDataReaderWriterTest {
 
 	@Test
 	public void testMaxClassId() throws IOException {
-		final boolean[] data = createData(0);
+		final boolean[] data = createData(8);
 		writer.visitClassExecution(new ExecutionData(Long.MAX_VALUE, "Sample",
 				data));
 		assertFalse(createReaderWithVisitors().read());
@@ -233,12 +233,20 @@ public class ExecutionDataReaderWriterTest {
 		final boolean[] data = createData(0);
 		writer.visitClassExecution(new ExecutionData(3, "Sample", data));
 		assertFalse(createReaderWithVisitors().read());
-		assertArrayEquals(data, store.get(3).getProbes());
+		assertTrue(store.getContents().isEmpty());
+	}
+
+	@Test
+	public void testNoHitClass() throws IOException {
+		final boolean[] data = new boolean[] { false, false, false };
+		writer.visitClassExecution(new ExecutionData(3, "Sample", data));
+		assertFalse(createReaderWithVisitors().read());
+		assertTrue(store.getContents().isEmpty());
 	}
 
 	@Test
 	public void testOneClass() throws IOException {
-		final boolean[] data = createData(5);
+		final boolean[] data = createData(15);
 		writer.visitClassExecution(new ExecutionData(3, "Sample", data));
 		assertFalse(createReaderWithVisitors().read());
 		assertArrayEquals(data, store.get(3).getProbes());
@@ -246,8 +254,8 @@ public class ExecutionDataReaderWriterTest {
 
 	@Test
 	public void testTwoClasses() throws IOException {
-		final boolean[] data1 = createData(5);
-		final boolean[] data2 = createData(7);
+		final boolean[] data1 = createData(15);
+		final boolean[] data2 = createData(185);
 		writer.visitClassExecution(new ExecutionData(333, "Sample", data1));
 		writer.visitClassExecution(new ExecutionData(-45, "Sample", data2));
 		assertFalse(createReaderWithVisitors().read());
@@ -257,7 +265,7 @@ public class ExecutionDataReaderWriterTest {
 
 	@Test
 	public void testBigClass() throws IOException {
-		final boolean[] data = createData(117);
+		final boolean[] data = createData(3599);
 		writer.visitClassExecution(new ExecutionData(123, "Sample", data));
 		assertFalse(createReaderWithVisitors().read());
 		assertArrayEquals(data, store.get(123).getProbes());
@@ -290,7 +298,7 @@ public class ExecutionDataReaderWriterTest {
 	}
 
 	private boolean[] createData(final int probeCount) {
-		final boolean[] data = new boolean[random.nextInt(probeCount + 1)];
+		final boolean[] data = new boolean[probeCount];
 		for (int j = 0; j < data.length; j++) {
 			data[j] = random.nextBoolean();
 		}

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
@@ -54,6 +54,22 @@ public class ExecutionDataTest {
 	}
 
 	@Test
+	public void testHasHits() {
+		final boolean[] probes = new boolean[] { false, false, false };
+		final ExecutionData e = new ExecutionData(5, "Example", probes);
+		assertFalse(e.hasHits());
+		probes[1] = true;
+		assertTrue(e.hasHits());
+	}
+
+	@Test
+	public void testHasHits_empty() {
+		final boolean[] probes = new boolean[] {};
+		final ExecutionData e = new ExecutionData(5, "Example", probes);
+		assertFalse(e.hasHits());
+	}
+
+	@Test
 	public void testMerge() {
 		final ExecutionData a = new ExecutionData(5, "Example", new boolean[] {
 				false, true, false, true });

--- a/org.jacoco.core.test/src/org/jacoco/core/tools/ExecFileLoaderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/tools/ExecFileLoaderTest.java
@@ -28,7 +28,6 @@ import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.ExecutionDataWriter;
 import org.jacoco.core.data.SessionInfo;
 import org.jacoco.core.data.SessionInfoStore;
-import org.jacoco.core.tools.ExecFileLoader;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -119,7 +118,8 @@ public class ExecFileLoaderTest {
 		final FileOutputStream out = new FileOutputStream(file);
 		final ExecutionDataWriter writer = new ExecutionDataWriter(out);
 		final int value = id.length();
-		writer.visitClassExecution(new ExecutionData(value, id, new boolean[0]));
+		writer.visitClassExecution(new ExecutionData(value, id,
+				new boolean[] { true }));
 		writer.visitSessionInfo(new SessionInfo(id, value, value));
 		out.close();
 		return file;

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
@@ -99,6 +99,20 @@ public final class ExecutionData {
 	}
 
 	/**
+	 * Checks whether any probe has been hit.
+	 * 
+	 * @return <code>true</code>, if at least one probe has been hit
+	 */
+	public boolean hasHits() {
+		for (final boolean p : probes) {
+			if (p) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Merges the given execution data into the probe data of this object. I.e.
 	 * a probe entry in this object is marked as executed (<code>true</code>) if
 	 * this probe or the corresponding other probe was executed. So the result
@@ -189,4 +203,5 @@ public final class ExecutionData {
 		return String.format("ExecutionData[name=%s, id=%016x]", name,
 				Long.valueOf(id));
 	}
+
 }

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
@@ -90,13 +90,15 @@ public class ExecutionDataWriter implements ISessionInfoVisitor,
 	}
 
 	public void visitClassExecution(final ExecutionData data) {
-		try {
-			out.writeByte(BLOCK_EXECUTIONDATA);
-			out.writeLong(data.getId());
-			out.writeUTF(data.getName());
-			out.writeBooleanArray(data.getProbes());
-		} catch (final IOException e) {
-			throw new RuntimeException(e);
+		if (data.hasHits()) {
+			try {
+				out.writeByte(BLOCK_EXECUTIONDATA);
+				out.writeLong(data.getId());
+				out.writeUTF(data.getName());
+				out.writeBooleanArray(data.getProbes());
+			} catch (final IOException e) {
+				throw new RuntimeException(e);
+			}
 		}
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -22,6 +22,9 @@
 
 <h3>Non-functional Changes</h3>
 <ul>
+  <li>Empty probe arrays are not written to execution data files any more. This
+      reduces exec file size significantly for per-test data dumps.
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/387">#387</a>).</li>
   <li>Require at least Maven 3.0 for build of JaCoCo.</li>
 </ul>
 


### PR DESCRIPTION
On the mailing list it was proposed to not dump empty probe arrays to execution data files:

https://groups.google.com/forum/?fromgroups=#!topic/jacoco/wQhTVf2zEtI

In case of repeated dumps (per-test coverage) this can lead to a significant performance improvement:

* test time: 12hrs -> 1hr
* jacoco.exec size: 93GB -> 1GB

Within JaCoCo there is no use for empty probe arrays vs. non existing ExecutionData entries. Therefore there is no need to dump such entries.