### PR TITLE
Improve EOF handling for exec files

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
@@ -13,7 +13,6 @@ package org.jacoco.core.data;
 
 import static java.lang.String.format;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -79,19 +78,19 @@ public class ExecutionDataReader {
 	 */
 	public boolean read() throws IOException,
 			IncompatibleExecDataVersionException {
-		try {
-			byte type;
-			do {
-				type = in.readByte();
-				if (firstBlock && type != ExecutionDataWriter.BLOCK_HEADER) {
-					throw new IOException("Invalid execution data file.");
-				}
-				firstBlock = false;
-			} while (readBlock(type));
-			return true;
-		} catch (final EOFException e) {
-			return false;
-		}
+		byte type;
+		do {
+			int i = in.read();
+			if (i == -1) {
+				return false; // EOF
+			}
+			type = (byte) i;
+			if (firstBlock && type != ExecutionDataWriter.BLOCK_HEADER) {
+				throw new IOException("Invalid execution data file.");
+			}
+			firstBlock = false;
+		} while (readBlock(type));
+		return true;
 	}
 
 	/**

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,12 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>Fixed Bugs</h3>
+<ul>
+  <li>Don't suppress EOF errors in case of truncated execution data files
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/397">#397</a>).</li>
+</ul>
+
 <h3>Non-functional Changes</h3>
 <ul>
   <li>Empty probe arrays are not written to execution data files any more. This


### PR DESCRIPTION
As proposed here we should not ignore EOFExceptions in case exec files are truncated somewhere in the middle: https://groups.google.com/d/msg/jacoco/qby-WuQp194/iFnx2fAHBAAJ