### PR TITLE
jacoco-maven-plugin depends on too old plexus-utils

### DIFF
--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>1.5.6</version>
+      <version>3.0.22</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Currently jacoco-maven-plugin depends on plexus-utils 1.5.6. It seems when maven decides to really use that version, building a report fails:

```
[INFO] --- jacoco-maven-plugin:0.7.4.201502262128:report (default-report) @ core ---
Mar 5, 2015 4:55:49 PM org.sonatype.guice.bean.reflect.Logs$JULSink warn
WARNING: Error injecting: org.apache.maven.doxia.siterenderer.DefaultSiteRenderer
java.lang.NoClassDefFoundError: org/codehaus/plexus/util/AbstractScanner
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2545)
	at java.lang.Class.getDeclaredConstructors(Class.java:1903)
	at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
	at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:98)
	at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:654)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:856)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:783)
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:279)
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:211)
	at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:979)
	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1012)
	at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:975)
	at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1025)
[...]
```

AbstractScanner seems to have been introduced in plexus-utils 1.5.8, so this is understandable. I would suggest raising the dependency version.