### PR TITLE
Fix compilation with JDK 9 >= b111

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -200,7 +200,7 @@ public class CoverageTransformerTest {
 	@Test
 	public void testTransformFiltered2() throws IllegalClassFormatException {
 		CoverageTransformer t = createTransformer();
-		assertNull(t.transform(null, "org.jacoco.Sample", null,
+		assertNull(t.transform((ClassLoader) null, "org.jacoco.Sample", null,
 				protectionDomain, new byte[0]));
 	}
 


### PR DESCRIPTION
Currently compilation of tests fails with JDK 9 >= b111.

@marchof do you have an ideas of how we can resolve this?

I can imagine following options:

1. start using mocking framework such as Mockito
2. conditional compilation of different mocks for pre JDK 9 and post JDK 9 using separate module
3. remove this test
