### PR TITLE
".resources" directory causes problems for github pages

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -27,6 +27,9 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/388">#388</a>).</li>
   <li>New parameters <code>title</code> and <code>footer</code> for Maven
       reporting goals allow customization of generated reports.</li>
+  <li>Renamed "dot" resources in generated HTML reports to become more web
+      hosting friendly
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/401">#401</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ReportPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ReportPageTest.java
@@ -98,7 +98,7 @@ public class ReportPageTest extends PageTestBase {
 		assertEquals("en", support.findStr(doc, "/html/@lang"));
 
 		// style sheet
-		assertEquals(".resources/report.css", support.findStr(doc,
+		assertEquals("jacoco-resources/report.css", support.findStr(doc,
 				"/html/head/link[@rel='stylesheet']/@href"));
 
 		// bread crumb

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SessionsPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SessionsPageTest.java
@@ -57,7 +57,7 @@ public class SessionsPageTest extends PageTestBase {
 	public void testGetFileName() {
 		final SessionsPage page = new SessionsPage(noSessions, noExecutionData,
 				index, null, rootFolder, context);
-		assertEquals(".sessions.html", page.getFileName());
+		assertEquals("jacoco-sessions.html", page.getFileName());
 	}
 
 	@Test
@@ -72,7 +72,8 @@ public class SessionsPageTest extends PageTestBase {
 		final SessionsPage page = new SessionsPage(noSessions, noExecutionData,
 				index, null, rootFolder, context);
 		page.render();
-		final Document doc = support.parse(output.getFile(".sessions.html"));
+		final Document doc = support.parse(output
+				.getFile("jacoco-sessions.html"));
 		assertEquals("No session information available.",
 				support.findStr(doc, "/html/body/p[1]"));
 		assertEquals("No execution data available.",
@@ -88,7 +89,8 @@ public class SessionsPageTest extends PageTestBase {
 		final SessionsPage page = new SessionsPage(sessions, noExecutionData,
 				index, null, rootFolder, context);
 		page.render();
-		final Document doc = support.parse(output.getFile(".sessions.html"));
+		final Document doc = support.parse(output
+				.getFile("jacoco-sessions.html"));
 		assertEquals("el_session", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/span/@class"));
 		assertEquals("Session-A", support.findStr(doc,
@@ -128,7 +130,8 @@ public class SessionsPageTest extends PageTestBase {
 		final SessionsPage page = new SessionsPage(noSessions, data, index,
 				null, rootFolder, context);
 		page.render();
-		final Document doc = support.parse(output.getFile(".sessions.html"));
+		final Document doc = support.parse(output
+				.getFile("jacoco-sessions.html"));
 		assertEquals("el_class", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/a/@class"));
 		assertEquals("Foo.html", support.findStr(doc,

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SourceFilePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SourceFilePageTest.java
@@ -52,15 +52,15 @@ public class SourceFilePageTest extends PageTestBase {
 				.getFile("SourceFilePageTest.java.html"));
 
 		// additional style sheet
-		assertEquals(".resources/report.css", support.findStr(result,
+		assertEquals("jacoco-resources/report.css", support.findStr(result,
 				"/html/head/link[@rel='stylesheet'][1]/@href"));
-		assertEquals(".resources/prettify.css", support.findStr(result,
+		assertEquals("jacoco-resources/prettify.css", support.findStr(result,
 				"/html/head/link[@rel='stylesheet'][2]/@href"));
 
 		// highlighting script
 		assertEquals("text/javascript",
 				support.findStr(result, "/html/head/script/@type"));
-		assertEquals(".resources/prettify.js",
+		assertEquals("jacoco-resources/prettify.js",
 				support.findStr(result, "/html/head/script/@src"));
 		assertEquals("window['PR_TAB_WIDTH']=4;prettyPrint()",
 				support.findStr(result, "/html/body/@onload"));

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/resources/ResourcesTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/resources/ResourcesTest.java
@@ -42,7 +42,7 @@ public class ResourcesTest {
 	@Test
 	public void testGetLink() {
 		ReportOutputFolder base = root.subFolder("f1").subFolder("f2");
-		assertEquals("../../.resources/test.png",
+		assertEquals("../../jacoco-resources/test.png",
 				resources.getLink(base, "test.png"));
 
 	}
@@ -50,25 +50,25 @@ public class ResourcesTest {
 	@Test
 	public void testCopyResources() throws IOException {
 		resources.copyResources();
-		output.assertFile(".resources/branchfc.gif");
-		output.assertFile(".resources/branchnc.gif");
-		output.assertFile(".resources/branchpc.gif");
-		output.assertFile(".resources/bundle.gif");
-		output.assertFile(".resources/class.gif");
-		output.assertFile(".resources/down.gif");
-		output.assertFile(".resources/greenbar.gif");
-		output.assertFile(".resources/group.gif");
-		output.assertFile(".resources/method.gif");
-		output.assertFile(".resources/package.gif");
-		output.assertFile(".resources/prettify.css");
-		output.assertFile(".resources/prettify.js");
-		output.assertFile(".resources/redbar.gif");
-		output.assertFile(".resources/report.css");
-		output.assertFile(".resources/report.gif");
-		output.assertFile(".resources/class.gif");
-		output.assertFile(".resources/sort.js");
-		output.assertFile(".resources/source.gif");
-		output.assertFile(".resources/up.gif");
+		output.assertFile("jacoco-resources/branchfc.gif");
+		output.assertFile("jacoco-resources/branchnc.gif");
+		output.assertFile("jacoco-resources/branchpc.gif");
+		output.assertFile("jacoco-resources/bundle.gif");
+		output.assertFile("jacoco-resources/class.gif");
+		output.assertFile("jacoco-resources/down.gif");
+		output.assertFile("jacoco-resources/greenbar.gif");
+		output.assertFile("jacoco-resources/group.gif");
+		output.assertFile("jacoco-resources/method.gif");
+		output.assertFile("jacoco-resources/package.gif");
+		output.assertFile("jacoco-resources/prettify.css");
+		output.assertFile("jacoco-resources/prettify.js");
+		output.assertFile("jacoco-resources/redbar.gif");
+		output.assertFile("jacoco-resources/report.css");
+		output.assertFile("jacoco-resources/report.gif");
+		output.assertFile("jacoco-resources/class.gif");
+		output.assertFile("jacoco-resources/sort.js");
+		output.assertFile("jacoco-resources/source.gif");
+		output.assertFile("jacoco-resources/up.gif");
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/BarColumnTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/BarColumnTest.java
@@ -101,7 +101,7 @@ public class BarColumnTest {
 				support.findStr(doc, "count(/html/body/table/tr[1]/td/img)"));
 
 		// red bar
-		assertEquals(".resources/redbar.gif",
+		assertEquals("jacoco-resources/redbar.gif",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@src"));
 		assertEquals("15",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@alt"));
@@ -109,7 +109,7 @@ public class BarColumnTest {
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@width"));
 
 		// green bar
-		assertEquals(".resources/greenbar.gif",
+		assertEquals("jacoco-resources/greenbar.gif",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[2]/@src"));
 		assertEquals("5",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[2]/@alt"));
@@ -129,7 +129,7 @@ public class BarColumnTest {
 				support.findStr(doc, "count(/html/body/table/tr[1]/td/img)"));
 
 		// red bar
-		assertEquals(".resources/redbar.gif",
+		assertEquals("jacoco-resources/redbar.gif",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@src"));
 		assertEquals("20",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@alt"));
@@ -149,7 +149,7 @@ public class BarColumnTest {
 				support.findStr(doc, "count(/html/body/table/tr[1]/td/img)"));
 
 		// red bar
-		assertEquals(".resources/greenbar.gif",
+		assertEquals("jacoco-resources/greenbar.gif",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@src"));
 		assertEquals("20",
 				support.findStr(doc, "/html/body/table/tr[1]/td/img[1]/@alt"));

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/SessionsPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/SessionsPage.java
@@ -146,7 +146,7 @@ public class SessionsPage extends ReportPage {
 
 	@Override
 	protected String getFileName() {
-		return ".sessions.html";
+		return "jacoco-sessions.html";
 	}
 
 	public String getLinkStyle() {

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/resources/Resources.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/resources/Resources.java
@@ -51,7 +51,7 @@ public class Resources {
 	 *            root folder of the report
 	 */
 	public Resources(final ReportOutputFolder root) {
-		folder = root.subFolder(".resources");
+		folder = root.subFolder("jacoco-resources");
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/github/maven-plugins/issues/112


### Steps to reproduce

JaCoCo version: 0.7.6.201602180812
Operating system: Windows/gitshell 
Tool integration: Maven (github-site plugin)

### Expected behaviour

Reports display correctly on github site. 

### Actual behaviour

The .resources directory is not deployed. 

I have raised an issue with the github/maven-plugins project 
https://github.com/github/maven-plugins/issues/112
however the problem may well not be solvable by them. 

The root cause is that some software, arguably correctly, overlooked a directory starting with a dot. 

Your resources directory should not be a hidden directory. 

Please consider renaming it to resources. 

