### PR TITLE
Fix build on Windows

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-aggregate/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/verify.bsh
@@ -13,15 +13,15 @@ import org.codehaus.plexus.util.*;
 
 String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
 
-if ( buildLog.indexOf( "/child1/target/jacoco.exec" ) < 0 ) {
+if ( buildLog.indexOf( "/child1/target/jacoco.exec".replace('/', File.separatorChar) ) < 0 ) {
     throw new RuntimeException( "Execution data from child1 was not loaded." );
 }
 
-if ( buildLog.indexOf( "/child1-test/target/jacoco.exec" ) < 0 ) {
+if ( buildLog.indexOf( "/child1-test/target/jacoco.exec".replace('/', File.separatorChar) ) < 0 ) {
     throw new RuntimeException( "Execution data from child1-test was not loaded." );
 }
 
-if ( buildLog.indexOf( "/child2/target/jacoco.exec" ) < 0 ) {
+if ( buildLog.indexOf( "/child2/target/jacoco.exec".replace('/', File.separatorChar) ) < 0 ) {
     throw new RuntimeException( "Execution data from child2 was not loaded." );
 }
 

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -306,7 +306,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>1.8</version>
+          <version>2.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We should update the versions of our build plugins. I came accross this issue while trying to build JaCoCo on Windows:

https://issues.apache.org/jira/browse/MNG-5792