### PR TITLE
Provide more context information when unable to read input during analysis

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -43,6 +43,9 @@
   <li>Empty probe arrays are not written to execution data files any more. This
       reduces exec file size significantly for per-test data dumps.
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/387">#387</a>).</li>
+  <li>More information about context is provided when unable to read input during
+      analysis.
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/400">#400</a>).</li>
   <li>Require at least Maven 3.0 for build of JaCoCo.</li>
 </ul>
 


### PR DESCRIPTION
Add location to `IOException` thrown from

1. `zip.getNextEntry()` in `analyzeZip`
2. `new GZIPInputStream(input)` in `analyzeGzip`
2. `Pack200Streams.unpack(input)` in `analyzePack200`
