### PR TITLE
Use Maven Plugin Tools Java Annotations

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -82,9 +82,7 @@ case "$JDK" in
   ;;
 9-ea)
   # see https://bugs.openjdk.java.net/browse/JDK-8131041 about "java.locale.providers"
-  # TODO(Godin): maven-javadoc-plugin doesn't work well due to modularization of JDK 9 - skip it and hence distribution
   mvn -V -B -e verify -Dbytecode.version=1.8 \
-    -Dmaven.javadoc.skip -pl !jacoco \
     -DargLine=-Djava.locale.providers=JRE,SPI
   ;;
 *)

--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -76,6 +76,14 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>org.jacoco.report</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.4</version>
+      <!-- annotations are needed only to build the plugin: -->
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -106,7 +114,15 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <executions>
           <execution>
+            <id>default-descriptor</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>help-mojo</id>
+            <phase>process-classes</phase>
             <goals>
               <goal>helpmojo</goal>
             </goals>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
 import org.jacoco.core.runtime.AgentOptions;
 
@@ -39,27 +40,22 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	static final String SUREFIRE_ARG_LINE = "argLine";
 	/**
 	 * Map of plugin artifacts.
-	 * 
-	 * @parameter property="plugin.artifactMap"
-	 * @required
-	 * @readonly
 	 */
+	@Parameter(property = "plugin.artifactMap", required = true, readonly = true)
 	Map<String, Artifact> pluginArtifactMap;
 	/**
 	 * Allows to specify property which will contains settings for JaCoCo Agent.
 	 * If not specified, then "argLine" would be used for "jar" packaging and
 	 * "tycho.testArgLine" for "eclipse-test-plugin".
-	 * 
-	 * @parameter property="jacoco.propertyName"
 	 */
+	@Parameter(property = "jacoco.propertyName")
 	String propertyName;
 	/**
 	 * If set to true and the execution data file already exists, coverage data
 	 * is appended to the existing file. If set to false, an existing execution
 	 * data file will be replaced.
-	 * 
-	 * @parameter property="jacoco.append"
 	 */
+	@Parameter(property = "jacoco.append")
 	Boolean append;
 	/**
 	 * A list of class loader names, that should be excluded from execution
@@ -68,36 +64,31 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	 * special frameworks that conflict with JaCoCo code instrumentation, in
 	 * particular class loaders that do not have access to the Java runtime
 	 * classes.
-	 * 
-	 * @parameter property="jacoco.exclClassLoaders"
 	 */
+	@Parameter(property = "jacoco.exclClassLoaders")
 	String exclClassLoaders;
 	/**
 	 * Specifies whether also classes from the bootstrap classloader should be
 	 * instrumented. Use this feature with caution, it needs heavy
 	 * includes/excludes tuning.
-	 * 
-	 * @parameter property="jacoco.inclBootstrapClasses"
 	 */
+	@Parameter(property = "jacoco.inclBootstrapClasses")
 	Boolean inclBootstrapClasses;
 	/**
 	 * Specifies whether classes without source location should be instrumented.
-	 * 
-	 * @parameter property="jacoco.inclNoLocationClasses"
 	 */
+	@Parameter(property = "jacoco.inclNoLocationClasses")
 	Boolean inclNoLocationClasses;
 	/**
 	 * A session identifier that is written with the execution data. Without
 	 * this parameter a random identifier is created by the agent.
-	 * 
-	 * @parameter property="jacoco.sessionId"
 	 */
+	@Parameter(property = "jacoco.sessionId")
 	String sessionId;
 	/**
 	 * If set to true coverage data will be written on VM shutdown.
-	 * 
-	 * @parameter property="jacoco.dumpOnExit"
 	 */
+	@Parameter(property = "jacoco.dumpOnExit")
 	Boolean dumpOnExit;
 	/**
 	 * Output method to use for writing coverage data. Valid options are:
@@ -111,41 +102,36 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	 * TCP connection.</li>
 	 * <li>none: Do not produce any output.</li>
 	 * </ul>
-	 * 
-	 * @parameter property="jacoco.output"
 	 */
+	@Parameter(property = "jacoco.output")
 	String output;
 	/**
 	 * IP address or hostname to bind to when the output method is tcpserver or
 	 * connect to when the output method is tcpclient. In tcpserver mode the
 	 * value "*" causes the agent to accept connections on any local address.
-	 * 
-	 * @parameter property="jacoco.address"
 	 */
+	@Parameter(property = "jacoco.address")
 	String address;
 	/**
 	 * Port to bind to when the output method is tcpserver or connect to when
 	 * the output method is tcpclient. In tcpserver mode the port must be
 	 * available, which means that if multiple JaCoCo agents should run on the
 	 * same machine, different ports have to be specified.
-	 * 
-	 * @parameter property="jacoco.port"
 	 */
+	@Parameter(property = "jacoco.port")
 	Integer port;
 	/**
 	 * If a directory is specified for this parameter the JaCoCo agent dumps all
 	 * class files it processes to the given location. This can be useful for
 	 * debugging purposes or in case of dynamically created classes for example
 	 * when scripting engines are used.
-	 * 
-	 * @parameter property="jacoco.classDumpDir"
 	 */
+	@Parameter(property = "jacoco.classDumpDir")
 	File classDumpDir;
 	/**
 	 * If set to true the agent exposes functionality via JMX.
-	 * 
-	 * @parameter property="jacoco.jmx"
 	 */
+	@Parameter(property = "jacoco.jmx")
 	Boolean jmx;
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -25,35 +26,30 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 
 	/**
 	 * Maven project.
-	 * 
-	 * @parameter property="project"
-	 * @readonly
 	 */
+	@Parameter(property = "project", readonly = true)
 	private MavenProject project;
 
 	/**
 	 * A list of class files to include in instrumentation/analysis/reports. May
 	 * use wildcard characters (* and ?). When not specified everything will be
 	 * included.
-	 * 
-	 * @parameter
 	 */
+	@Parameter
 	private List<String> includes;
 
 	/**
 	 * A list of class files to exclude from instrumentation/analysis/reports.
 	 * May use wildcard characters (* and ?). When not specified nothing will be
 	 * excluded.
-	 * 
-	 * @parameter
 	 */
+	@Parameter
 	private List<String> excludes;
 
 	/**
 	 * Flag used to suppress execution.
-	 * 
-	 * @parameter property="jacoco.skip" default-value="false"
 	 */
+	@Parameter(property = "jacoco.skip", defaultValue = "false")
 	private boolean skip;
 
 	public final void execute() throws MojoExecutionException,

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -17,6 +17,8 @@ import java.util.Locale;
 
 import org.apache.maven.doxia.siterenderer.Renderer;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
@@ -31,71 +33,62 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 
 	/**
 	 * Encoding of the generated reports.
-	 * 
-	 * @parameter property="project.reporting.outputEncoding"
-	 *            default-value="UTF-8"
 	 */
+	@Parameter(property = "project.reporting.outputEncoding", defaultValue = "UTF-8")
 	String outputEncoding;
 
 	/**
 	 * Name of the root node HTML report pages.
-	 * 
-	 * @parameter default-value="${project.name}"
+	 *
 	 * @since 0.7.7
 	 */
+	@Parameter(defaultValue = "${project.name}")
 	String title;
 
 	/**
 	 * Footer text used in HTML report pages.
-	 * 
-	 * @parameter
+	 *
 	 * @since 0.7.7
 	 */
+	@Parameter
 	String footer;
 
 	/**
 	 * Encoding of the source files.
-	 * 
-	 * @parameter property="project.build.sourceEncoding" default-value="UTF-8"
 	 */
+	@Parameter(property = "project.build.sourceEncoding", defaultValue = "UTF-8")
 	String sourceEncoding;
 
 	/**
 	 * A list of class files to include in the report. May use wildcard
 	 * characters (* and ?). When not specified everything will be included.
-	 * 
-	 * @parameter
 	 */
+	@Parameter
 	List<String> includes;
 
 	/**
 	 * A list of class files to exclude from the report. May use wildcard
 	 * characters (* and ?). When not specified nothing will be excluded.
-	 * 
-	 * @parameter
 	 */
+	@Parameter
 	List<String> excludes;
 
 	/**
 	 * Flag used to suppress execution.
-	 * 
-	 * @parameter property="jacoco.skip" default-value="false"
 	 */
+	@Parameter(property = "jacoco.skip", defaultValue = "false")
 	boolean skip;
 
 	/**
 	 * Maven project.
-	 * 
-	 * @parameter property="project"
-	 * @readonly
 	 */
+	@Parameter(property = "project", readonly = true)
 	MavenProject project;
 
 	/**
 	 * Doxia Site Renderer.
-	 * 
-	 * @component
 	 */
+	@Component
 	Renderer siteRenderer;
 
 	public String getDescription(final Locale locale) {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AgentITMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AgentITMojo.java
@@ -14,6 +14,11 @@ package org.jacoco.maven;
 
 import java.io.File;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
 /**
  * Same as <code>prepare-agent</code>, but provides default values suitable for
  * integration-tests:
@@ -22,21 +27,15 @@ import java.io.File;
  * <li>different <code>destFile</code></li>
  * </ul>
  * 
- * @phase pre-integration-test
- * @goal prepare-agent-integration
- * @requiresProject true
- * @requiresDependencyResolution runtime
- * @threadSafe
  * @since 0.6.4
  */
+@Mojo(name = "prepare-agent-integration", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class AgentITMojo extends AbstractAgentMojo {
 
 	/**
 	 * Path to the output file for execution data.
-	 * 
-	 * @parameter property="jacoco.destFile"
-	 *            default-value="${project.build.directory}/jacoco-it.exec"
 	 */
+	@Parameter(property = "jacoco.destFile", defaultValue = "${project.build.directory}/jacoco-it.exec")
 	private File destFile;
 
 	/**

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
@@ -13,6 +13,11 @@ package org.jacoco.maven;
 
 import java.io.File;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
 /**
  * <p>
  * Prepares a property pointing to the JaCoCo runtime agent that can be passed
@@ -50,21 +55,15 @@ import java.io.File;
  * written to a file when the process terminates.
  * </p>
  * 
- * @phase initialize
- * @goal prepare-agent
- * @requiresProject true
- * @requiresDependencyResolution runtime
- * @threadSafe
  * @since 0.5.3
  */
+@Mojo(name = "prepare-agent", defaultPhase = LifecyclePhase.INITIALIZE, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class AgentMojo extends AbstractAgentMojo {
 
 	/**
 	 * Path to the output file for execution data.
-	 * 
-	 * @parameter property="jacoco.destFile"
-	 *            default-value="${project.build.directory}/jacoco.exec"
 	 */
+	@Parameter(property = "jacoco.destFile", defaultValue = "${project.build.directory}/jacoco.exec")
 	private File destFile;
 
 	/**

--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.report.IReportVisitor;
 import org.jacoco.report.check.IViolationsOutput;
@@ -28,12 +31,9 @@ import org.jacoco.report.check.Rule;
 /**
  * Checks that the code coverage metrics are being met.
  * 
- * @goal check
- * @phase verify
- * @requiresProject true
- * @threadSafe
  * @since 0.6.1
  */
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 
 	private static final String MSG_SKIPPING = "Skipping JaCoCo execution due to missing execution data file:";
@@ -117,25 +117,20 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 	 *   </rule>
 	 * </rules>}
 	 * </pre>
-	 * 
-	 * @parameter
-	 * @required
 	 */
+	@Parameter(required = true)
 	private List<RuleConfiguration> rules;
 
 	/**
 	 * Halt the build if any of the checks fail.
-	 * 
-	 * @parameter property="jacoco.haltOnFailure" default-value="true"
-	 * @required
 	 */
+	@Parameter(property = "jacoco.haltOnFailure", defaultValue = "true", required = true)
 	private boolean haltOnFailure;
 
 	/**
 	 * File with execution data.
-	 * 
-	 * @parameter default-value="${project.build.directory}/jacoco.exec"
 	 */
+	@Parameter(defaultValue = "${project.build.directory}/jacoco.exec")
 	private File dataFile;
 
 	private boolean violations;

--- a/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
@@ -18,6 +18,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.jacoco.core.tools.ExecDumpClient;
 import org.jacoco.core.tools.ExecFileLoader;
 
@@ -33,66 +36,56 @@ import org.jacoco.core.tools.ExecFileLoader;
  * resource.
  * </p>
  * 
- * @goal dump
- * @phase post-integration-test
- * @threadSafe
  * @since 0.6.4
  */
+@Mojo(name = "dump", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, threadSafe = true)
 public class DumpMojo extends AbstractJacocoMojo {
 
 	/**
 	 * Path to the output file for execution data.
-	 * 
-	 * @parameter property="jacoco.destFile"
-	 *            default-value="${project.build.directory}/jacoco.exec"
 	 */
+	@Parameter(property = "jacoco.destFile", defaultValue = "${project.build.directory}/jacoco.exec")
 	private File destFile;
 
 	/**
 	 * If set to true and the execution data file already exists, coverage data
 	 * is appended to the existing file. If set to false, an existing execution
 	 * data file will be replaced.
-	 * 
-	 * @parameter property="jacoco.append" default-value="true"
 	 */
+	@Parameter(property = "jacoco.append", defaultValue = "true")
 	private boolean append;
 
 	/**
 	 * Sets whether execution data should be downloaded from the remote host.
-	 * 
-	 * @parameter property="jacoco.dump" default-value="true"
 	 */
+	@Parameter(property = "jacoco.dump", defaultValue = "true")
 	private boolean dump;
 
 	/**
 	 * Sets whether a reset command should be sent after the execution data has
 	 * been dumped.
-	 * 
-	 * @parameter property="jacoco.reset" default-value="false"
 	 */
+	@Parameter(property = "jacoco.reset", defaultValue = "false")
 	private boolean reset;
 
 	/**
 	 * IP address or hostname to connect to.
-	 * 
-	 * @parameter property="jacoco.address"
 	 */
+	@Parameter(property = "jacoco.address")
 	private String address;
 
 	/**
 	 * Port number to connect to. If multiple JaCoCo agents should run on the
 	 * same machine, different ports have to be specified for the agents.
-	 * 
-	 * @parameter property="jacoco.port" default-value="6300"
 	 */
+	@Parameter(property = "jacoco.port", defaultValue = "6300")
 	private int port;
 
 	/**
 	 * Number of retries which the goal will attempt to establish a connection.
 	 * This can be used to wait until the target JVM is successfully launched.
-	 * 
-	 * @parameter property="jacoco.retryCount" default-value="10"
 	 */
+	@Parameter(property = "jacoco.retryCount", defaultValue = "10")
 	private int retryCount;
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.jacoco.core.instr.Instrumenter;
@@ -37,12 +39,9 @@ import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
  * offline instrumentation before using this mode.
  * </p>
  * 
- * @phase process-classes
- * @goal instrument
- * @requiresProject true
- * @threadSafe
  * @since 0.6.2
  */
+@Mojo(name = "instrument", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
 public class InstrumentMojo extends AbstractJacocoMojo {
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
@@ -17,6 +17,9 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.shared.model.fileset.FileSet;
 import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.jacoco.core.tools.ExecFileLoader;
@@ -24,22 +27,17 @@ import org.jacoco.core.tools.ExecFileLoader;
 /**
  * Mojo for merging a set of execution data files (*.exec) into a single file
  * 
- * @phase generate-resources
- * @goal merge
- * @requiresProject true
- * @threadSafe
  * @since 0.6.4
  */
+@Mojo(name = "merge", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public class MergeMojo extends AbstractJacocoMojo {
 
 	private static final String MSG_SKIPPING = "Skipping JaCoCo merge execution due to missing execution data files";
 
 	/**
 	 * Path to the output file for execution data.
-	 * 
-	 * @parameter property="jacoco.destFile"
-	 *            default-value="${project.build.directory}/jacoco.exec"
 	 */
+	@Parameter(property = "jacoco.destFile", defaultValue = "${project.build.directory}/jacoco.exec")
 	private File destFile;
 
 	/**
@@ -60,10 +58,8 @@ public class MergeMojo extends AbstractJacocoMojo {
 	 * &lt;/fileSets&gt;
 	 * </code>
 	 * </pre>
-	 * 
-	 * @parameter property="jacoco.fileSets"
-	 * @required
 	 */
+	@Parameter(property = "jacoco.fileSets", required = true)
 	private List<FileSet> fileSets;
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -20,6 +20,8 @@ import java.util.Locale;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.jacoco.report.IReportGroupVisitor;
 
@@ -44,29 +46,25 @@ import org.jacoco.report.IReportGroupVisitor;
  * <li><code>test</code>: Only execution data is considered for the report.</li>
  * </ul>
  * 
- * @goal report-aggregate
- * @requiresProject true
- * @threadSafe
  * @since 0.7.7
  */
+@Mojo(name = "report-aggregate", threadSafe = true)
 public class ReportAggregateMojo extends AbstractReportMojo {
 
 	/**
 	 * A list of execution data files to include in the report from each
 	 * project. May use wildcard characters (* and ?). When not specified all
 	 * *.exec files from the target folder will be included.
-	 * 
-	 * @parameter default-value="target/*.exec"
 	 */
+	@Parameter(defaultValue = "target/*.exec")
 	List<String> dataFileIncludes;
 
 	/**
 	 * A list of execution data files to exclude from the report. May use
 	 * wildcard characters (* and ?). When not specified nothing will be
 	 * excluded.
-	 * 
-	 * @parameter
 	 */
+	@Parameter
 	List<String> dataFileExcludes;
 
 	/**
@@ -75,18 +73,14 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	 * build lifecycle. If the goal is run indirectly as part of a site
 	 * generation, the output directory configured in the Maven Site Plugin is
 	 * used instead.
-	 * 
-	 * @parameter 
-	 *            default-value="${project.reporting.outputDirectory}/jacoco-aggregate"
 	 */
+	@Parameter(defaultValue = "${project.reporting.outputDirectory}/jacoco-aggregate")
 	private File outputDirectory;
 
 	/**
 	 * The projects in the reactor.
-	 * 
-	 * @parameter property="reactorProjects"
-	 * @readonly
 	 */
+	@Parameter(property = "reactorProjects", readonly = true)
 	private List<MavenProject> reactorProjects;
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportITMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportITMojo.java
@@ -16,6 +16,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.jacoco.report.IReportGroupVisitor;
 
 /**
@@ -26,12 +29,9 @@ import org.jacoco.report.IReportGroupVisitor;
  * <li>different <code>dataFile</code></li>
  * </ul>
  * 
- * @phase verify
- * @goal report-integration
- * @requiresProject true
- * @threadSafe
  * @since 0.6.4
  */
+@Mojo(name = "report-integration", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class ReportITMojo extends AbstractReportMojo {
 
 	/**
@@ -40,16 +40,14 @@ public class ReportITMojo extends AbstractReportMojo {
 	 * build lifecycle. If the goal is run indirectly as part of a site
 	 * generation, the output directory configured in the Maven Site Plugin is
 	 * used instead.
-	 * 
-	 * @parameter default-value="${project.reporting.outputDirectory}/jacoco-it"
 	 */
+	@Parameter(defaultValue = "${project.reporting.outputDirectory}/jacoco-it")
 	private File outputDirectory;
 
 	/**
 	 * File with execution data.
-	 * 
-	 * @parameter default-value="${project.build.directory}/jacoco-it.exec"
 	 */
+	@Parameter(defaultValue = "${project.build.directory}/jacoco-it.exec")
 	private File dataFile;
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
@@ -15,18 +15,18 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.jacoco.report.IReportGroupVisitor;
 
 /**
  * Creates a code coverage report for tests of a single project in multiple
  * formats (HTML, XML, and CSV).
  * 
- * @phase verify
- * @goal report
- * @requiresProject true
- * @threadSafe
  * @since 0.5.3
  */
+@Mojo(name = "report", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public class ReportMojo extends AbstractReportMojo {
 
 	/**
@@ -35,16 +35,14 @@ public class ReportMojo extends AbstractReportMojo {
 	 * build lifecycle. If the goal is run indirectly as part of a site
 	 * generation, the output directory configured in the Maven Site Plugin is
 	 * used instead.
-	 * 
-	 * @parameter default-value="${project.reporting.outputDirectory}/jacoco"
 	 */
+	@Parameter(defaultValue = "${project.reporting.outputDirectory}/jacoco")
 	private File outputDirectory;
 
 	/**
 	 * File with execution data.
-	 * 
-	 * @parameter default-value="${project.build.directory}/jacoco.exec"
 	 */
+	@Parameter(defaultValue = "${project.build.directory}/jacoco.exec")
 	private File dataFile;
 
 	@Override

--- a/jacoco-maven-plugin/src/org/jacoco/maven/RestoreMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/RestoreMojo.java
@@ -16,17 +16,16 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
  * Restores original classes as they were before offline instrumentation.
  * 
- * @phase prepare-package
- * @goal restore-instrumented-classes
- * @requiresProject true
- * @threadSafe
  * @since 0.6.2
  */
+@Mojo(name = "restore-instrumented-classes", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, threadSafe = true)
 public class RestoreMojo extends AbstractJacocoMojo {
 
 	@Override

--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -108,7 +108,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>3068000</maxsize>
+                  <maxsize>3500000</maxsize>
                   <minsize>2500000</minsize>
                   <files>
                     <file>${project.build.directory}/jacoco-${qualified.bundle.version}.zip</file>


### PR DESCRIPTION
Currently with JDK 9 EA creation of javadoc for jacoco-maven-plugin fails with messages like `unknown tag: requiresProject`.

This problem should vanish, if we'll use annotations - http://maven.apache.org/plugin-tools/maven-plugin-plugin/examples/using-annotations.html And anyway this is a good modernization of code.