### PR TITLE
Build with JDK 8 should not require additional arguments

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ install:
 
 build_script:
   # Maven 3.3.9 requires Java >= 7, but generation of Javadocs requires Java <= 6 (https://github.com/jacoco/jacoco/issues/110)
-  - mvn -V -B -e verify -Pno-java8-validation -Djdk.version=1.6 --toolchains=.travis\appveyor-toolchains.xml
+  - mvn -V -B -e verify -Djdk.version=1.6 --toolchains=.travis\appveyor-toolchains.xml
 
 artifacts:
   - path: jacoco\target\*.zip

--- a/org.jacoco.core.test/.classpath
+++ b/org.jacoco.core.test/.classpath
@@ -10,7 +10,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="org/jacoco/core/test/validation/java8/*.java" including="**/*.java" kind="src" output="target/classes" path="src">
+	<classpathentry kind="src" output="target/classes" path="src">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>

--- a/org.jacoco.core.test/pom.xml
+++ b/org.jacoco.core.test/pom.xml
@@ -40,24 +40,67 @@
   
   <profiles>
     <profile>
-      <id>no-java8-validation</id>
+      <id>java8-validation</id>
       <activation>
-        <jdk>(,1.8)</jdk>
+        <property>
+          <name>bytecode.version</name>
+          <value>1.8</value>
+        </property>
       </activation>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>org/jacoco/core/test/validation/java8/*.java</exclude>
-              </excludes>
-            </configuration>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src-java8</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java9-validation</id>
+      <activation>
+        <property>
+          <name>bytecode.version</name>
+          <value>1.9</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src-java8</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
-  
+
 </project>

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/InterfaceDefaultMethodsTest.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/InterfaceDefaultMethodsTest.java
@@ -9,34 +9,31 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.test.validation.java8;
+package org.jacoco.core.test.validation;
 
 import org.jacoco.core.analysis.ICounter;
-import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.targets.InterfaceDefaultMethodsTarget;
 import org.junit.Test;
 
 /**
- * Tests for different lambda expressions.
+ * Tests of static initializer in interfaces.
  */
-public class LambdaExpressionsTest extends ValidationTestBase {
+public class InterfaceDefaultMethodsTest extends ValidationTestBase {
 
-	public LambdaExpressionsTest() {
-		super(LambdaExpressionsTarget.class);
+	public InterfaceDefaultMethodsTest() {
+		super("src-java8", InterfaceDefaultMethodsTarget.class);
 	}
 
 	@Override
 	protected void run(final Class<?> targetClass) throws Exception {
-		final Object instance = targetClass.newInstance();
-		((Runnable) instance).run();
+		loader.add(InterfaceDefaultMethodsTarget.Impl.class).newInstance();
 	}
 
 	@Test
 	public void testCoverageResult() {
-
-		// Coverage of lambda bodies
-		assertLine("executedlambdabody", ICounter.FULLY_COVERED);
-		assertLine("notexecutedlambdabody", ICounter.NOT_COVERED);
-
+		assertLine("clinit", ICounter.FULLY_COVERED);
+		assertLine("m1", ICounter.FULLY_COVERED);
+		assertLine("m2", ICounter.NOT_COVERED);
 	}
 
 }

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/LambdaExpressionsTest.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/LambdaExpressionsTest.java
@@ -9,31 +9,33 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.test.validation.java8;
+package org.jacoco.core.test.validation;
 
 import org.jacoco.core.analysis.ICounter;
-import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.targets.LambdaExpressionsTarget;
 import org.junit.Test;
 
 /**
- * Tests a constant with a lambda value in an interface.
+ * Tests for different lambda expressions.
  */
-public class LambdaInInterfaceTest extends ValidationTestBase {
+public class LambdaExpressionsTest extends ValidationTestBase {
 
-	public LambdaInInterfaceTest() {
-		super(LambdaInInterfaceTarget.class);
+	public LambdaExpressionsTest() {
+		super("src-java8", LambdaExpressionsTarget.class);
 	}
 
 	@Override
 	protected void run(final Class<?> targetClass) throws Exception {
-		((Runnable) targetClass.getField("RUN").get(null)).run();
+		final Object instance = targetClass.newInstance();
+		((Runnable) instance).run();
 	}
 
 	@Test
 	public void testCoverageResult() {
 
-		// Coverage of lambda body
-		assertLine("lambdabody", ICounter.FULLY_COVERED);
+		// Coverage of lambda bodies
+		assertLine("executedlambdabody", ICounter.FULLY_COVERED);
+		assertLine("notexecutedlambdabody", ICounter.NOT_COVERED);
 
 	}
 

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/LambdaInInterfaceTest.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/LambdaInInterfaceTest.java
@@ -9,31 +9,32 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.test.validation.java8;
+package org.jacoco.core.test.validation;
 
 import org.jacoco.core.analysis.ICounter;
-import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.targets.LambdaInInterfaceTarget;
 import org.junit.Test;
 
 /**
- * Tests of static initializer in interfaces.
+ * Tests a constant with a lambda value in an interface.
  */
-public class InterfaceDefaultMethodsTest extends ValidationTestBase {
+public class LambdaInInterfaceTest extends ValidationTestBase {
 
-	public InterfaceDefaultMethodsTest() {
-		super(InterfaceDefaultMethodsTarget.class);
+	public LambdaInInterfaceTest() {
+		super("src-java8", LambdaInInterfaceTarget.class);
 	}
 
 	@Override
 	protected void run(final Class<?> targetClass) throws Exception {
-		loader.add(InterfaceDefaultMethodsTarget.Impl.class).newInstance();
+		((Runnable) targetClass.getField("RUN").get(null)).run();
 	}
 
 	@Test
 	public void testCoverageResult() {
-		assertLine("clinit", ICounter.FULLY_COVERED);
-		assertLine("m1", ICounter.FULLY_COVERED);
-		assertLine("m2", ICounter.NOT_COVERED);
+
+		// Coverage of lambda body
+		assertLine("lambdabody", ICounter.FULLY_COVERED);
+
 	}
 
 }

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/InterfaceDefaultMethodsTarget.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/InterfaceDefaultMethodsTarget.java
@@ -9,7 +9,7 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.test.validation.java8;
+package org.jacoco.core.test.validation.targets;
 
 import static org.jacoco.core.test.validation.targets.Stubs.i1;
 

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/LambdaExpressionsTarget.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/LambdaExpressionsTarget.java
@@ -9,7 +9,7 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.test.validation.java8;
+package org.jacoco.core.test.validation.targets;
 
 import static org.jacoco.core.test.validation.targets.Stubs.exec;
 import static org.jacoco.core.test.validation.targets.Stubs.noexec;

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/LambdaInInterfaceTarget.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/LambdaInInterfaceTarget.java
@@ -9,7 +9,7 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-package org.jacoco.core.test.validation.java8;
+package org.jacoco.core.test.validation.targets;
 
 import static org.jacoco.core.test.validation.targets.Stubs.nop;
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/Source.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/Source.java
@@ -12,6 +12,7 @@
 package org.jacoco.core.test.validation;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
@@ -31,16 +32,18 @@ import java.util.regex.Pattern;
 public class Source {
 
 	/**
-	 * Reads the source for the given type from the <code>./src/</code> folder
-	 * relative to the working directory.
+	 * Reads the source for the given type from the given source folder relative
+	 * to the working directory.
 	 * 
+	 * @param srcFolder
+	 *            source folder
 	 * @param type
 	 *            type to load the source file for
-	 * @throws IOException
-	 * @throws
 	 */
-	public static Source getSourceFor(final Class<?> type) throws IOException {
-		String file = "src/" + type.getName().replace('.', '/') + ".java";
+	public static Source getSourceFor(final String srcFolder,
+			final Class<?> type) throws IOException {
+		File folder = new File(srcFolder);
+		File file = new File(folder, type.getName().replace('.', '/') + ".java");
 		return new Source(new FileReader(file));
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/SourceTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/SourceTest.java
@@ -78,7 +78,7 @@ public class SourceTest {
 
 	@Test
 	public void testGetSourceFor() throws IOException {
-		final Source s = Source.getSourceFor(SourceTest.class);
+		final Source s = Source.getSourceFor("src", SourceTest.class);
 		// Here we are. $line-testGetSourceFor$
 		final String l = s.getLine(s.getLineNumber("testGetSourceFor"));
 		assertTrue(l, l.contains("Here we are."));

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -47,6 +47,8 @@ public abstract class ValidationTestBase {
 		STATUS_NAME[ICounter.PARTLY_COVERED] = "PARTLY_COVERED";
 	}
 
+	protected final String srcFolder;
+
 	protected final Class<?> target;
 
 	protected IClassCoverage classCoverage;
@@ -57,8 +59,13 @@ public abstract class ValidationTestBase {
 
 	protected TargetLoader loader;
 
-	protected ValidationTestBase(final Class<?> target) {
+	protected ValidationTestBase(final String srcFolder, final Class<?> target) {
+		this.srcFolder = srcFolder;
 		this.target = target;
+	}
+
+	protected ValidationTestBase(final Class<?> target) {
+		this("src", target);
 	}
 
 	@Before
@@ -68,7 +75,7 @@ public abstract class ValidationTestBase {
 				TargetLoader.getClassData(target));
 		final ExecutionDataStore store = execute(reader);
 		analyze(reader, store);
-		source = Source.getSourceFor(target);
+		source = Source.getSourceFor(srcFolder, target);
 	}
 
 	private ExecutionDataStore execute(final ClassReader reader)


### PR DESCRIPTION
Currently "-Dbytecode.version=1.8" should be specified to run build using JDK 8, whereas would be better to use just "mvn clean install".