### PR TITLE
Update documentation of prepare-agent mojo

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
@@ -32,8 +32,27 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * 
  * <p>
  * If your project already defines VM arguments for test execution, be sure that
- * the VM arguments are defined as a property, rather than as part of the plugin
- * configuration. For example in case of maven-surefire-plugin:
+ * they will include property defined by JaCoCo.
+ * </p>
+ *
+ * <p>
+ * One of the ways to do this in case of maven-surefore-plugin - is to use
+ * syntax for <a href="http://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation">late property evaluation</a>:
+ * </p>
+ * 
+ * <pre>
+ *   &lt;plugin&gt;
+ *     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
+ *     &lt;artifactId&gt;maven-surefire-plugin&lt;/artifactId&gt;
+ *     &lt;configuration&gt;
+ *       &lt;argLine&gt;@{argLine} -your -extra -arguments&lt;/argLine&gt;
+ *     &lt;/configuration&gt;
+ *   &lt;/plugin&gt;
+ * </pre>
+ * 
+ * <p>
+ * Another way is to define "argLine" as a Maven property rather than
+ * as part of the configuration of maven-surefire-plugin:
  * </p>
  * 
  * <pre>
@@ -45,7 +64,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  *     &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
  *     &lt;artifactId&gt;maven-surefire-plugin&lt;/artifactId&gt;
  *     &lt;configuration&gt;
- *       &lt;!-- Do not define argLine here! --&gt;
+ *       &lt;!-- no argLine here --&gt;
  *     &lt;/configuration&gt;
  *   &lt;/plugin&gt;
  * </pre>


### PR DESCRIPTION
From https://groups.google.com/d/msg/jacoco/ugbiYAbCDA0/1hhdZTPfs7wJ

> You might want to update the documentation at http://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html
```
<plugin>
  <groupId>org.apache.maven.plugins</groupId>
  <artifactId>maven-surefire-plugin</artifactId>
  <configuration>
    <!-- Do not define argLine here! -->
  </configuration>
</plugin>
```
Indeed, it seems to properly work while defining argLine within the configuration tag using the @{...} syntax: http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine