### PR TITLE
Property dataFileIncludes in report-aggregate is not changeable by pom due to known maven bug

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-customization</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child1</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <jacoco.destFile>target/child1.coverage</jacoco.destFile>
+  </properties>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/main/java/package1/Example1.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/main/java/package1/Example1.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1 {
+
+  public void a() {
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/test/java/package1/Example1Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/test/java/package1/Example1Test.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1Test {
+
+  @Test
+  public void test() {
+    new Example1().a();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-customization</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child2</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <jacoco.destFile>target/child2.coverage</jacoco.destFile>
+  </properties>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/main/java/package2/Example2.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+public class Example2 {
+
+  public void a() {
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/test/java/package2/Example2Test.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+import org.junit.Test;
+
+public class Example2Test {
+
+  @Test
+  public void test() {
+    new Example2().a();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-aggregate-customization</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child1</module>
+    <module>child2</module>
+    <module>report</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/report/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/report/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-customization</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>report</artifactId>
+  <name>Aggregate Report</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>child1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>child2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <configuration>
+              <dataFileIncludes>
+                <dataFileInclude>target/*.coverage</dataFileInclude>
+              </dataFileIncludes>
+              <dataFileExcludes>
+                <dataFileExclude>target/child2.coverage</dataFileExclude>
+              </dataFileExcludes>
+              <outputDirectory>target/jacoco-aggregate-customization</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/verify.bsh
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+import org.codehaus.plexus.util.*;
+import java.util.regex.*;
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+// Test customization of dataFileIncludes and dataFileExcludes
+
+if ( !Pattern.compile( "Loading execution data file \\S*child1.target.child1.coverage").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child1 was not loaded." );
+}
+
+if ( Pattern.compile( "Loading execution data file \\S*child2").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child2 was loaded." );
+}
+
+// Test customization of outputDirectory
+
+File reportChild1 = new File( basedir, "report/target/jacoco-aggregate-customization/child1/index.html" );
+if ( !reportChild1.isFile() ) {
+    throw new RuntimeException( "Report for child1 was not created." );
+}
+
+File reportChild2 = new File( basedir, "report/target/jacoco-aggregate-customization/child2/index.html" );
+if ( !reportChild2.isFile() ) {
+    throw new RuntimeException( "Report for child2 was not created." );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -57,7 +57,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	 * project. May use wildcard characters (* and ?). When not specified all
 	 * *.exec files from the target folder will be included.
 	 */
-	@Parameter(defaultValue = "target/*.exec")
+	@Parameter
 	List<String> dataFileIncludes;
 
 	/**
@@ -96,6 +96,11 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 
 	@Override
 	void loadExecutionData(final ReportSupport support) throws IOException {
+		// https://issues.apache.org/jira/browse/MNG-5440
+		if (dataFileIncludes == null) {
+			dataFileIncludes = Arrays.asList("target/*.exec");
+		}
+
 		final FileFilter filter = new FileFilter(dataFileIncludes,
 				dataFileExcludes);
 		loadExecutionData(support, filter, getProject().getBasedir());


### PR DESCRIPTION
JaCoCo version: 0.7.7-SNAPSHOT
Operating system: Windows
Tool integration: Maven

The property dataFileIncludes in the report-aggregate can't be set by the pom file due to a known bug in maven:
[see here](https://issues.apache.org/jira/browse/MNG-5440?jql=project%20%3D%20MNG%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22%40Parameter%22%20ORDER%20BY%20priority%20DESC)

To fix this by a workaround, the default-value has to been removed from the parameter and access to it should be done by a getter which will set the default if the value is always null
