### PR TITLE
maven goal report-aggregate doesn't use it's own measurement 

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-aggregate/report/src/test/java/packagereport/ReportTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/report/src/test/java/packagereport/ReportTest.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package packagereport;
+
+import org.junit.Test;
+
+public class ReportTest {
+
+  @Test
+  public void test() {
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/verify.bsh
@@ -10,19 +10,24 @@
  *
  *******************************************************************************/
 import org.codehaus.plexus.util.*;
+import java.util.regex.*;
 
 String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
 
-if ( buildLog.indexOf( "/child1/target/jacoco.exec".replace('/', File.separatorChar) ) < 0 ) {
+if ( !Pattern.compile( "Loading execution data file \\S*child1.target.jacoco.exec").matcher( buildLog ).find() ) {
     throw new RuntimeException( "Execution data from child1 was not loaded." );
 }
 
-if ( buildLog.indexOf( "/child1-test/target/jacoco.exec".replace('/', File.separatorChar) ) < 0 ) {
+if ( !Pattern.compile( "Loading execution data file \\S*child1-test.target.jacoco.exec").matcher( buildLog ).find() ) {
     throw new RuntimeException( "Execution data from child1-test was not loaded." );
 }
 
-if ( buildLog.indexOf( "/child2/target/jacoco.exec".replace('/', File.separatorChar) ) < 0 ) {
+if ( !Pattern.compile( "Loading execution data file \\S*child2.target.jacoco.exec").matcher( buildLog ).find() ) {
     throw new RuntimeException( "Execution data from child2 was not loaded." );
+}
+
+if ( !Pattern.compile( "Loading execution data file \\S*report.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from report was not loaded." );
 }
 
 File reportChild1 = new File( basedir, "report/target/site/jacoco-aggregate/child1/index.html" );

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -30,14 +30,15 @@ import org.jacoco.report.IReportGroupVisitor;
  * Creates a structured code coverage report (HTML, XML, and CSV) from multiple
  * projects within reactor. The report is created from all modules this project
  * depends on. From those projects class and source files as well as JaCoCo
- * execution data files will be collected. This also allows to create coverage
+ * execution data files will be collected. In addition execution data is
+ * collected from the project itself. This also allows to create coverage
  * reports when tests are in separate projects than the code under test, for
  * example in case of integration tests.
  * </p>
  * 
  * <p>
  * Using the dependency scope allows to distinguish projects which contribute
- * execution data but should not be part of the report itself:
+ * execution data but should not become part of the report:
  * </p>
  * 
  * <ul>
@@ -97,11 +98,17 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	void loadExecutionData(final ReportSupport support) throws IOException {
 		final FileFilter filter = new FileFilter(dataFileIncludes,
 				dataFileExcludes);
+		loadExecutionData(support, filter, getProject().getBasedir());
 		for (final MavenProject dependency : findDependencies(
 				Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST)) {
-			for (final File execFile : filter.getFiles(dependency.getBasedir())) {
-				support.loadExecutionData(execFile);
-			}
+			loadExecutionData(support, filter, dependency.getBasedir());
+		}
+	}
+
+	private void loadExecutionData(final ReportSupport support,
+			final FileFilter filter, final File basedir) throws IOException {
+		for (final File execFile : filter.getFiles(basedir)) {
+			support.loadExecutionData(execFile);
 		}
 	}
 


### PR DESCRIPTION
JaCoCo version: 0.7.7-SNAPSHOT
Operating system: Windows
Tool integration: Maven

The maven goal report-aggregate doesn't read the exec file in the executing project.
When an integration-test module IT has collected the coverage data and stored the result to IT/target/jacoco.exec, the report generation by report-aggregate reads all the jacoco.exec files of all dependant projects in the reactor but not the file in the IT module itself.

Since a module isn't dependant by itself in maven, in the method findDependencies there should be the statement
`result.add(this.project);`

Another solution could be, to redesign this goal to walk not thru the depends but thru the submodules like aggregated reports of other tools, so the report will be on the top level of the generated site.
