### PR TITLE
Example in documentation uses possible null parent

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
@@ -50,7 +50,7 @@ public class MergeMojo extends AbstractJacocoMojo {
 	 * <code>
 	 * &lt;fileSets&gt;
 	 *   &lt;fileSet implementation="org.apache.maven.shared.model.fileset.FileSet"&gt;
-	 *     &lt;directory&gt;${project.parent.build.directory}&lt;/directory&gt;
+	 *     &lt;directory&gt;${project.build.directory}&lt;/directory&gt;
 	 *     &lt;includes&gt;
 	 *       &lt;include&gt;*.exec&lt;/include&gt;
 	 *     &lt;/includes&gt;


### PR DESCRIPTION
### Steps to reproduce

JaCoCo version: 7.7.-SNAPSHOT

http://eclemma.org/jacoco/trunk/doc/merge-mojo.html
gives 
```
<fileSets>
  <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
    <directory>${project.parent.build.directory}</directory>
    <includes>
      <include>*.exec</include>
    </includes>
  </fileSet>
</fileSets>
```
A simple cut and paste into a project without a parent results in a null pointer, the example would be better as: 
```
<fileSets>
  <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
    <directory>${project.build.directory}</directory>
    <includes>
      <include>*.exec</include>
    </includes>
  </fileSet>
</fileSets>
```

