### PR TITLE
Get rid of DNS request in DumpTaskTest

### DIFF
--- a/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskTest.xml
@@ -35,7 +35,12 @@
 	
 	<target name="testUnknownHost">
 		<au:expectfailure expectedMessage="Unable to dump coverage data">
-			<jacoco:dump dump="false" address="nosuchhost"/>
+			<!--
+			Note that malformed literal IPv6 address is used
+			to cause UnknownHostException from java.net.InetAddress.getByName
+			without DNS request.
+			-->
+			<jacoco:dump dump="false" address="[nosuchhost]"/>
 		</au:expectfailure>
 		<au:assertFileDoesntExist file="${exec.file}"/>
 	</target>


### PR DESCRIPTION
This PR covers case described in https://github.com/jacoco/jacoco/pull/300#issuecomment-221838166