### PR TITLE
Frames are re-calculated for large methods

### DIFF
--- a/org.jacoco.ant/META-INF/MANIFEST.MF
+++ b/org.jacoco.ant/META-INF/MANIFEST.MF
@@ -17,4 +17,4 @@ Import-Package: org.jacoco.agent;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.report.csv;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.report.html;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.report.xml;bundle-version="[0.7.9,0.7.10)",
- org.objectweb.asm;version="[5.1.0,5.2.0)"
+ org.objectweb.asm;version="[5.2.0,5.3.0)"

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -141,7 +141,7 @@
     <argLine>${jvm.args}</argLine>
 
     <!-- Dependencies versions -->
-    <asm.version>5.1</asm.version>
+    <asm.version>5.2</asm.version>
     <ant.version>1.7.1</ant.version>
     <junit.version>4.8.2</junit.version>
 

--- a/org.jacoco.core.test/META-INF/MANIFEST.MF
+++ b/org.jacoco.core.test/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Fragment-Host: org.jacoco.core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: org.junit;version="[4.8.0,5.0.0)",
  org.junit.rules;version="[4.8.0,5.0.0)",
- org.objectweb.asm.util;version="[5.1.0,5.2.0)"
+ org.objectweb.asm.util;version="[5.2.0,5.3.0)"

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.IRuntime;
@@ -70,7 +70,7 @@ public class ResizeInstructionsTest {
 		mv.visitEnd();
 		cw.visitEnd();
 		final byte[] original = cw.toByteArray();
-		assertEquals(true, computedCommonSuperClass);
+		assertTrue(computedCommonSuperClass);
 
 		load(className, original);
 		instrumenter.instrument(original, className);

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -113,8 +113,8 @@ public class ResizeInstructionsTest {
 	}
 
 	/**
-	 * Adds code that triggers invocation of
-	 * {@link org.objectweb.asm.MethodWriter#resizeInstructions()} during
+	 * Adds code that triggers usage of
+	 * {@link org.objectweb.asm.MethodWriter#INSERTED_FRAMES} during
 	 * instrumentation.
 	 */
 	private static void addCauseOfResizeInstructions(final MethodVisitor mv) {

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -17,6 +17,7 @@ import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.RuntimeData;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.jacoco.core.test.TargetLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,23 +72,11 @@ public class ResizeInstructionsTest {
 		cw.visitEnd();
 		final byte[] original = cw.toByteArray();
 		assertTrue(computedCommonSuperClass);
+		new TargetLoader().add(className, original);
 
-		load(className, original);
-		instrumenter.instrument(original, className);
-	}
-
-	private static void load(final String className, final byte[] bytes)
-			throws ClassNotFoundException {
-		new ClassLoader() {
-			@Override
-			protected Class<?> loadClass(final String name,
-					final boolean resolve) throws ClassNotFoundException {
-				if (name.equals(className)) {
-					return defineClass(name, bytes, 0, bytes.length);
-				}
-				return super.loadClass(name, resolve);
-			}
-		}.loadClass(className);
+		final byte[] instrumented = instrumenter.instrument(original,
+				className);
+		new TargetLoader().add(className, instrumented);
 	}
 
 	/**

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.RuntimeData;
+import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Test of ASM bug <a href=
+ * "http://forge.ow2.org/tracker/?func=detail&aid=317630&group_id=23&atid=100023">#317630</a>
+ * that caused {@code java.lang.ClassNotFoundException}.
+ */
+public class ResizeInstructionsTest {
+
+	private final IRuntime runtime = new SystemPropertiesRuntime();
+	private final Instrumenter instrumenter = new Instrumenter(runtime);
+
+	private boolean computedCommonSuperClass = false;
+
+	@Before
+	public void setup() throws Exception {
+		runtime.startup(new RuntimeData());
+	}
+
+	@After
+	public void teardown() {
+		runtime.shutdown();
+	}
+
+	@Test
+	public void test() throws Exception {
+		final String className = "Example";
+
+		final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES) {
+			@Override
+			protected String getCommonSuperClass(final String type1,
+					final String type2) {
+				computedCommonSuperClass = true;
+				return "java/lang/Object";
+			}
+		};
+		cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC, className, null,
+				"java/lang/Object", null);
+		final MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "m", "()V",
+				null, null);
+		mv.visitCode();
+		addCauseOfResizeInstructions(mv);
+		addCauseOfGetCommonSuperClass(mv);
+		mv.visitMaxs(1, 1);
+		mv.visitEnd();
+		cw.visitEnd();
+		final byte[] original = cw.toByteArray();
+		assertEquals(true, computedCommonSuperClass);
+
+		load(className, original);
+		instrumenter.instrument(original, className);
+	}
+
+	private static void load(final String className, final byte[] bytes)
+			throws ClassNotFoundException {
+		new ClassLoader() {
+			@Override
+			protected Class<?> loadClass(final String name,
+					final boolean resolve) throws ClassNotFoundException {
+				if (name.equals(className)) {
+					return defineClass(name, bytes, 0, bytes.length);
+				}
+				return super.loadClass(name, resolve);
+			}
+		}.loadClass(className);
+	}
+
+	/**
+	 * Adds code that requires
+	 * {@link ClassWriter#getCommonSuperClass(String, String)}.
+	 * 
+	 * <pre>
+	 * Object o = this;
+	 * while (true) {
+	 * 	o = (Integer) null;
+	 * }
+	 * </pre>
+	 */
+	private static void addCauseOfGetCommonSuperClass(final MethodVisitor mv) {
+		mv.visitVarInsn(Opcodes.ALOAD, 0);
+		mv.visitVarInsn(Opcodes.ASTORE, 1);
+		Label label = new Label();
+		mv.visitLabel(label);
+		mv.visitInsn(Opcodes.ACONST_NULL);
+		mv.visitTypeInsn(Opcodes.CHECKCAST, "java/lang/Integer");
+		mv.visitVarInsn(Opcodes.ASTORE, 1);
+		mv.visitJumpInsn(Opcodes.GOTO, label);
+	}
+
+	/**
+	 * Adds code that triggers invocation of
+	 * {@link org.objectweb.asm.MethodWriter#resizeInstructions()} during
+	 * instrumentation.
+	 */
+	private static void addCauseOfResizeInstructions(final MethodVisitor mv) {
+		mv.visitInsn(Opcodes.ICONST_0);
+		mv.visitInsn(Opcodes.ICONST_1);
+		final Label target = new Label();
+		mv.visitJumpInsn(Opcodes.IFLE, target);
+		for (int i = 0; i < Short.MAX_VALUE; i++) {
+			mv.visitInsn(Opcodes.NOP);
+		}
+		mv.visitLabel(target);
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -56,7 +56,8 @@ public class ResizeInstructionsTest {
 			@Override
 			protected String getCommonSuperClass(final String type1,
 					final String type2) {
-				computedCommonSuperClass = true;
+				computedCommonSuperClass |= className.equals(type1)
+						|| className.equals(type2);
 				return "java/lang/Object";
 			}
 		};

--- a/org.jacoco.core/META-INF/MANIFEST.MF
+++ b/org.jacoco.core/META-INF/MANIFEST.MF
@@ -12,6 +12,6 @@ Export-Package: org.jacoco.core;version="0.7.9",
  org.jacoco.core.internal.analysis;version="0.7.9";x-internal=true,
  org.jacoco.core.runtime;version="0.7.9",
  org.jacoco.core.tools;version="0.7.9"
-Import-Package: org.objectweb.asm;version="[5.1.0,5.2.0)",
- org.objectweb.asm.tree;version="[5.1.0,5.2.0)",
- org.objectweb.asm.commons;version="[5.1.0,5.2.0)"
+Import-Package: org.objectweb.asm;version="[5.2.0,5.3.0)",
+ org.objectweb.asm.tree;version="[5.2.0,5.3.0)",
+ org.objectweb.asm.commons;version="[5.2.0,5.3.0)"

--- a/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
@@ -76,7 +76,13 @@ public class Instrumenter {
 	 * 
 	 */
 	public byte[] instrument(final ClassReader reader) {
-		final ClassWriter writer = new ClassWriter(reader, 0);
+		final ClassWriter writer = new ClassWriter(reader, 0) {
+			@Override
+			protected String getCommonSuperClass(final String type1,
+					final String type2) {
+				throw new IllegalStateException();
+			}
+		};
 		final IProbeArrayStrategy strategy = ProbeArrayStrategyFactory
 				.createFor(reader, accessorGenerator);
 		final ClassVisitor visitor = new ClassProbesAdapter(

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -22,6 +22,9 @@
 
 <h3>Fixed Bugs</h3>
 <ul>
+  <li>Do not recompute frames in case of large methods, otherwise
+      <code>java.lang.ClassNotFoundException</code> might be thrown
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/177">#177</a>).</li>
   <li><code>ExecutionDataWriter.FORMAT_VERSION</code> is not a compile-time constant
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/474">#474</a>).</li>
 </ul>
@@ -30,6 +33,11 @@
 <ul>
   <li><code>JaCoCo.ASM_API_VERSION</code> removed
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/474">#474</a>).</li>
+</ul>
+
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>JaCoCo now depends on ASM 5.2.</li>
 </ul>
 
 <h2>Release 0.7.8 (2016/12/09)</h2>

--- a/org.jacoco.examples/META-INF/MANIFEST.MF
+++ b/org.jacoco.examples/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Import-Package: org.jacoco.core.analysis;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.core.tools;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.report;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.report.html;bundle-version="[0.7.9,0.7.10)",
- org.objectweb.asm;version="[5.1.0,5.2.0)"
+ org.objectweb.asm;version="[5.2.0,5.3.0)"

--- a/org.jacoco.report/META-INF/MANIFEST.MF
+++ b/org.jacoco.report/META-INF/MANIFEST.MF
@@ -14,4 +14,4 @@ Import-Package: org.jacoco.core;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.core.analysis;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.core.data;bundle-version="[0.7.9,0.7.10)",
  org.jacoco.core.runtime;bundle-version="[0.7.9,0.7.10)",
- org.objectweb.asm;version="[5.1.0,5.2.0)"
+ org.objectweb.asm;version="[5.2.0,5.3.0)"


### PR DESCRIPTION
JaCoCo cannot re-calculate stackmap frames as this is an expensive operation and would require knowing the type hierarchy (which is not available). Also ASM default implementation for the type hierarchy actually loads(!) the classes.

Therefore in JaCoCo special care has been taken to incrementally update the stackmap frames during instrumentation.

It has been reported that the stackmap frame are re-calculated anyways is special situations, stack trace:

```
java.lang.ClassNotFoundException: javax.servlet.jsp.tagext.BodyContent
         at org.jacoco.asm.ClassWriter.getCommonSuperClass(Unknown Source)
         at org.jacoco.asm.ClassWriter.a(Unknown Source)
         at org.jacoco.asm.Frame.a(Unknown Source)
         at org.jacoco.asm.Frame.a(Unknown Source)
         at org.jacoco.asm.MethodWriter.visitMaxs(Unknown Source)
         at org.jacoco.asm.ClassReader.a(Unknown Source)
         at org.jacoco.asm.ClassReader.b(Unknown Source)
         at org.jacoco.asm.ClassReader.accept(Unknown Source)
         at org.jacoco.asm.ClassReader.accept(Unknown Source)
         at org.jacoco.asm.ClassWriter.toByteArray(Unknown Source)
         at org.jacoco.core.instr.Instrumenter.instrument(Instrumenter.java:79)
         at org.jacoco.core.instr.Instrumenter.instrument(Instrumenter.java:139) 
```

Looking at ASM source code it turned out that ASM triggers a frame re-calculation if the methods exceeds a certain size. See MethodWriter.resizeInstructions(). Shit.

Corresponding ASM issue: http://forge.ow2.org/tracker/?func=detail&aid=317551&group_id=23&atid=100023
