### PR TITLE
Test whether there are child execution data files to report upon

### DIFF
--- a/jacoco-maven-plugin.test/it/it-no-aggregate-report/invoker.properties
+++ b/jacoco-maven-plugin.test/it/it-no-aggregate-report/invoker.properties
@@ -1,0 +1,4 @@
+invoker.goals = clean install site
+
+# maven-site-plugin 3.0 requires at least Maven 2.2.0
+invoker.maven.version = 2.2.0+

--- a/jacoco-maven-plugin.test/it/it-no-aggregate-report/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-no-aggregate-report/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>no-aggregate</artifactId>
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/jacoco-maven-plugin.test/it/it-no-aggregate-report/src/main/java/package1/Example1a.java
+++ b/jacoco-maven-plugin.test/it/it-no-aggregate-report/src/main/java/package1/Example1a.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1a {
+
+  public void a() {
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-no-aggregate-report/src/main/java/package1/Example1b.java
+++ b/jacoco-maven-plugin.test/it/it-no-aggregate-report/src/main/java/package1/Example1b.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1b {
+
+  public void b() {
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-no-aggregate-report/src/test/java/package1/Example1aTest.java
+++ b/jacoco-maven-plugin.test/it/it-no-aggregate-report/src/test/java/package1/Example1aTest.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1aTest {
+
+  @Test
+  public void test() {
+    new Example1a().a();
+  }
+
+}

--- a/jacoco-maven-plugin.test/it/it-no-aggregate-report/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-no-aggregate-report/verify.bsh
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+import org.codehaus.plexus.util.*;
+import java.util.regex.*;
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+File report = new File( basedir, "target/site/jacoco-aggregate/index.html" );
+if ( report.isFile() ) {
+    throw new RuntimeException( "Aggregate report was created." );
+}
+

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -86,7 +86,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 
 	@Override
 	boolean canGenerateReportRegardingDataFiles() {
-		return true;
+		return executionDataFilesCount() > 0;
 	}
 
 	@Override
@@ -107,6 +107,22 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 		for (final MavenProject dependency : findDependencies(
 				Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST)) {
 			loadExecutionData(support, filter, dependency.getBasedir());
+		}
+	}
+
+	private int executionDataFilesCount() {
+		final FileFilter filter = new FileFilter(dataFileIncludes,
+				dataFileExcludes);
+		try {
+			int count = 0;
+			for (final MavenProject dependency : findDependencies(
+					Artifact.SCOPE_COMPILE, Artifact.SCOPE_TEST)) {
+				count += filter.getFiles(dependency.getBasedir()).size();
+			}
+			return count;
+		} catch (IOException e) {
+			throw new RuntimeException(
+					"Unable to determine number of executing data files", e);
 		}
 	}
 


### PR DESCRIPTION
Ensure that the aggregate report is only created if there are data files present in dependent children.