### PR TITLE
Fix 0.7.7 regression: broken links to stylesheet and javascript in documentation

### DIFF
--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -4,9 +4,9 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href=".resources/doc.css" charset="UTF-8" type="text/css" />
-  <link rel="stylesheet" href="../coverage/.resources/prettify.css" charset="UTF-8" type="text/css" />
+  <link rel="stylesheet" href="../coverage/jacoco-resources/prettify.css" charset="UTF-8" type="text/css" />
   <link rel="shortcut icon" href=".resources/report.gif" type="image/gif" />
-  <script type="text/javascript" src="../coverage/.resources/prettify.js"></script>
+  <script type="text/javascript" src="../coverage/jacoco-resources/prettify.js"></script>
   <title>JaCoCo - Ant Tasks</title>
 </head>
 <body onload="prettyPrint()">

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -4,9 +4,9 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href=".resources/doc.css" charset="UTF-8" type="text/css" />
-  <link rel="stylesheet" href="../coverage/.resources/prettify.css" charset="UTF-8" type="text/css" />
+  <link rel="stylesheet" href="../coverage/jacoco-resources/prettify.css" charset="UTF-8" type="text/css" />
   <link rel="shortcut icon" href=".resources/report.gif" type="image/gif" />
-  <script type="text/javascript" src="../coverage/.resources/prettify.js"></script>
+  <script type="text/javascript" src="../coverage/jacoco-resources/prettify.js"></script>
   <title>JaCoCo - Build</title>
 </head>
 <body onload="prettyPrint()">

--- a/org.jacoco.doc/docroot/doc/flow.html
+++ b/org.jacoco.doc/docroot/doc/flow.html
@@ -4,9 +4,9 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href=".resources/doc.css" charset="UTF-8" type="text/css" />
-  <link rel="stylesheet" href="../coverage/.resources/prettify.css" charset="UTF-8" type="text/css" />
+  <link rel="stylesheet" href="../coverage/jacoco-resources/prettify.css" charset="UTF-8" type="text/css" />
   <link rel="shortcut icon" href=".resources/report.gif" type="image/gif" />
-  <script type="text/javascript" src="../coverage/.resources/prettify.js"></script>
+  <script type="text/javascript" src="../coverage/jacoco-resources/prettify.js"></script>
   <title>JaCoCo - Control Flow Analysis</title>
 </head>
 <body onload="prettyPrint()">

--- a/org.jacoco.doc/docroot/doc/implementation.html
+++ b/org.jacoco.doc/docroot/doc/implementation.html
@@ -4,9 +4,9 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href=".resources/doc.css" charset="UTF-8" type="text/css" />
-  <link rel="stylesheet" href="../coverage/.resources/prettify.css" charset="UTF-8" type="text/css" />
+  <link rel="stylesheet" href="../coverage/jacoco-resources/prettify.css" charset="UTF-8" type="text/css" />
   <link rel="shortcut icon" href=".resources/report.gif" type="image/gif" />
-  <script type="text/javascript" src="../coverage/.resources/prettify.js"></script>
+  <script type="text/javascript" src="../coverage/jacoco-resources/prettify.js"></script>
   <title>JaCoCo - Implementation Design</title>
 </head>
 <body onload="prettyPrint()">

--- a/org.jacoco.doc/docroot/doc/maven.html
+++ b/org.jacoco.doc/docroot/doc/maven.html
@@ -4,9 +4,9 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href=".resources/doc.css" charset="UTF-8" type="text/css" />
-  <link rel="stylesheet" href="../coverage/.resources/prettify.css" charset="UTF-8" type="text/css" />
+  <link rel="stylesheet" href="../coverage/jacoco-resources/prettify.css" charset="UTF-8" type="text/css" />
   <link rel="shortcut icon" href=".resources/report.gif" type="image/gif" />
-  <script type="text/javascript" src="../coverage/.resources/prettify.js"></script>
+  <script type="text/javascript" src="../coverage/jacoco-resources/prettify.js"></script>
   <title>JaCoCo - Maven Plug-in</title>
 </head>
 <body onload="prettyPrint()">

--- a/org.jacoco.doc/docroot/doc/repo.html
+++ b/org.jacoco.doc/docroot/doc/repo.html
@@ -4,9 +4,9 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <link rel="stylesheet" href=".resources/doc.css" charset="UTF-8" type="text/css" />
-  <link rel="stylesheet" href="../coverage/.resources/prettify.css" charset="UTF-8" type="text/css" />
+  <link rel="stylesheet" href="../coverage/jacoco-resources/prettify.css" charset="UTF-8" type="text/css" />
   <link rel="shortcut icon" href=".resources/report.gif" type="image/gif" />
-  <script type="text/javascript" src="../coverage/.resources/prettify.js"></script>
+  <script type="text/javascript" src="../coverage/jacoco-resources/prettify.js"></script>
   <title>JaCoCo - Maven Repository</title>
 </head>
 <body onload="prettyPrint()">


### PR DESCRIPTION
In #401 we forgot to adapt some files in documentation to new location of resources:

![image](https://cloud.githubusercontent.com/assets/138671/15973410/904b991c-2f43-11e6-923e-d31aa2f9908e.png)
