### PR TITLE
Fix documentation

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
@@ -29,7 +29,7 @@ import org.objectweb.asm.Opcodes;
 
 /**
  * This {@link IRuntime} implementation works with a modified system class. A
- * new static method is added to a bootstrap class that will be used by
+ * new static field is added to a bootstrap class that will be used by
  * instrumented classes. As the system class itself needs to be instrumented
  * this runtime requires a Java agent.
  */
@@ -84,7 +84,7 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 
 	/**
 	 * Creates a new {@link ModifiedSystemClassRuntime} using the given class as
-	 * the data container. Members are creates with internal default names. The
+	 * the data container. Member is created with internal default name. The
 	 * given class must not have been loaded before by the agent.
 	 * 
 	 * @param inst
@@ -144,8 +144,7 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 	}
 
 	/**
-	 * Adds the static access method and data field to the given class
-	 * definition.
+	 * Adds the static data field to the given class definition.
 	 * 
 	 * @param source
 	 *            class definition source

--- a/org.jacoco.doc/docroot/doc/implementation.html
+++ b/org.jacoco.doc/docroot/doc/implementation.html
@@ -215,7 +215,7 @@ boolean[] probes = (boolean[]) args[0];
 <p>
   The current JaCoCo Java agent implementation uses the 
   <code>ModifiedSystemClassRuntime</code> adding a field to the class
-  <code>java.sql.Types</code>.
+  <code>java.util.UUID</code>.
 </p>
 
 


### PR DESCRIPTION
* ModifiedSystemClassRuntime doesn't add method starting from commit a942c8949be59f949ec110391d766d1f4856a4e0 in v0.3.2.
* Agent modifies "java.util.UUID" instead of "java.sql.Types" starting from commit 5ff6b2dc7a8a82132fbe3a65e4c86a60a0be8693 in v0.5.0.