### PR TITLE
"m2e/lifecycle-mapping-metadata.xml" should include "report-aggregate"

### DIFF
--- a/jacoco-maven-plugin/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/jacoco-maven-plugin/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -18,6 +18,7 @@
           <goal>merge</goal>
           <goal>report</goal>
           <goal>report-integration</goal>
+          <goal>report-aggregate</goal>
           <goal>check</goal>
           <goal>dump</goal>
           <goal>instrument</goal>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -27,6 +27,12 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/322">#322</a>).</li>
 </ul>
 
+<h3>Fixed Bugs</h3>
+<ul>
+  <li>Add Maven goal <code>report-aggregate</code> to lifecycle-mapping-metadata.xml
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/427">#427</a>).</li>
+</ul>
+
 <h2>Release 0.7.7 (2016/06/06)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
In #388 we forgot to do this.