### PR TITLE
java.lang.IncompatibleClassChangeError: Method $jacocoInit()[Z must be InterfaceMethodref constant

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -12,7 +12,9 @@
 package org.jacoco.core.internal.instr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
@@ -92,9 +94,13 @@ public class ProbeArrayStrategyFactoryTest {
 
 	@Test
 	public void testClass8() {
-		test(Opcodes.V1_8, 0, false, true);
+		final IProbeArrayStrategy strategy = test(Opcodes.V1_8, 0, false, true);
 		assertDataField(InstrSupport.DATAFIELD_ACC);
 		assertInitMethod(true);
+
+		final ClassVisitorMock cv = new ClassVisitorMock();
+		strategy.storeInstance(cv.visitMethod(0, null, null, null, null), 0);
+		assertFalse(cv.interfaceMethod);
 	}
 
 	@Test
@@ -120,9 +126,14 @@ public class ProbeArrayStrategyFactoryTest {
 
 	@Test
 	public void testInterface8() {
-		test(Opcodes.V1_8, Opcodes.ACC_INTERFACE, false, true);
+		final IProbeArrayStrategy strategy = test(Opcodes.V1_8,
+				Opcodes.ACC_INTERFACE, false, true);
 		assertDataField(InstrSupport.DATAFIELD_INTF_ACC);
 		assertInitMethod(true);
+
+		final ClassVisitorMock cv = new ClassVisitorMock();
+		strategy.storeInstance(cv.visitMethod(0, null, null, null, null), 0);
+		assertTrue(cv.interfaceMethod);
 	}
 
 	@Test
@@ -177,6 +188,7 @@ public class ProbeArrayStrategyFactoryTest {
 		private String methodName;
 
 		private boolean frames;
+		private boolean interfaceMethod;
 
 		ClassVisitorMock() {
 			super(Opcodes.ASM5);
@@ -202,6 +214,12 @@ public class ProbeArrayStrategyFactoryTest {
 				public void visitFrame(int type, int nLocal, Object[] local,
 						int nStack, Object[] stack) {
 					frames = true;
+				}
+
+				@Override
+				public void visitMethodInsn(int opcode, String owner,
+						String name, String desc, boolean itf) {
+					interfaceMethod = itf;
 				}
 			};
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/FieldProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/FieldProbeArrayStrategy.java
@@ -37,15 +37,18 @@ class FieldProbeArrayStrategy implements IProbeArrayStrategy {
 	private final String className;
 	private final long classId;
 	private final boolean withFrames;
+	private final boolean isInterface;
 	private final int fieldAccess;
 	private final IExecutionDataAccessorGenerator accessorGenerator;
 
 	FieldProbeArrayStrategy(final String className, final long classId,
-			final boolean withFrames, final int fieldAccess,
+			final boolean withFrames, final boolean isInterface,
+			final int fieldAccess,
 			final IExecutionDataAccessorGenerator accessorGenerator) {
 		this.className = className;
 		this.classId = classId;
 		this.withFrames = withFrames;
+		this.isInterface = isInterface;
 		this.fieldAccess = fieldAccess;
 		this.accessorGenerator = accessorGenerator;
 	}
@@ -53,7 +56,7 @@ class FieldProbeArrayStrategy implements IProbeArrayStrategy {
 	public int storeInstance(final MethodVisitor mv, final int variable) {
 		mv.visitMethodInsn(Opcodes.INVOKESTATIC, className,
 				InstrSupport.INITMETHOD_NAME, InstrSupport.INITMETHOD_DESC,
-				false);
+				isInterface);
 		mv.visitVarInsn(Opcodes.ASTORE, variable);
 		return 1;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -51,7 +51,7 @@ public final class ProbeArrayStrategyFactory {
 			}
 			if (version >= Opcodes.V1_8 && counter.hasMethods()) {
 				return new FieldProbeArrayStrategy(className, classId,
-						withFrames, InstrSupport.DATAFIELD_INTF_ACC,
+						withFrames, true, InstrSupport.DATAFIELD_INTF_ACC,
 						accessorGenerator);
 			} else {
 				return new LocalProbeArrayStrategy(className, classId,
@@ -59,7 +59,7 @@ public final class ProbeArrayStrategyFactory {
 			}
 		} else {
 			return new FieldProbeArrayStrategy(className, classId, withFrames,
-					InstrSupport.DATAFIELD_ACC, accessorGenerator);
+					false, InstrSupport.DATAFIELD_ACC, accessorGenerator);
 		}
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -29,6 +29,10 @@
 
 <h3>Fixed Bugs</h3>
 <ul>
+  <li>Fix instrumentation of interfaces with default methods to not create incorrect
+      constant pool entries, which lead to <code>IncompatibleClassChangeError</code>
+      starting from OpenJDK 9 EA b122
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/428">#428</a>).</li>
   <li>Add Maven goal <code>report-aggregate</code> to lifecycle-mapping-metadata.xml
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/427">#427</a>).</li>
 </ul>


### PR DESCRIPTION
### Steps to reproduce

I receive with Java 9 the follow error:
```
java.lang.IncompatibleClassChangeError: Method com.inet.error.ErrorCode.$jacocoInit()[Z must be InterfaceMethodref constant
	at com.inet.error.ErrorCode.getMsg(ErrorCode.java)
	at com.inet.error.BaseErrorTest.testErrorCodeHasDefaultTranslation(BaseErrorTest.java:16)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:533)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:114)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:57)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:66)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
```

The code look like:

```
public interface ErrorCode {
    default String getMsg( Object... params ) {
        String baseName = getClass().getName();
        baseName = baseName.substring( 0, baseName.lastIndexOf( '.' ) ) + ".LanguageResources";

        ResourceBundle bundle = LoaderUtils.getBundle( baseName, ClientLocale.getThreadLocale(), getClass() );
        String msg = name();
        try {
            msg = bundle.getString( msg );
        } catch( Exception e ) {/* ignore */
        }
        try {
            msg = java.text.MessageFormat.format( msg, params );
        } catch( Exception t ) {/*ignore*/
        }
        return msg;
    }
}
```



JaCoCo version: 0.7.5.201505241946
Operating system: Windows 10 
Tool integration: Gradle
