### PR TITLE
Java 9 Support: Profile for 1.9?

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -52,6 +52,9 @@ case "$JDK" in
 9-ea)
   install_jdk $JDK9_EA_URL
   ;;
+9-ea-stable)
+  install_jdk $JDK9_EA_STABLE_URL
+  ;;
 esac
 
 # Do not use "~/.mavenrc" set by Travis (https://github.com/travis-ci/travis-ci/issues/3893),
@@ -81,9 +84,9 @@ case "$JDK" in
 8 | 8-ea)
   mvn -V -B -e verify -Dbytecode.version=1.8
   ;;
-9-ea)
+9-ea | 9-ea-stable)
   # see https://bugs.openjdk.java.net/browse/JDK-8131041 about "java.locale.providers"
-  mvn -V -B -e verify -Dbytecode.version=1.8 \
+  mvn -V -B -e verify -Dbytecode.version=1.9 \
     -DargLine=-Djava.locale.providers=JRE,SPI
   ;;
 *)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - JDK=8
   - JDK=8-ea
   - JDK=9-ea
+  - JDK=9-ea-stable
 
 matrix:
   allow_failures:

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -654,6 +654,24 @@
         <maven.compiler.target>${bytecode.version}</maven.compiler.target>
       </properties>
     </profile>
+    <profile>
+      <id>java9-validation</id>
+      <activation>
+        <property>
+          <name>bytecode.version</name>
+          <value>1.9</value>
+        </property>
+      </activation>
+      <properties>
+        <!--
+        Compile into bytecode version 8 by default,
+        because maven-shade-plugin and maven-plugin-plugin are unable to proceess bytecode version 9,
+        this is overridden for tests
+        -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+      </properties>
+    </profile>
 
     <profile>
       <id>jdk16</id>
@@ -687,6 +705,19 @@
         <property>
           <name>jdk.version</name>
           <value>1.8</value>
+        </property>
+      </activation>
+      <properties>
+        <jvm.args>-XX:-FailOverToOldVerifier -Xverify:all</jvm.args>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>jdk9</id>
+      <activation>
+        <property>
+          <name>jdk.version</name>
+          <value>1.9</value>
         </property>
       </activation>
       <properties>

--- a/org.jacoco.core.test/pom.xml
+++ b/org.jacoco.core.test/pom.xml
@@ -37,7 +37,7 @@
       <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>java8-validation</id>
@@ -73,11 +73,15 @@
     <profile>
       <id>java9-validation</id>
       <activation>
+        <!-- for some reason activation should be presented here, even if already defined in parent -->
         <property>
           <name>bytecode.version</name>
           <value>1.9</value>
         </property>
       </activation>
+      <properties>
+        <maven.compiler.target>1.9</maven.compiler.target>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -36,6 +36,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.internal.Java9Support;
 import org.jacoco.core.internal.data.CRC64;
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Before;
@@ -91,8 +92,9 @@ public class AnalyzerTest {
 
 	@Test
 	public void testAnalyzeClassIdMatch() throws IOException {
-		final byte[] bytes = TargetLoader
-				.getClassDataAsBytes(AnalyzerTest.class);
+		// class IDs are always calculated after downgrade of the version
+		final byte[] bytes = Java9Support.downgradeIfRequired(
+				TargetLoader.getClassDataAsBytes(AnalyzerTest.class));
 		executionData.get(Long.valueOf(CRC64.checksum(bytes)),
 				"org/jacoco/core/analysis/AnalyzerTest", 200);
 		analyzer.analyzeClass(bytes, "Test");

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
@@ -19,6 +19,7 @@ import java.io.StringWriter;
 
 import org.jacoco.core.JaCoCo;
 import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.Java9Support;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
 import org.jacoco.core.test.TargetLoader;
@@ -87,7 +88,8 @@ public class FramesTest {
 	}
 
 	private byte[] calculateFrames(byte[] source) {
-		ClassReader rc = new ClassReader(source);
+		ClassReader rc = new ClassReader(
+				Java9Support.downgradeIfRequired(source));
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
 		// Adjust Version to 1.6 to enable frames:

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/StructuredLockingTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/StructuredLockingTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.Java9Support;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
 import org.jacoco.core.test.TargetLoader;
@@ -63,7 +64,8 @@ public class StructuredLockingTest {
 		byte[] instrumented = instrumenter.instrument(source, "TestTarget");
 
 		ClassNode cn = new ClassNode();
-		new ClassReader(instrumented).accept(cn, 0);
+		new ClassReader(Java9Support.downgradeIfRequired(instrumented))
+				.accept(cn, 0);
 		for (MethodNode mn : cn.methods) {
 			assertStructuredLocking(cn.name, mn);
 		}


### PR DESCRIPTION
Question: Do we need to add a profile for Java 9? Like for the other java versions:

    <profile>
      <id>jdk18</id>
      <activation>
        <property>
          <name>jdk.version</name>
          <value>1.8</value>
        </property>
      </activation>
      <properties>
        <jvm.args>-XX:-FailOverToOldVerifier -Xverify:all</jvm.args>
      </properties>
    </profile>