### PR TITLE
Exceptions cause missed branches in previous lines

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -103,6 +103,13 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("explicitExceptionFinally.finallyBlock",
 				ICounter.FULLY_COVERED);
 
+		// TODO(Godin): why fully covered? it looks strange, but the same in
+		// already presented cases above:
+		assertLine("implicitExceptionAfterBranch.if", ICounter.FULLY_COVERED, 1,
+				1);
+		assertLine("implicitExceptionAfterBranch.ifbody", ICounter.NOT_COVERED);
+		assertLine("implicitExceptionAfterBranch.exception",
+				ICounter.NOT_COVERED);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
@@ -44,6 +44,10 @@ public class Target03 implements Runnable {
 			implicitExceptionFinally();
 		} catch (StubException e) {
 		}
+		try {
+			implicitExceptionAfterBranch();
+		} catch (StubException e) {
+		}
 	}
 
 	private void implicitException() {
@@ -126,6 +130,13 @@ public class Target03 implements Runnable {
 		} finally { // $line-explicitExceptionFinally.finally$
 			nop(); // $line-explicitExceptionFinally.finallyBlock$
 		}
+	}
+
+	private void implicitExceptionAfterBranch() {
+		if (f()) { // $line-implicitExceptionAfterBranch.if$
+			return; // $line-implicitExceptionAfterBranch.ifbody$
+		}
+		ex(); // $line-implicitExceptionAfterBranch.exception$
 	}
 
 	public static void main(String[] args) {

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelInfo.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelInfo.java
@@ -137,6 +137,9 @@ public final class LabelInfo {
 	 *            label to test
 	 * @return <code>true</code> if a probe should be inserted before
 	 */
+	// TODO(Godin): IMO misleading method name since it is not always used,
+	// e.g. not in
+	// org.jacoco.core.internal.flow.MethodProbesAdapter.visitJumpInsn()
 	public static boolean needsProbe(final Label label) {
 		final LabelInfo info = get(label);
 		return info != null && info.successor

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
@@ -108,7 +108,8 @@ public final class MethodProbesAdapter extends MethodVisitor {
 
 	@Override
 	public void visitJumpInsn(final int opcode, final Label label) {
-		if (LabelInfo.isMultiTarget(label)) {
+		if (LabelInfo.isMultiTarget(label)
+				|| LabelInfo.isMethodInvocationLine(label)) {
 			probesVisitor.visitJumpInsnWithProbe(opcode, label,
 					idGenerator.nextId(), frame(jumpPopCount(opcode)));
 		} else {


### PR DESCRIPTION
If a for loop is followed by line with a implicit exception the execution of one of the branches for the loop condition is reported as missed (1 of 2 branches missed):

	private void implicitExceptionAfterForLoop() {
		for (int i = 0; i < 3; i++) { // $line-implicitExceptionAfterForLoop.for$
			nop(); // $line-implicitExceptionAfterForLoop.loopbody$
		}
		ex(); // $line-implicitExceptionAfterForLoop.exception$
	}

This only happens for class files compiled with the JDK compilers, it works for class files compiled with Eclipse.