### PR TITLE
Update comments about "bad cycles" with interfaces

### DIFF
--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/BadCycleInterfaceTest.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/BadCycleInterfaceTest.java
@@ -26,22 +26,23 @@ public class BadCycleInterfaceTest extends ValidationTestBase {
 
 	@Test
 	public void test() throws Exception {
-		if (System.getProperty("java.version").startsWith("9-ea")) {
-			// JDK-9042842
-			assertLine("baseclinit", ICounter.EMPTY);
-			assertLine("childdefault", ICounter.NOT_COVERED);
-			assertLogEvents("childclinit", "childstaticmethod");
-		} else {
+		if (System.getProperty("java.version").startsWith("1.8")) {
+			// Incorrect interpetation of JVMS 5.5 in JDK 8 causes a default
+			// method to be called before the static initializer of an interface
+			// (see JDK-8098557 and JDK-8164302):
 			assertLine("baseclinit", ICounter.FULLY_COVERED);
 			assertLine("childdefault", ICounter.FULLY_COVERED);
 
-			// The cycle causes a default method to be called before the static
-			// initializer of a interface:
 			assertLogEvents("baseclinit", "childdefaultmethod", "childclinit",
 					"childstaticmethod");
+		} else {
+			// This shouldn't happen with JDK 9 (see also JDK-8043275):
+			assertLine("baseclinit", ICounter.EMPTY);
+			assertLine("childdefault", ICounter.NOT_COVERED);
+			assertLogEvents("childclinit", "childstaticmethod");
 		}
 		assertLine("childclinit", ICounter.FULLY_COVERED);
 		assertLine("childstatic", ICounter.FULLY_COVERED);
-
 	}
+
 }


### PR DESCRIPTION
Our current example of "bad cycles" with interfaces ( https://github.com/jacoco/jacoco/pull/434#issuecomment-239643789 ) - is more a demonstration of correct change of behavior between JDK8 and JDK9 than a correct example of "bad cycles" with interfaces as stated in [JDK-8164302](https://bugs.openjdk.java.net/browse/JDK-8164302). We should add correct example.