### PR TITLE
Use jacoco.org domain

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 This is a issue tracker. Please use our mailing list for general questions: 
 https://groups.google.com/forum/?fromgroups=#!forum/jacoco
 
-Also check FAQ before opening an issue: http://www.eclemma.org/jacoco/trunk/doc/faq.html
+Also check FAQ before opening an issue: http://www.jacoco.org/jacoco/trunk/doc/faq.html
 
 
 ### Steps to reproduce

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,5 +10,5 @@ License Version 1.0 ("EPL"). A copy of the EPL is available at
 [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html).
 
 Please visit
-[http://www.eclemma.org/jacoco/trunk/doc/license.html](http://www.eclemma.org/jacoco/trunk/doc/license.html)
+[http://www.jacoco.org/jacoco/trunk/doc/license.html](http://www.jacoco.org/jacoco/trunk/doc/license.html)
 for the complete license information including third party licenses and trademarks.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ JaCoCo Java Code Coverage Library
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jacoco/org.jacoco.core/badge.svg?style=flat)](http://search.maven.org/#search|ga|1|g%3Aorg.jacoco)
 
 JaCoCo is a free Java code coverage library distributed under the Eclipse Public
-License. Check the [project homepage](http://www.eclemma.org/jacoco)
+License. Check the [project homepage](http://www.jacoco.org/jacoco)
 for downloads, documentation and feedback.
 
 Please use our [mailing list](https://groups.google.com/forum/?fromgroups=#!forum/jacoco)
 for questions regarding JaCoCo which are not already covered by the
-[extensive documentation](http://www.eclemma.org/jacoco/trunk/doc/).
+[extensive documentation](http://www.jacoco.org/jacoco/trunk/doc/).
 
 Note: We do not answer general questions in the project's issue tracker. Please use our [mailing list](https://groups.google.com/forum/?fromgroups=#!forum/jacoco) for this.
 -------------------------------------------------------------------------

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -131,7 +131,7 @@
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
 
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
-    <jacoco.home.url>http://www.eclemma.org/jacoco</jacoco.home.url>
+    <jacoco.home.url>http://www.jacoco.org/jacoco</jacoco.home.url>
     <copyright.years>${project.inceptionYear}, 2016</copyright.years>
 
     <maven.compiler.source>1.5</maven.compiler.source>

--- a/org.jacoco.examples/build/pom-it.xml
+++ b/org.jacoco.examples/build/pom-it.xml
@@ -20,7 +20,7 @@
   <packaging>jar</packaging>
 
   <name>JaCoCo Maven plug-in example</name>
-  <url>http://www.eclemma.org/jacoco</url>
+  <url>http://www.jacoco.org/jacoco</url>
 
   <dependencies>
     <dependency>

--- a/org.jacoco.examples/build/pom-offline.xml
+++ b/org.jacoco.examples/build/pom-offline.xml
@@ -19,7 +19,7 @@
   <packaging>jar</packaging>
 
   <name>JaCoCo Maven plug-in example with Offline Instrumentation</name>
-  <url>http://www.eclemma.org/jacoco</url>
+  <url>http://www.jacoco.org/jacoco</url>
 
   <dependencies>
     <dependency>

--- a/org.jacoco.examples/build/pom.xml
+++ b/org.jacoco.examples/build/pom.xml
@@ -20,7 +20,7 @@
   <packaging>jar</packaging>
 
   <name>JaCoCo Maven plug-in example</name>
-  <url>http://www.eclemma.org/jacoco</url>
+  <url>http://www.jacoco.org/jacoco</url>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
As we're handing over eclemma.org to Eclipse foundation we should use jacoco.org only in JaCoCo URLs.