### PR TITLE
Remove obsolete build.properties Files

### DIFF
--- a/org.jacoco.agent.rt.test/build.properties
+++ b/org.jacoco.agent.rt.test/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.agent.rt/build.properties
+++ b/org.jacoco.agent.rt/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.agent.test/build.properties
+++ b/org.jacoco.agent.test/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.agent/build.properties
+++ b/org.jacoco.agent/build.properties
@@ -1,4 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .

--- a/org.jacoco.ant.test/build.properties
+++ b/org.jacoco.ant.test/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.ant/build.properties
+++ b/org.jacoco.ant/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.core.test/build.properties
+++ b/org.jacoco.core.test/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.core/build.properties
+++ b/org.jacoco.core/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.doc/build.properties
+++ b/org.jacoco.doc/build.properties
@@ -1,2 +1,0 @@
-bin.includes = META-INF/,\
-               about.html

--- a/org.jacoco.examples.test/build.properties
+++ b/org.jacoco.examples.test/build.properties
@@ -1,4 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .

--- a/org.jacoco.examples/build.properties
+++ b/org.jacoco.examples/build.properties
@@ -1,4 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .

--- a/org.jacoco.report.test/build.properties
+++ b/org.jacoco.report.test/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html

--- a/org.jacoco.report/build.properties
+++ b/org.jacoco.report/build.properties
@@ -1,5 +1,0 @@
-source.. = src/
-output.. = bin/
-bin.includes = META-INF/,\
-               .,\
-               about.html


### PR DESCRIPTION
Since we fully moved to Maven build and IDE setup build.properties files are obsolete.