### PR TITLE
No need to sign JARs using maven-jarsigner-plugin

### DIFF
--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -25,10 +25,6 @@
   <name>JaCoCo :: Distribution</name>
   <description>JaCoCo Standalone Distribution</description>
 
-  <properties>
-    <jarsigner.skip>true</jarsigner.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/org.jacoco.agent.rt/pom.xml
+++ b/org.jacoco.agent.rt/pom.xml
@@ -26,7 +26,6 @@
   <description>JaCoCo Java Agent</description>
 
   <properties>
-    <jarsigner.skip>true</jarsigner.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -316,11 +316,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jarsigner-plugin</artifactId>
-          <version>1.4</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.8</version>
           <configuration>
@@ -726,31 +721,6 @@
     </profile>
 
     <profile>
-      <id>sign</id>
-      <activation>
-        <property>
-          <name>jarsigner.alias</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jarsigner-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign</id>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>manifest</id>
       <activation>
         <file>
@@ -857,12 +827,6 @@
                 </goals>
                 <configuration>
                   <rules>
-                    <!--
-                    <requireActiveProfile>
-                      <message>You must sign JARs during release.</message>
-                      <profiles>sign</profiles>
-                    </requireActiveProfile>
-                    -->
                     <requireReleaseVersion/>
                     <requireProperty>
                       <property>buildNumber</property>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -48,6 +48,13 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/427">#427</a>).</li>
 </ul>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>Released JaCoCo JARs are not signed any more. Signed versions of JaCoCo are
+      now available from the Eclipse Orbit project
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/466">#466</a>).</li>
+</ul>
+
 <h2>Release 0.7.7 (2016/06/06)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
The primary use case for signing JaCoCo artifacts was the EclEmma plugin. Next release of EclEmma under Eclipse Foundation umbrella will use JaCoCo bundles from [Eclipse Orbit](http://download.eclipse.org/tools/orbit/downloads/), which signed by eclipse.org anyway. So that no need to sign anymore during our releases.

Initial discussion: https://groups.google.com/d/msg/jacoco-dev/hTLvWPXqaUg/fKoDA3zqBAAJ
