### PR TITLE
Fix build failure with JDK 9 EA b148

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -85,6 +85,9 @@ case "$JDK" in
   mvn -V -B -e verify -Dbytecode.version=1.8
   ;;
 9-ea | 9-ea-stable)
+  # Groovy version should be updated to get rid of "--add-opens" options (see https://twitter.com/CedricChampeau/status/807285853580103684)
+  export MAVEN_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
+
   # see https://bugs.openjdk.java.net/browse/JDK-8131041 about "java.locale.providers"
   mvn -V -B -e verify -Dbytecode.version=1.9 \
     -DargLine=-Djava.locale.providers=JRE,SPI

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/URLStreamHandlerRuntimeTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/URLStreamHandlerRuntimeTest.java
@@ -11,6 +11,9 @@
  *******************************************************************************/
 package org.jacoco.core.runtime;
 
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
 /**
  * Unit tests for {@link URLStreamHandlerRuntime}.
  */
@@ -19,6 +22,13 @@ public class URLStreamHandlerRuntimeTest extends RuntimeTestBase {
 	@Override
 	IRuntime createRuntime() {
 		return new URLStreamHandlerRuntime();
+	}
+
+	@BeforeClass
+	public static void checkJDK() {
+		final boolean jdk9 = System.getProperty("java.version")
+				.startsWith("9-");
+		Assume.assumeTrue(!jdk9);
 	}
 
 }


### PR DESCRIPTION
```
Failed to execute goal org.codehaus.groovy.maven:gmaven-plugin:1.0:execute (parse-version) on project org.jacoco.build

Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make java.lang.String(char[],int,int,java.lang.Void) accessible: module java.base does not "opens java.lang" to unnamed module @603cabc4
	at java.base/jdk.internal.reflect.Reflection.throwInaccessibleObjectException(Reflection.java:427)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:201)
	at java.base/java.lang.reflect.Constructor.checkCanSetAccessible(Constructor.java:184)
	at java.base/java.lang.reflect.Constructor.setAccessible(Constructor.java:177)
	at org.codehaus.groovy.reflection.CachedConstructor.<init>(CachedConstructor.java:32)
	at org.codehaus.groovy.reflection.CachedClass.getConstructors(CachedClass.java:233)
	at groovy.lang.MetaClassImpl.<init>(MetaClassImpl.java:115)
	at groovy.lang.MetaClassRegistry$MetaClassCreationHandle.createNormalMetaClass(MetaClassRegistry.java:102)
	at groovy.lang.MetaClassRegistry$MetaClassCreationHandle.create(MetaClassRegistry.java:92)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.getGlobalMetaClass(MetaClassRegistryImpl.java:252)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.access$100(MetaClassRegistryImpl.java:45)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl$LocallyKnownClasses.getFromGlobal(MetaClassRegistryImpl.java:112)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl$LocallyKnownClasses.getMetaClass(MetaClassRegistryImpl.java:88)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl$MyThreadLocal.getMetaClass(MetaClassRegistryImpl.java:361)
	at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.getMetaClass(MetaClassRegistryImpl.java:265)
	at org.codehaus.groovy.runtime.InvokerHelper.invokePojoMethod(InvokerHelper.java:765)
	at org.codehaus.groovy.runtime.InvokerHelper.invokeMethod(InvokerHelper.java:754)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodN(ScriptBytecodeAdapter.java:170)
	at script1481306263465.run(script1481306263465.groovy:6)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:538)
	at org.codehaus.groovy.maven.runtime.support.ScriptExecutorSupport.invokeMethod(ScriptExecutorSupport.java:158)
	... 26 more
```

According to https://twitter.com/CedricChampeau/status/807285853580103684 Groovy should be updated to 2.4.8