### PR TITLE
Simplify numbering of versions

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -53,6 +53,9 @@
   <li>Released JaCoCo JARs are not signed any more. Signed versions of JaCoCo are
       now available from the Eclipse Orbit project
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/466">#466</a>).</li>
+  <li>Simplified numbering of versions - JaCoCo JARs in Maven Central repository
+      do not have qualifier any more
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/468">#468</a>).</li>
 </ul>
 
 <h2>Release 0.7.7 (2016/06/06)</h2>


### PR DESCRIPTION
JARs of releases that we we publish into Maven central repository should have major, minor and patch components in version, but not qualifier, i.e. simply `0.7.8`. Qualifier should remain in MANIFEST files.

Initial discussion: https://groups.google.com/d/msg/jacoco-dev/HNWPzop4ZI4/pvmfWsSSCAAJ