### PR TITLE
Runtime initialize non-constant static finals

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -142,7 +142,7 @@ public class ExecutionDataReaderWriterTest {
 		buffer.write(ExecutionDataWriter.BLOCK_HEADER);
 		buffer.write(0xC0);
 		buffer.write(0xC0);
-		final char version = ExecutionDataWriter.FORMAT_VERSION - 1;
+		final char version = (char) (ExecutionDataWriter.FORMAT_VERSION - 1);
 		buffer.write(version >> 8);
 		buffer.write(version & 0xFF);
 		createReader().read();

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassInstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassInstrumenterTest.java
@@ -13,7 +13,6 @@ package org.jacoco.core.internal.instr;
 
 import static org.junit.Assert.assertNull;
 
-import org.jacoco.core.JaCoCo;
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.asm.ClassVisitor;
@@ -29,7 +28,7 @@ public class ClassInstrumenterTest implements IProbeArrayStrategy {
 	@Before
 	public void setup() {
 		instrumenter = new ClassInstrumenter(this, new ClassVisitor(
-				JaCoCo.ASM_API_VERSION) {
+				InstrSupport.ASM_API_VERSION) {
 		});
 	}
 
@@ -50,7 +49,7 @@ public class ClassInstrumenterTest implements IProbeArrayStrategy {
 	@Test
 	public void testNoMethodVisitor() {
 		instrumenter = new ClassInstrumenter(this, new ClassVisitor(
-				JaCoCo.ASM_API_VERSION) {
+				InstrSupport.ASM_API_VERSION) {
 			@Override
 			public MethodVisitor visitMethod(int access, String name,
 					String desc, String signature, String[] exceptions) {

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/RuntimeTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/RuntimeTestBase.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.jacoco.core.JaCoCo;
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.test.TargetLoader;
 import org.junit.After;
@@ -66,7 +65,7 @@ public abstract class RuntimeTestBase {
 	public void testNoLocalVariablesInDataAccessor()
 			throws InstantiationException, IllegalAccessException {
 		runtime.generateDataAccessor(1001, "Target", 5, new MethodVisitor(
-				JaCoCo.ASM_API_VERSION) {
+				InstrSupport.ASM_API_VERSION) {
 			@Override
 			public void visitVarInsn(int opcode, int var) {
 				fail("No usage of local variables allowed.");

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ClassFileVersionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ClassFileVersionsTest.java
@@ -28,9 +28,9 @@ import static org.objectweb.asm.Opcodes.V1_8;
 
 import java.io.IOException;
 
-import org.jacoco.core.JaCoCo;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.internal.Java9Support;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
 import org.junit.Test;
@@ -102,12 +102,12 @@ public class ClassFileVersionsTest {
 	private void assertFrames(byte[] source, boolean expected) {
 		final boolean[] hasFrames = new boolean[] { false };
 		new ClassReader(Java9Support.downgradeIfRequired(source)).accept(
-				new ClassVisitor(JaCoCo.ASM_API_VERSION) {
+				new ClassVisitor(InstrSupport.ASM_API_VERSION) {
 
 					@Override
 					public MethodVisitor visitMethod(int access, String name,
 							String desc, String signature, String[] exceptions) {
-						return new MethodVisitor(JaCoCo.ASM_API_VERSION) {
+						return new MethodVisitor(InstrSupport.ASM_API_VERSION) {
 
 							@Override
 							public void visitFrame(int type, int nLocal,

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
@@ -20,6 +20,7 @@ import java.io.StringWriter;
 import org.jacoco.core.JaCoCo;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.internal.Java9Support;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
 import org.jacoco.core.test.TargetLoader;
@@ -56,7 +57,7 @@ public class FramesTest {
 	 */
 	private static class MaxStackEliminator extends ClassVisitor {
 		public MaxStackEliminator(ClassVisitor cv) {
-			super(JaCoCo.ASM_API_VERSION, cv);
+			super(InstrSupport.ASM_API_VERSION, cv);
 		}
 
 		@Override
@@ -64,7 +65,7 @@ public class FramesTest {
 				String signature, String[] exceptions) {
 			final MethodVisitor mv = super.visitMethod(access, name, desc,
 					signature, exceptions);
-			return new MethodVisitor(JaCoCo.ASM_API_VERSION, mv) {
+			return new MethodVisitor(InstrSupport.ASM_API_VERSION, mv) {
 				@Override
 				public void visitMaxs(int maxStack, int maxLocals) {
 					super.visitMaxs(-1, maxLocals);
@@ -93,7 +94,7 @@ public class FramesTest {
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 
 		// Adjust Version to 1.6 to enable frames:
-		rc.accept(new ClassVisitor(JaCoCo.ASM_API_VERSION, cw) {
+		rc.accept(new ClassVisitor(InstrSupport.ASM_API_VERSION, cw) {
 
 			@Override
 			public void visit(int version, int access, String name,

--- a/org.jacoco.core/src/org/jacoco/core/JaCoCo.java
+++ b/org.jacoco.core/src/org/jacoco/core/JaCoCo.java
@@ -13,8 +13,6 @@ package org.jacoco.core;
 
 import java.util.ResourceBundle;
 
-import org.objectweb.asm.Opcodes;
-
 /**
  * Static Meta information about JaCoCo.
  */
@@ -28,9 +26,6 @@ public final class JaCoCo {
 
 	/** Name of the runtime package of this build */
 	public static final String RUNTIMEPACKAGE;
-
-	/** ASM API version */
-	public static final int ASM_API_VERSION = Opcodes.ASM5;
 
 	static {
 		final ResourceBundle bundle = ResourceBundle

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
@@ -24,7 +24,12 @@ public class ExecutionDataWriter implements ISessionInfoVisitor,
 		IExecutionDataVisitor {
 
 	/** File format version, will be incremented for each incompatible change. */
-	public static final char FORMAT_VERSION = 0x1007;
+	public static final char FORMAT_VERSION;
+
+	static {
+		// Runtime initialize to ensure javac does not inline the value.
+		FORMAT_VERSION = 0x1007;
+	}
 
 	/** Magic number in header for file format identification. */
 	public static final char MAGIC_NUMBER = 0xC0C0;

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesAdapter.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.internal.flow;
 
-import org.jacoco.core.JaCoCo;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.commons.AnalyzerAdapter;
@@ -44,7 +44,7 @@ public class ClassProbesAdapter extends ClassVisitor implements
 	 */
 	public ClassProbesAdapter(final ClassProbesVisitor cv,
 			final boolean trackFrames) {
-		super(JaCoCo.ASM_API_VERSION, cv);
+		super(InstrSupport.ASM_API_VERSION, cv);
 		this.cv = cv;
 		this.trackFrames = trackFrames;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesVisitor.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.internal.flow;
 
-import org.jacoco.core.JaCoCo;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.ClassVisitor;
 
 /**
@@ -34,7 +34,7 @@ public abstract class ClassProbesVisitor extends ClassVisitor {
 	 *            optional next visitor in chain
 	 */
 	public ClassProbesVisitor(final ClassVisitor cv) {
-		super(JaCoCo.ASM_API_VERSION, cv);
+		super(InstrSupport.ASM_API_VERSION, cv);
 	}
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelFlowAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelFlowAnalyzer.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.internal.flow;
 
-import org.jacoco.core.JaCoCo;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -62,7 +62,7 @@ public final class LabelFlowAnalyzer extends MethodVisitor {
 	 * Create new instance.
 	 */
 	public LabelFlowAnalyzer() {
-		super(JaCoCo.ASM_API_VERSION);
+		super(InstrSupport.ASM_API_VERSION);
 	}
 
 	@Override

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
@@ -14,7 +14,7 @@ package org.jacoco.core.internal.flow;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jacoco.core.JaCoCo;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -44,7 +44,7 @@ public final class MethodProbesAdapter extends MethodVisitor {
 	 */
 	public MethodProbesAdapter(final MethodProbesVisitor probesVisitor,
 			final IProbeIdGenerator idGenerator) {
-		super(JaCoCo.ASM_API_VERSION, probesVisitor);
+		super(InstrSupport.ASM_API_VERSION, probesVisitor);
 		this.probesVisitor = probesVisitor;
 		this.idGenerator = idGenerator;
 		this.tryCatchProbeLabels = new HashMap<Label, Label>();

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesVisitor.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.internal.flow;
 
-import org.jacoco.core.JaCoCo;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
@@ -35,7 +35,7 @@ public abstract class MethodProbesVisitor extends MethodVisitor {
 	 *            optional next visitor in chain
 	 */
 	public MethodProbesVisitor(final MethodVisitor mv) {
-		super(JaCoCo.ASM_API_VERSION, mv);
+		super(InstrSupport.ASM_API_VERSION, mv);
 	}
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodSanitizer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodSanitizer.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.internal.flow;
 
-import org.jacoco.core.JaCoCo;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.commons.JSRInlinerAdapter;
@@ -33,7 +33,7 @@ class MethodSanitizer extends JSRInlinerAdapter {
 	MethodSanitizer(final MethodVisitor mv, final int access,
 			final String name, final String desc, final String signature,
 			final String[] exceptions) {
-		super(JaCoCo.ASM_API_VERSION, mv, access, name, desc, signature,
+		super(InstrSupport.ASM_API_VERSION, mv, access, name, desc, signature,
 				exceptions);
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/DuplicateFrameEliminator.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/DuplicateFrameEliminator.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.jacoco.core.internal.instr;
 
-import org.jacoco.core.JaCoCo;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -27,7 +26,7 @@ class DuplicateFrameEliminator extends MethodVisitor {
 	private boolean instruction;
 
 	public DuplicateFrameEliminator(final MethodVisitor mv) {
-		super(JaCoCo.ASM_API_VERSION, mv);
+		super(InstrSupport.ASM_API_VERSION, mv);
 		instruction = true;
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
@@ -24,6 +24,9 @@ public final class InstrSupport {
 	private InstrSupport() {
 	}
 
+	/** ASM API version */
+	public static final int ASM_API_VERSION = Opcodes.ASM5;
+
 	// === Data Field ===
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.jacoco.core.internal.instr;
 
-import org.jacoco.core.JaCoCo;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -56,7 +55,7 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
 	 */
 	ProbeInserter(final int access, final String name, final String desc, final MethodVisitor mv,
 			final IProbeArrayStrategy arrayStrategy) {
-		super(JaCoCo.ASM_API_VERSION, mv);
+		super(InstrSupport.ASM_API_VERSION, mv);
 		this.clinit = InstrSupport.CLINIT_NAME.equals(name);
 		this.arrayStrategy = arrayStrategy;
 		int pos = (Opcodes.ACC_STATIC & access) == 0 ? 1 : 0;

--- a/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
@@ -19,8 +19,8 @@ import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Field;
 import java.security.ProtectionDomain;
 
-import org.jacoco.core.JaCoCo;
 import org.jacoco.core.internal.Java9Support;
+import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -156,7 +156,7 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 			final String accessFieldName) {
 		final ClassReader reader = new ClassReader(Java9Support.downgradeIfRequired(source));
 		final ClassWriter writer = new ClassWriter(reader, 0);
-		reader.accept(new ClassVisitor(JaCoCo.ASM_API_VERSION, writer) {
+		reader.accept(new ClassVisitor(InstrSupport.ASM_API_VERSION, writer) {
 
 			@Override
 			public void visitEnd() {

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,12 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>Fixed Bugs</h3>
+<ul>
+  <li><code>ExecutionDataWriter.FORMAT_VERSION</code> is not a compile-time constant
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/474">#474</a>).</li>
+</ul>
+
 <h3>API Changes</h3>
 <ul>
   <li><code>JaCoCo.ASM_API_VERSION</code> removed

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,12 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>API Changes</h3>
+<ul>
+  <li><code>JaCoCo.ASM_API_VERSION</code> removed
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/474">#474</a>).</li>
+</ul>
+
 <h2>Release 0.7.8 (2016/12/09)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
In my case, `ExecutionDataWriter.FORMAT_VERSION` is the problematic constant.  We workaround by using reflection to access the field so that javac won't inline the value from the version of the library we use to compile.

I reviewed the `org.jacoco.doc/target/apidocs/constant-values.html`, and `JaCoCo.ASM_API_VERSION` seemed like the only other constant that was likely to cause similar problems for anyone.
