### PR TITLE
Add missing test case that is described in documentation

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -27,9 +27,15 @@ public class ExceptionsTest extends ValidationTestBase {
 	@Test
 	public void testCoverageResult() {
 
-		// 1. Implicit Exception
+		// 0. Implicit NullPointerException
 		// Currently no coverage at all, as we don't see when a block aborts
 		// somewhere in the middle.
+		assertLine("implicitNullPointerException.before", ICounter.NOT_COVERED);
+		assertLine("implicitNullPointerException.exception",
+				ICounter.NOT_COVERED);
+		assertLine("implicitNullPointerException.after", ICounter.NOT_COVERED);
+
+		// 1. Implicit Exception
 		assertLine("implicitException.before", ICounter.FULLY_COVERED);
 		assertLine("implicitException.exception", ICounter.NOT_COVERED);
 		assertLine("implicitException.after", ICounter.NOT_COVERED);
@@ -45,8 +51,6 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("noExceptionTryCatch.catchBlock", ICounter.NOT_COVERED);
 
 		// 4. Try/Catch Block With Exception Thrown Implicitly
-		// As always with implicit exceptions we don't see when a block aborts
-		// somewhere in the middle.
 		assertLine("implicitExceptionTryCatch.beforeBlock",
 				ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionTryCatch.before", ICounter.FULLY_COVERED);

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
@@ -25,6 +25,10 @@ public class Target03 {
 	public static void main(String[] args) {
 
 		try {
+			implicitNullPointerException(null);
+		} catch (NullPointerException e) {
+		}
+		try {
 			implicitException();
 		} catch (StubException e) {
 		}
@@ -45,6 +49,12 @@ public class Target03 {
 			implicitExceptionFinally();
 		} catch (StubException e) {
 		}
+	}
+
+	private static void implicitNullPointerException(int[] a) {
+		nop(); // $line-implicitNullPointerException.before$
+		a[0] = 0; // $line-implicitNullPointerException.exception$
+		nop(); // $line-implicitNullPointerException.after$
 	}
 
 	private static void implicitException() {


### PR DESCRIPTION
This adds test case that is described on page http://www.eclemma.org/jacoco/trunk/doc/flow.html :

> ..  implicit exceptions from other instructions than method invocations (e.g. NullPointerException ...

And removes misleading comments

> Currently no coverage at all, as we don't see when a block aborts somewhere in the middle.

from the cases, where we actually see some coverage, when block aborts in the middle.