### PR TITLE
Add missing assertions

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -53,6 +53,11 @@ public class ExceptionsTest extends ValidationTestBase {
 			/* partly when ECJ: */ICounter.NOT_COVERED);
 		}
 		assertLine("noExceptionTryCatch.catchBlock", ICounter.NOT_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("noExceptionTryCatch.catchBlockEnd",
+			/* empty when ECJ: */ICounter.FULLY_COVERED);
+		}
+		assertLine("noExceptionTryCatch.afterBlock", ICounter.FULLY_COVERED);
 
 		// 4. Try/Catch Block With Exception Thrown Implicitly
 		assertLine("implicitExceptionTryCatch.beforeBlock",
@@ -65,6 +70,12 @@ public class ExceptionsTest extends ValidationTestBase {
 			/* partly when ECJ: */ICounter.FULLY_COVERED);
 		}
 		assertLine("implicitExceptionTryCatch.catchBlock",
+				ICounter.FULLY_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("implicitExceptionTryCatch.catchBlockEnd",
+			/* empty when ECJ: */ICounter.NOT_COVERED);
+		}
+		assertLine("implicitExceptionTryCatch.afterBlock",
 				ICounter.FULLY_COVERED);
 
 		// 5. Try/Catch Block With Exception Thrown Implicitly After Condition
@@ -85,6 +96,9 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("explicitExceptionTryCatch.catch", ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionTryCatch.catchBlock",
 				ICounter.FULLY_COVERED);
+		assertLine("explicitExceptionTryCatch.catchBlockEnd", ICounter.EMPTY);
+		assertLine("explicitExceptionTryCatch.afterBlock",
+				ICounter.FULLY_COVERED);
 
 		// 7. Finally Block Without Exception Thrown
 		// Finally block is yellow as the exception path is missing.
@@ -95,6 +109,11 @@ public class ExceptionsTest extends ValidationTestBase {
 			/* partly when ECJ: */ICounter.EMPTY);
 		}
 		assertLine("noExceptionFinally.finallyBlock", ICounter.PARTLY_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("noExceptionFinally.finallyBlockEnd",
+			/* not covered when ECJ: */ICounter.FULLY_COVERED);
+		}
+		assertLine("noExceptionFinally.afterBlock", ICounter.FULLY_COVERED);
 
 		// 8. Finally Block With Implicit Exception
 		// Finally block is yellow as the non-exception path is missing.
@@ -109,6 +128,11 @@ public class ExceptionsTest extends ValidationTestBase {
 		}
 		assertLine("implicitExceptionFinally.finallyBlock",
 				ICounter.PARTLY_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("implicitExceptionFinally.finallyBlockEnd",
+			/* fully when ECJ: */ICounter.NOT_COVERED);
+		}
+		assertLine("implicitExceptionFinally.afterBlock", ICounter.NOT_COVERED);
 
 		// 9. Finally Block With Exception Thrown Explicitly
 		assertLine("explicitExceptionFinally.beforeBlock",
@@ -121,6 +145,11 @@ public class ExceptionsTest extends ValidationTestBase {
 		}
 		assertLine("explicitExceptionFinally.finallyBlock",
 				ICounter.FULLY_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("explicitExceptionFinally.finallyBlockEnd",
+			/* fully when ECJ: */ICounter.EMPTY);
+		}
+		assertLine("explicitExceptionFinally.afterBlock", ICounter.EMPTY);
 
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -48,6 +48,7 @@ public class ExceptionsTest extends ValidationTestBase {
 		// 3. Try/Catch Block Without Exception Thrown
 		assertLine("noExceptionTryCatch.beforeBlock", ICounter.FULLY_COVERED);
 		assertLine("noExceptionTryCatch.tryBlock", ICounter.FULLY_COVERED);
+		assertLine("noExceptionTryCatch.catch", ICounter.NOT_COVERED);
 		assertLine("noExceptionTryCatch.catchBlock", ICounter.NOT_COVERED);
 
 		// 4. Try/Catch Block With Exception Thrown Implicitly
@@ -56,6 +57,7 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("implicitExceptionTryCatch.before", ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionTryCatch.exception", ICounter.NOT_COVERED);
 		assertLine("implicitExceptionTryCatch.after", ICounter.NOT_COVERED);
+		assertLine("implicitExceptionTryCatch.catch", ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionTryCatch.catchBlock",
 				ICounter.FULLY_COVERED);
 
@@ -74,6 +76,7 @@ public class ExceptionsTest extends ValidationTestBase {
 				ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionTryCatch.before", ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionTryCatch.throw", ICounter.FULLY_COVERED);
+		assertLine("explicitExceptionTryCatch.catch", ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionTryCatch.catchBlock",
 				ICounter.FULLY_COVERED);
 
@@ -81,6 +84,7 @@ public class ExceptionsTest extends ValidationTestBase {
 		// Finally block is yellow as the exception path is missing.
 		assertLine("noExceptionFinally.beforeBlock", ICounter.FULLY_COVERED);
 		assertLine("noExceptionFinally.tryBlock", ICounter.FULLY_COVERED);
+		assertLine("noExceptionFinally.finally", ICounter.EMPTY);
 		assertLine("noExceptionFinally.finallyBlock", ICounter.PARTLY_COVERED);
 
 		// 8. Finally Block With Implicit Exception
@@ -90,6 +94,7 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("implicitExceptionFinally.before", ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionFinally.exception", ICounter.NOT_COVERED);
 		assertLine("implicitExceptionFinally.after", ICounter.NOT_COVERED);
+		assertLine("implicitExceptionFinally.finally", ICounter.EMPTY);
 		assertLine("implicitExceptionFinally.finallyBlock",
 				ICounter.PARTLY_COVERED);
 
@@ -98,6 +103,7 @@ public class ExceptionsTest extends ValidationTestBase {
 				ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionFinally.before", ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionFinally.throw", ICounter.FULLY_COVERED);
+		assertLine("implicitExceptionFinally.finally", ICounter.EMPTY);
 		assertLine("explicitExceptionFinally.finallyBlock",
 				ICounter.FULLY_COVERED);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -103,7 +103,7 @@ public class ExceptionsTest extends ValidationTestBase {
 				ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionFinally.before", ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionFinally.throw", ICounter.FULLY_COVERED);
-		assertLine("implicitExceptionFinally.finally", ICounter.EMPTY);
+		assertLine("explicitExceptionFinally.finally", ICounter.EMPTY);
 		assertLine("explicitExceptionFinally.finallyBlock",
 				ICounter.FULLY_COVERED);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ExceptionsTest.java
@@ -48,7 +48,10 @@ public class ExceptionsTest extends ValidationTestBase {
 		// 3. Try/Catch Block Without Exception Thrown
 		assertLine("noExceptionTryCatch.beforeBlock", ICounter.FULLY_COVERED);
 		assertLine("noExceptionTryCatch.tryBlock", ICounter.FULLY_COVERED);
-		assertLine("noExceptionTryCatch.catch", ICounter.NOT_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("noExceptionTryCatch.catch",
+			/* partly when ECJ: */ICounter.NOT_COVERED);
+		}
 		assertLine("noExceptionTryCatch.catchBlock", ICounter.NOT_COVERED);
 
 		// 4. Try/Catch Block With Exception Thrown Implicitly
@@ -57,7 +60,10 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("implicitExceptionTryCatch.before", ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionTryCatch.exception", ICounter.NOT_COVERED);
 		assertLine("implicitExceptionTryCatch.after", ICounter.NOT_COVERED);
-		assertLine("implicitExceptionTryCatch.catch", ICounter.FULLY_COVERED);
+		if (isJDKCompiler()) {
+			assertLine("implicitExceptionTryCatch.catch",
+			/* partly when ECJ: */ICounter.FULLY_COVERED);
+		}
 		assertLine("implicitExceptionTryCatch.catchBlock",
 				ICounter.FULLY_COVERED);
 
@@ -84,7 +90,10 @@ public class ExceptionsTest extends ValidationTestBase {
 		// Finally block is yellow as the exception path is missing.
 		assertLine("noExceptionFinally.beforeBlock", ICounter.FULLY_COVERED);
 		assertLine("noExceptionFinally.tryBlock", ICounter.FULLY_COVERED);
-		assertLine("noExceptionFinally.finally", ICounter.EMPTY);
+		if (isJDKCompiler()) {
+			assertLine("noExceptionFinally.finally",
+			/* partly when ECJ: */ICounter.EMPTY);
+		}
 		assertLine("noExceptionFinally.finallyBlock", ICounter.PARTLY_COVERED);
 
 		// 8. Finally Block With Implicit Exception
@@ -94,7 +103,10 @@ public class ExceptionsTest extends ValidationTestBase {
 		assertLine("implicitExceptionFinally.before", ICounter.FULLY_COVERED);
 		assertLine("implicitExceptionFinally.exception", ICounter.NOT_COVERED);
 		assertLine("implicitExceptionFinally.after", ICounter.NOT_COVERED);
-		assertLine("implicitExceptionFinally.finally", ICounter.EMPTY);
+		if (isJDKCompiler()) {
+			assertLine("implicitExceptionFinally.finally",
+			/* partly when ECJ: */ICounter.EMPTY);
+		}
 		assertLine("implicitExceptionFinally.finallyBlock",
 				ICounter.PARTLY_COVERED);
 
@@ -103,7 +115,10 @@ public class ExceptionsTest extends ValidationTestBase {
 				ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionFinally.before", ICounter.FULLY_COVERED);
 		assertLine("explicitExceptionFinally.throw", ICounter.FULLY_COVERED);
-		assertLine("explicitExceptionFinally.finally", ICounter.EMPTY);
+		if (isJDKCompiler()) {
+			assertLine("explicitExceptionFinally.finally",
+			/* fully when ECJ: */ICounter.EMPTY);
+		}
 		assertLine("explicitExceptionFinally.finallyBlock",
 				ICounter.FULLY_COVERED);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ImplicitDefaultConstructorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ImplicitDefaultConstructorTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 
 /**
  * Test of a implicit default constructor.
+ *
+ * @see PrivateEmptyDefaultConstructorTest
  */
 public class ImplicitDefaultConstructorTest extends ValidationTestBase {
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/PrivateEmptyDefaultConstructorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/PrivateEmptyDefaultConstructorTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 
 /**
  * Test of a private empty default constructor.
+ *
+ * @see ImplicitDefaultConstructorTest
  */
 public class PrivateEmptyDefaultConstructorTest extends ValidationTestBase {
 
@@ -28,6 +30,7 @@ public class PrivateEmptyDefaultConstructorTest extends ValidationTestBase {
 	public void testCoverageResult() {
 
 		assertLine("classdef", ICounter.EMPTY);
+		assertLine("super", ICounter.NOT_COVERED);
 		assertLine("constructor", ICounter.NOT_COVERED);
 
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -107,6 +107,10 @@ public abstract class ValidationTestBase {
 		analyzer.analyzeClass(bytes, data.getName());
 	}
 
+	boolean isJDKCompiler() {
+		return System.getProperty("bytecode.version") != null;
+	}
+
 	protected void assertLine(final String tag, final int status) {
 		final int nr = source.getLineNumber(tag);
 		final ILine line = sourceCoverage.getLine(nr);

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
@@ -74,8 +74,8 @@ public class Target03 {
 			nop(); // $line-noExceptionTryCatch.tryBlock$
 		} catch (StubException e) { // $line-noExceptionTryCatch.catch$
 			nop(); // $line-noExceptionTryCatch.catchBlock$
-		}
-	}
+		} // $line-noExceptionTryCatch.catchBlockEnd$
+	} // $line-noExceptionTryCatch.afterBlock$
 
 	private static void implicitExceptionTryCatch() {
 		nop(); // $line-implicitExceptionTryCatch.beforeBlock$
@@ -85,8 +85,8 @@ public class Target03 {
 			nop(); // $line-implicitExceptionTryCatch.after$
 		} catch (StubException e) { // $line-implicitExceptionTryCatch.catch$
 			nop(); // $line-implicitExceptionTryCatch.catchBlock$
-		}
-	}
+		} // $line-implicitExceptionTryCatch.catchBlockEnd$
+	} // $line-implicitExceptionTryCatch.afterBlock$
 
 	private static void implicitExceptionTryCatchAfterCondition() {
 		if (f()) { // $line-implicitExceptionTryCatchAfterCondition.condition$
@@ -106,8 +106,8 @@ public class Target03 {
 			throw new StubException(); // $line-explicitExceptionTryCatch.throw$
 		} catch (StubException e) { // $line-explicitExceptionTryCatch.catch$
 			nop(); // $line-explicitExceptionTryCatch.catchBlock$
-		}
-	}
+		} // $line-explicitExceptionTryCatch.catchBlockEnd$
+	} // $line-explicitExceptionTryCatch.afterBlock$
 
 	private static void noExceptionFinally() {
 		nop(); // $line-noExceptionFinally.beforeBlock$
@@ -115,8 +115,8 @@ public class Target03 {
 			nop(); // $line-noExceptionFinally.tryBlock$
 		} finally { // $line-noExceptionFinally.finally$
 			nop(); // $line-noExceptionFinally.finallyBlock$
-		}
-	}
+		} // $line-noExceptionFinally.finallyBlockEnd$
+	} // $line-noExceptionFinally.afterBlock$
 
 	private static void implicitExceptionFinally() {
 		nop(); // $line-implicitExceptionFinally.beforeBlock$
@@ -126,8 +126,8 @@ public class Target03 {
 			nop(); // $line-implicitExceptionFinally.after$
 		} finally { // $line-implicitExceptionFinally.finally$
 			nop(); // $line-implicitExceptionFinally.finallyBlock$
-		}
-	}
+		} // $line-implicitExceptionFinally.finallyBlockEnd$
+	} // $line-implicitExceptionFinally.afterBlock$
 
 	private static void explicitExceptionFinally() {
 		nop(); // $line-explicitExceptionFinally.beforeBlock$
@@ -136,7 +136,7 @@ public class Target03 {
 			throw new StubException(); // $line-explicitExceptionFinally.throw$
 		} finally { // $line-explicitExceptionFinally.finally$
 			nop(); // $line-explicitExceptionFinally.finallyBlock$
-		}
-	}
+		} // $line-explicitExceptionFinally.finallyBlockEnd$
+	} // $line-explicitExceptionFinally.afterBlock$
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target03.java
@@ -113,7 +113,7 @@ public class Target03 {
 		nop(); // $line-noExceptionFinally.beforeBlock$
 		try {
 			nop(); // $line-noExceptionFinally.tryBlock$
-		} finally { // $line-noExceptionFinallyFinally$
+		} finally { // $line-noExceptionFinally.finally$
 			nop(); // $line-noExceptionFinally.finallyBlock$
 		}
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target05.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target05.java
@@ -16,7 +16,7 @@ import static org.jacoco.core.test.validation.targets.Stubs.i1;
 /**
  * This test target is a class with a static initializer.
  */
-public class Target05 { // $line-classdef$
+public class Target05 {
 
 	// No code required to initialize these fields:
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target06.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target06.java
@@ -13,6 +13,8 @@ package org.jacoco.core.test.validation.targets;
 
 /**
  * This test target is a class with a implicit default constructor.
+ *
+ * @see Target07 explicit constructor
  */
 public class Target06 { // $line-classdef$
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target07.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/targets/Target07.java
@@ -13,10 +13,12 @@ package org.jacoco.core.test.validation.targets;
 
 /**
  * This test target is a private empty default constructor.
+ *
+ * @see Target06 implicit constructor
  */
 public class Target07 { // $line-classdef$
 
-	private Target07() {
+	private Target07() { // $line-super$
 	} // $line-constructor$
 
 	public static void main(String[] args) {


### PR DESCRIPTION
There are some unused line markers in validation tests. IMO either they should be removed as they are misleadingly look like important for test, either assertions should be added.