### PR TITLE
MethodAnalyzerTest should not violate contract of ASM API

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -26,6 +26,7 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
+import org.objectweb.asm.util.CheckMethodAdapter;
 
 /**
  * Unit tests for {@link MethodAnalyzer}.
@@ -55,9 +56,13 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	// === Scenario: linear Sequence without branches ===
 
 	private void createLinearSequence() {
-		method.visitLineNumber(1001, new Label());
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
 		method.visitInsn(Opcodes.NOP);
-		method.visitLineNumber(1002, new Label());
+		final Label l1 = new Label();
+		method.visitLabel(l1);
+		method.visitLineNumber(1002, l1);
 		method.visitInsn(Opcodes.RETURN);
 	}
 
@@ -95,11 +100,15 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	// === Scenario: simple if branch ===
 
 	private void createIfBranch() {
-		method.visitLineNumber(1001, new Label());
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
 		method.visitVarInsn(Opcodes.ILOAD, 1);
 		Label l1 = new Label();
 		method.visitJumpInsn(Opcodes.IFEQ, l1);
-		method.visitLineNumber(1002, new Label());
+		final Label l2 = new Label();
+		method.visitLabel(l2);
+		method.visitLineNumber(1002, l2);
 		method.visitLdcInsn("a");
 		method.visitInsn(Opcodes.ARETURN);
 		method.visitLabel(l1);
@@ -156,11 +165,15 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	// === Scenario: branch which merges back ===
 
 	private void createIfBranchMerge() {
-		method.visitLineNumber(1001, new Label());
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
 		method.visitVarInsn(Opcodes.ILOAD, 1);
 		Label l1 = new Label();
 		method.visitJumpInsn(Opcodes.IFEQ, l1);
-		method.visitLineNumber(1002, new Label());
+		final Label l2 = new Label();
+		method.visitLabel(l2);
+		method.visitLineNumber(1002, l2);
 		method.visitInsn(Opcodes.NOP);
 		method.visitLabel(l1);
 		method.visitLineNumber(1003, l1);
@@ -216,7 +229,9 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	// === Scenario: branch which jump backwards ===
 
 	private void createJumpBackwards() {
-		method.visitLineNumber(1001, new Label());
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
 		final Label l1 = new Label();
 		method.visitJumpInsn(Opcodes.GOTO, l1);
 		final Label l2 = new Label();
@@ -302,7 +317,9 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	// === Scenario: table switch ===
 
 	private void createTableSwitch() {
-		method.visitLineNumber(1001, new Label());
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
 		method.visitVarInsn(Opcodes.ILOAD, 1);
 		Label l1 = new Label();
 		Label l2 = new Label();
@@ -312,14 +329,18 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		method.visitLineNumber(1002, l1);
 		method.visitIntInsn(Opcodes.BIPUSH, 11);
 		method.visitVarInsn(Opcodes.ISTORE, 2);
-		method.visitLineNumber(1003, new Label());
+		final Label l4 = new Label();
+		method.visitLabel(l4);
+		method.visitLineNumber(1003, l4);
 		Label l5 = new Label();
 		method.visitJumpInsn(Opcodes.GOTO, l5);
 		method.visitLabel(l2);
 		method.visitLineNumber(1004, l2);
 		method.visitIntInsn(Opcodes.BIPUSH, 22);
 		method.visitVarInsn(Opcodes.ISTORE, 2);
-		method.visitLineNumber(1005, new Label());
+		final Label l6 = new Label();
+		method.visitLabel(l6);
+		method.visitLineNumber(1005, l6);
 		method.visitJumpInsn(Opcodes.GOTO, l5);
 		method.visitLabel(l3);
 		method.visitLineNumber(1006, l3);
@@ -402,10 +423,14 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	// === Scenario: table switch with merge ===
 
 	private void createTableSwitchMerge() {
-		method.visitLineNumber(1001, new Label());
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
 		method.visitInsn(Opcodes.ICONST_0);
 		method.visitVarInsn(Opcodes.ISTORE, 2);
-		method.visitLineNumber(1002, new Label());
+		final Label l1 = new Label();
+		method.visitLabel(l1);
+		method.visitLineNumber(1002, l1);
 		method.visitVarInsn(Opcodes.ILOAD, 1);
 		Label l2 = new Label();
 		Label l3 = new Label();
@@ -559,7 +584,9 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 				probes);
 		final MethodProbesAdapter probesAdapter = new MethodProbesAdapter(
 				analyzer, this);
-		method.accept(probesAdapter);
+		// note that CheckMethodAdapter verifies that this test does not violate
+		// contracts of ASM API
+		method.accept(new CheckMethodAdapter(probesAdapter));
 		result = analyzer.getCoverage();
 	}
 


### PR DESCRIPTION
For some experimental work I tried to implement addition of probe at beginning of method and had hard time to understand inconsistent failures in `MethodAnalyzerTest` - while some tests were failing as expected, others were passing.

Turned out that this was caused by the fact that `MethodAnalyzerTest` violates ASM API - according to [JavaDoc]( http://static.javadoc.io/org.ow2.asm/asm/5.2/org/objectweb/asm/MethodVisitor.html) of `MethodVisitor`:
> visitLineNumber methods must be called after the labels passed as arguments have been visited

As consequence test is less realistic, because simulates behavior that is different from the case when class is loaded from bytecode. Should be noted that such violation is not a big problem to generate bytecode. To demonstrate this asymmetry:
```java
package org.jacoco.core.internal.analysis;

import org.objectweb.asm.ClassReader;
import org.objectweb.asm.ClassWriter;
import org.objectweb.asm.Label;
import org.objectweb.asm.Opcodes;
import org.objectweb.asm.tree.ClassNode;
import org.objectweb.asm.tree.MethodNode;
import org.objectweb.asm.util.TraceClassVisitor;

import java.io.PrintWriter;
import java.util.ArrayList;

public class Example {

	public static void main(String[] args) {
		final ClassNode classNode = new ClassNode();
		classNode.version = Opcodes.V1_6;
		classNode.access = Opcodes.ACC_PUBLIC;
		classNode.name = "Example";
		classNode.superName = "java/lang/Object";

		final MethodNode mn = new MethodNode();
		mn.name = "m";
		mn.desc = "()V";
		mn.exceptions = new ArrayList<String>();

		final Label label = new Label();
		// mn.visitLabel(label);
		mn.visitLineNumber(1, label);
		mn.visitInsn(Opcodes.RETURN);
		classNode.methods.add(mn);

		classNode.accept(newTraceClassVisitor());

		// label "L0" will not be presented in an output for above case,
		// but will be presented in an output for case below,
		// where class loaded from bytecode:
		final ClassWriter cw = new ClassWriter(
				ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
		classNode.accept(cw);

		new ClassReader(cw.toByteArray()).accept(newTraceClassVisitor(), 0);
	}

	private static TraceClassVisitor newTraceClassVisitor() {
		return new TraceClassVisitor(new PrintWriter(System.out));
	}

}
```

IMO test should be fixed to avoid hard debugging time in future and to make test more realistic. As for fix: while we can remove direct usage of `MethodNode` by saving and loading bytes as shown above, I think will be better to simply use API properly.