### PR TITLE
Add TotalCoverage output to maven report

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
@@ -8,6 +8,7 @@
  * Contributors:
  *    Evgeny Mandrikov - initial API and implementation
  *    Kyle Lieber - implementation of CheckMojo
+ *    Maurice Quach - implementation of total coverage
  *
  *******************************************************************************/
 package org.jacoco.maven;
@@ -42,6 +43,7 @@ import org.jacoco.report.check.Rule;
 import org.jacoco.report.check.RulesChecker;
 import org.jacoco.report.csv.CSVFormatter;
 import org.jacoco.report.html.HTMLFormatter;
+import org.jacoco.report.totalcoverage.TotalCoverageFormatter;
 import org.jacoco.report.xml.XMLFormatter;
 
 /**
@@ -113,12 +115,21 @@ final class ReportSupport {
 				targetdir)));
 	}
 
+	public void addTotalCoverageFormatter(final File targetfile,
+			final String encoding) throws IOException {
+		final TotalCoverageFormatter totalCoverageFormatter = new TotalCoverageFormatter();
+		totalCoverageFormatter.setOutputEncoding(encoding);
+		formatters.add(totalCoverageFormatter
+				.createVisitor(new FileOutputStream(targetfile)));
+	}
+
 	public void addAllFormatters(final File targetdir, final String encoding,
 			final String footer, final Locale locale) throws IOException {
 		targetdir.mkdirs();
 		addXmlFormatter(new File(targetdir, "jacoco.xml"), encoding);
 		addCsvFormatter(new File(targetdir, "jacoco.csv"), encoding);
 		addHtmlFormatter(targetdir, encoding, footer, locale);
+		addTotalCoverageFormatter(new File(targetdir, "testcoverage.txt"), encoding);
 	}
 
 	public void addRulesChecker(final List<Rule> rules,

--- a/org.jacoco.report.test/src/org/jacoco/report/totalcoverage/TotalCoverageFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/totalcoverage/TotalCoverageFormatterTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Maurice Quach - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.report.totalcoverage;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jacoco.report.IReportVisitor;
+import org.jacoco.report.MemoryOutput;
+import org.jacoco.report.ReportStructureTestDriver;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TotalCoverageFormatterTest {
+	private static final String expectedPercentage = "60.0";
+
+	private ReportStructureTestDriver driver;
+
+	private TotalCoverageFormatter formatter;
+
+	private IReportVisitor visitor;
+
+	private MemoryOutput output;
+
+	@Before
+	public void setup() throws Exception {
+		driver = new ReportStructureTestDriver();
+		formatter = new TotalCoverageFormatter();
+		output = new MemoryOutput();
+		visitor = formatter.createVisitor(output);
+	}
+
+	@Test
+	public void testPercentage() throws IOException {
+		driver.sendBundle(visitor);
+		final List<String> lines = getLines();
+		assertEquals(expectedPercentage, lines.get(0));
+	}
+
+	@Test
+	public void testSetEncoding() throws Exception {
+		formatter.setOutputEncoding("UTF-16");
+		visitor = formatter.createVisitor(output);
+		driver.sendBundle(visitor);
+		final List<String> lines = getLines("UTF-16");
+		assertEquals(expectedPercentage, lines.get(0));
+	}
+
+	private List<String> getLines() throws IOException {
+		return getLines("UTF-8");
+	}
+
+	private List<String> getLines(String encoding) throws IOException {
+		final BufferedReader reader = new BufferedReader(
+				new InputStreamReader(output.getContentsAsStream(), encoding));
+		final List<String> lines = new ArrayList<String>();
+		String line;
+		while ((line = reader.readLine()) != null) {
+			lines.add(line);
+		}
+		return lines;
+	}
+}

--- a/org.jacoco.report/src/org/jacoco/report/MultiReportVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/MultiReportVisitor.java
@@ -73,7 +73,10 @@ class MultiGroupVisitor implements IReportGroupVisitor {
 	public IReportGroupVisitor visitGroup(final String name) throws IOException {
 		final List<IReportGroupVisitor> children = new ArrayList<IReportGroupVisitor>();
 		for (final IReportGroupVisitor v : visitors) {
-			children.add(v.visitGroup(name));
+			final IReportGroupVisitor group = v.visitGroup(name);
+			if (group != null) {
+				children.add(group);
+			}
 		}
 		return new MultiGroupVisitor(children);
 	}

--- a/org.jacoco.report/src/org/jacoco/report/totalcoverage/TotalCoverageFormatter.java
+++ b/org.jacoco.report/src/org/jacoco/report/totalcoverage/TotalCoverageFormatter.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Maurice Quach - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.report.totalcoverage;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.List;
+
+import org.jacoco.core.analysis.IBundleCoverage;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.data.ExecutionData;
+import org.jacoco.core.data.SessionInfo;
+import org.jacoco.report.IReportGroupVisitor;
+import org.jacoco.report.IReportVisitor;
+import org.jacoco.report.ISourceFileLocator;
+
+/**
+ * Report formatter that will create a single text file containing the coverage
+ * percentage.
+ */
+public class TotalCoverageFormatter {
+	private String outputEncoding = "UTF-8";
+
+	/**
+	 * Sets the encoding used for generated document. Default is UTF-8.
+	 * 
+	 * @param outputEncoding
+	 *            output encoding
+	 */
+	public void setOutputEncoding(final String outputEncoding) {
+		this.outputEncoding = outputEncoding;
+	}
+
+	/**
+	 * Creates a new visitor to write a report to the given stream.
+	 * 
+	 * @param output
+	 *            output stream to write the report to
+	 * @return visitor to emit the report data to
+	 * @throws IOException
+	 *             in case of problems with the output stream
+	 */
+	public IReportVisitor createVisitor(final OutputStream output)
+			throws IOException {
+		final Writer writer = new OutputStreamWriter(output, outputEncoding);
+
+		class Visitor implements IReportVisitor {
+			public void visitInfo(final List<SessionInfo> sessionInfos,
+					final Collection<ExecutionData> executionData)
+					throws IOException {
+				// Info not used
+			}
+
+			public void visitEnd() throws IOException {
+				writer.close();
+			}
+
+			public void visitBundle(final IBundleCoverage bundle,
+					final ISourceFileLocator locator) throws IOException {
+				final ICounter instructionCounter = bundle.getInstructionCounter();
+				final String percentage = String.valueOf(
+						Math.floor(
+								(instructionCounter != null ? 
+										((instructionCounter.getMissedRatio() +
+												instructionCounter.getCoveredCount() == 0) ?
+												0 :
+												instructionCounter.getCoveredRatio())
+										: 0)
+								* 10000) / 100);
+				writer.write(percentage);
+			}
+
+			public IReportGroupVisitor visitGroup(final String name)
+					throws IOException {
+				return null;
+			}
+		}
+		return new Visitor();
+	}
+}


### PR DESCRIPTION
I have written a small formatter to output test coverage percentage to a text file.
In my case, it was useful for Gitlab CI because it avoided installing xml parsing tools on the server.

Here is the .gitlab-ci.yml I am using :

```
test:
  script: 
    - "mvn test"
    - "mvn jacoco:report"
    - "echo \"$(cat target/site/jacoco/testcoverage.txt)% covered\""
```