### PR TITLE
Fix broken links to CSV and XML coverage reports in distribution

### DIFF
--- a/org.jacoco.doc/docroot/index.html
+++ b/org.jacoco.doc/docroot/index.html
@@ -34,8 +34,8 @@
   <li><a href="doc/index.html">Documentation</a></li>
   <li><a href="test/index.html">JUnit Test Results</a></li>
   <li><a href="coverage/index.html">Code Coverage Report</a>
-      (<a href="coverage/coverage.csv">CSV</a>, 
-       <a href="coverage/coverage.xml">XML</a>)</li>
+      (<a href="coverage/jacoco.csv">CSV</a>,
+       <a href="coverage/jacoco.xml">XML</a>)</li>
   <li><a href="doc/changes.html">Change History</a></li>
   <li><a href="doc/license.html">License</a></li>
 </ul>


### PR DESCRIPTION
Currently they point on non existing files. And this is regression that was introduced in version 0.7.7 by commit c181f60ce08ec9b0a6f59a2391c33c41bca8f1c0.

![screenshot](https://cloud.githubusercontent.com/assets/138671/23181728/5dea3e4a-f876-11e6-965a-18701f2541be.png)
