### PR TITLE
Use new compiler detection facility

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ControlStructuresTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ControlStructuresTest.java
@@ -41,8 +41,8 @@ public class ControlStructuresTest extends ValidationTestBase {
 		assertLine("missedelse", ICounter.NOT_COVERED);
 
 		// 4. Missed while block
-		// ECJ and javac produce different status here
-		assertLine("whilefalse", 1, 1);
+		assertLine("whilefalse", isJDKCompiler ? ICounter.FULLY_COVERED
+				: ICounter.PARTLY_COVERED, 1, 1);
 		assertLine("missedwhile", ICounter.NOT_COVERED);
 
 		// 5. Always true while block

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -118,8 +118,9 @@ public abstract class ValidationTestBase {
 		assertEquals(msg, STATUS_NAME[status], STATUS_NAME[insnStatus]);
 	}
 
-	protected void assertLine(final String tag, final int missedBranches,
-			final int coveredBranches) {
+	protected void assertLine(final String tag, final int status,
+			final int missedBranches, final int coveredBranches) {
+		assertLine(tag, status);
 		final int nr = source.getLineNumber(tag);
 		final ILine line = sourceCoverage.getLine(nr);
 		final String msg = String.format("Branches in line %s: %s",
@@ -127,12 +128,6 @@ public abstract class ValidationTestBase {
 		assertEquals(msg + " branches",
 				CounterImpl.getInstance(missedBranches, coveredBranches),
 				line.getBranchCounter());
-	}
-
-	protected void assertLine(final String tag, final int status,
-			final int missedBranches, final int coveredBranches) {
-		assertLine(tag, status);
-		assertLine(tag, missedBranches, coveredBranches);
 	}
 
 	protected void assertLogEvents(String... events) throws Exception {


### PR DESCRIPTION
Use new `ValidationTestBase.isJDKCompiler` constant for missing assertions.