### PR TITLE
[Experimental] Declarative pattern matching

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/pattern/MatchContextTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/pattern/MatchContextTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.pattern;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MatchContext}.
+ */
+public class MatchContextTest {
+
+	private MatchContext ctx;
+
+	@Before
+	public void before() {
+		ctx = new MatchContext();
+	}
+
+	@Test
+	public void isLocal_shouldReturnFalse_whenNoVariableIsSet() {
+		assertFalse(ctx.isLocal(5, "foo"));
+	}
+
+	@Test
+	public void isLocal_shouldReturnFalse_whenOnlyVariableAtLowerIndexIsSet() {
+		ctx.setLocal(2, "foo");
+		assertFalse(ctx.isLocal(200, "foo"));
+	}
+
+	@Test
+	public void isLocal_shouldReturnFalse_whenVariableWithDifferentNameIsSet() {
+		ctx.setLocal(5, "bar");
+		assertFalse(ctx.isLocal(5, "foo"));
+	}
+
+	@Test
+	public void setLocal_shouldOverwritePreviousDefinition_whenNewVariableNameIsGiven() {
+		ctx.setLocal(5, "foo");
+		ctx.setLocal(5, "bar");
+		assertTrue(ctx.isLocal(5, "bar"));
+	}
+
+	@Test
+	public void setLocal_shouldExpandInternalStorage_whenVariableWithBigIndexIsSet() {
+		ctx.setLocal(5, "foo");
+		ctx.setLocal(500, "bar");
+		assertTrue(ctx.isLocal(5, "foo"));
+		assertTrue(ctx.isLocal(500, "bar"));
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SynchronizedFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SynchronizedFilter.java
@@ -19,6 +19,7 @@ import static org.jacoco.core.internal.analysis.pattern.Patterns.choice;
 import static org.jacoco.core.internal.analysis.pattern.Patterns.sequence;
 
 import org.jacoco.core.internal.analysis.pattern.IPattern;
+import org.jacoco.core.internal.analysis.pattern.MatchContext;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
@@ -31,7 +32,7 @@ public final class SynchronizedFilter implements IFilter {
 	private static final IPattern EXCEPTIONAL_EXIT = choice( //
 
 			// javac
-			sequence(ASTORE, ALOAD, MONITOREXIT, ALOAD, ATHROW),
+			sequence(ASTORE("e"), ALOAD, MONITOREXIT, ALOAD("e"), ATHROW),
 
 			// ecj
 			sequence(ALOAD, MONITOREXIT, ATHROW)
@@ -47,8 +48,8 @@ public final class SynchronizedFilter implements IFilter {
 			if (tryCatch.start == tryCatch.handler) {
 				continue;
 			}
-			final AbstractInsnNode toNode = EXCEPTIONAL_EXIT
-					.matchForward(tryCatch.handler);
+			final AbstractInsnNode toNode = EXCEPTIONAL_EXIT.matchForward(
+					tryCatch.handler, new MatchContext());
 			if (toNode != null) {
 				output.ignore(tryCatch.handler, toNode);
 			}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/IPattern.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/IPattern.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.pattern;
+
+import org.objectweb.asm.tree.AbstractInsnNode;
+
+/**
+ * A pattern is a immutable definition of some structure that can be matches
+ * against a bytecode sequence. It is stateless and can be (re-)used
+ * concurrently.
+ */
+public interface IPattern {
+
+	/**
+	 * Matches from the beginning of the pattern starting from a given node.
+	 * 
+	 * @param startNode
+	 *            node to start matching with
+	 * @return last matched node or <code>null</code> if pattern does not match
+	 */
+	AbstractInsnNode matchForward(AbstractInsnNode startNode);
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/IPattern.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/IPattern.java
@@ -25,8 +25,10 @@ public interface IPattern {
 	 * 
 	 * @param startNode
 	 *            node to start matching with
+	 * @param ctx
+	 *            current context to execute the match operation in
 	 * @return last matched node or <code>null</code> if pattern does not match
 	 */
-	AbstractInsnNode matchForward(AbstractInsnNode startNode);
+	AbstractInsnNode matchForward(AbstractInsnNode startNode, MatchContext ctx);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/MatchContext.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/MatchContext.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.pattern;
+
+/**
+ * Internally used context passed through the {@link IPattern}s while matching.
+ * A context can only be used once for matching.
+ */
+public class MatchContext {
+
+	private String[] locals = null;
+
+	boolean isLocal(final int var, final String name) {
+		if (locals == null) {
+			return false;
+		}
+		if (locals.length <= var) {
+			return false;
+		}
+		return name.equals(locals[var]);
+	}
+
+	void setLocal(final int var, final String name) {
+		if (locals == null) {
+			locals = new String[(var + 1) * 2];
+		}
+		if (locals.length <= var) {
+			final String[] newLocals = new String[(var + 1) * 2];
+			System.arraycopy(locals, 0, newLocals, 0, locals.length);
+			locals = newLocals;
+		}
+		locals[var] = name;
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/Patterns.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/pattern/Patterns.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.pattern;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+
+/**
+ * A collection of static factory methods to create {@link IPattern} instances.
+ */
+public final class Patterns {
+
+	private Patterns() {
+	}
+
+	/**
+	 * Combines a sequence of patterns to a new pattern which only matches if
+	 * the patterns match in the given sequence.
+	 * 
+	 * @param sequence
+	 *            sequence of patterns
+	 * @return pattern for the sequence
+	 */
+	public static IPattern sequence(final IPattern... sequence) {
+		return new IPattern() {
+			public AbstractInsnNode matchForward(AbstractInsnNode node) {
+				boolean first = true;
+				for (final IPattern p : sequence) {
+					if (!first) {
+						node = node.getNext();
+					}
+					first = false;
+					if (node == null) {
+						return null;
+					}
+					node = p.matchForward(node);
+					if (node == null) {
+						return null;
+					}
+				}
+				return node;
+			}
+		};
+	}
+
+	/**
+	 * Creates a new matcher that matches if any of the given patterns matches.
+	 * 
+	 * @param choice
+	 *            list of patterns to check one after the other
+	 * @return pattern for the choice
+	 */
+	public static IPattern choice(final IPattern... choice) {
+		return new IPattern() {
+			public AbstractInsnNode matchForward(final AbstractInsnNode node) {
+				for (final IPattern p : choice) {
+					final AbstractInsnNode result = p.matchForward(node);
+					if (result != null) {
+						return result;
+					}
+				}
+				return null;
+			}
+		};
+	}
+
+	/**
+	 * Pattern for a single ALOAD instruction
+	 */
+	public static IPattern ALOAD = new SingleInstructionPattern(Opcodes.ALOAD);
+
+	/**
+	 * Pattern for a single ASTORE instruction
+	 */
+	public static IPattern ASTORE = new SingleInstructionPattern(Opcodes.ASTORE);
+
+	/**
+	 * Pattern for a single ATHROW instruction
+	 */
+	public static IPattern ATHROW = new SingleInstructionPattern(Opcodes.ATHROW);
+
+	/**
+	 * Pattern for a single MONITOREXIT instruction
+	 */
+	public static IPattern MONITOREXIT = new SingleInstructionPattern(
+			Opcodes.MONITOREXIT);
+
+	private static class SingleInstructionPattern implements IPattern {
+		private final int opcode;
+
+		SingleInstructionPattern(final int opcode) {
+			this.opcode = opcode;
+
+		}
+
+		public AbstractInsnNode matchForward(AbstractInsnNode node) {
+			node = skipNonInstructions(node);
+			if (node != null && node.getOpcode() == opcode) {
+				return node;
+			}
+			return null;
+		}
+
+		private AbstractInsnNode skipNonInstructions(AbstractInsnNode node) {
+			while (node != null) {
+				final int type = node.getType();
+				if ((type != AbstractInsnNode.FRAME)
+						&& (type != AbstractInsnNode.LABEL)
+						&& (type != AbstractInsnNode.LINE)) {
+					return node;
+				}
+				node = node.getNext();
+			}
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
@Godin Here is an experimental declarative pattern matching approach. I only applied it to the simple synchronized filter. For the try-with-resources filter of course there is still a long way to go. Also it would be nice to integrate the handler semantic into the matcher.

From my point of view this would simplify filter declaration a lot.

As discussed before this is **not** meant to be mandatory for merging new filters!

