### PR TITLE
Provide more context information when unable to read input during instrumentation

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -212,11 +212,11 @@ public class CoverageTransformerTest {
 					protectionDomain, null);
 			fail("IllegalClassFormatException expected.");
 		} catch (IllegalClassFormatException e) {
-			assertEquals("Error while instrumenting class org.jacoco.Sample.",
+			assertEquals("Error while instrumenting org.jacoco.Sample.",
 					e.getMessage());
 		}
 		recorder.assertException(IllegalClassFormatException.class,
-				"Error while instrumenting class org.jacoco.Sample.",
+				"Error while instrumenting org.jacoco.Sample.",
 				IOException.class);
 		recorder.clear();
 	}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -38,6 +38,13 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/498">#498</a>).</li>
 </ul>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>More information about context is provided when unable to read input during
+      instrumentation
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/527">#527</a>).</li>
+</ul>
+
 <h2>Release 0.7.9 (2017/02/05)</h2>
 
 <h3>Fixed Bugs</h3>


### PR DESCRIPTION
In #400 we updated `Analyzer`, but not `Instrumenter`.

So that for example for the same `broken.zip` `Analyzer.analyzeAll` produces:
```
java.io.IOException: Error while analyzing /tmp/jacoco/in/broken.zip@brokenentry.txt.
```

while `Instrumenter.instrumentAll`:
```
java.util.zip.ZipException: invalid distance too far back
```

This difference is also visible between Ant tasks `report` and `instrument` when they used for archives that contain corrupted nested archives - in a stack trace in case of `report` name of a nested corrupted archive is shown, while in case of `instrument` not.