### PR TITLE
Improve Documentation about StackOverflowError Situations

### DIFF
--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -149,6 +149,21 @@
   classpath and accessible from by the instrumented classes. 
 </p>
 
+<h3>Why do I get a <code>StackOverflowError</code> during code coverage analysis?</h3>
+<p>
+  There are two known reasons for this:
+</p>
+<ul>
+  <li>Misconfiguration: If you configure two JaCoCo agents of different releases
+      they will instrument each other and cause a endless recursion. Check the
+      effective java command line and avoid such configurations.</li>
+  <li>Heavy stack usage: JaCoCo instrumentation adds a small runtime overhead
+      by adding a local variable to each method. If your application is already
+      close to the maximum stack size this can eventually lead to an
+      <code>StackOverflowError</code>. Increase the maximum java stack size with
+      the <code>-Xss</code> JVM option.</li>
+</ul>
+
 </div>
 <div class="footer">
   <span class="right"><a href="@jacoco.home.url@">JaCoCo</a> @qualified.bundle.version@</span>


### PR DESCRIPTION
I have a project which is validating html content using nu.validator in unit tests. Works fine but when I instrument it with jacoco it's going nuts.

I end up with the following java.lang.StackOverflowError:

```
java.lang.StackOverflowError
	at com.thaiopensource.relaxng.impl.DuplicateAttributeDetector$Alternative.<init>(Unknown Source)
	at com.thaiopensource.relaxng.impl.DuplicateAttributeDetector$Alternative.<init>(Unknown Source)
	at com.thaiopensource.relaxng.impl.DuplicateAttributeDetector.startChoice(Unknown Source)
	at com.thaiopensource.relaxng.impl.ChoicePattern.checkRestrictions(Unknown Source)
	at com.thaiopensource.relaxng.impl.ChoicePattern.checkRestrictions(Unknown Source)
	at com.thaiopensource.relaxng.impl.ChoicePattern.checkRestrictions(Unknown Source)
	at com.thaiopensource.relaxng.impl.ChoicePattern.checkRestrictions(Unknown Source)
        ...
```

Here is a simple project to reproduce the bug:
[stackoverflow.zip](https://github.com/jacoco/jacoco/files/976090/stackoverflow.zip)

Note that it's a little flickering (I get the StackOverflowError almost all the time but from time to time it's passing).

See also https://github.com/validator/validator/issues/505 on nu.validator side.

As a workaround I excluded `**com.thaiopensource.relaxng.impl.**` in jacoco setup.