### PR TITLE
ExecDumpClient should report error when no execution data is retrieved

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/tools/ExecDumpClientTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/tools/ExecDumpClientTest.java
@@ -101,7 +101,7 @@ public class ExecDumpClientTest {
 				// 3. Retry
 				"onConnectionFailure", "onConnecting")
 
-		, callbacks);
+				, callbacks);
 	}
 
 	@Test
@@ -124,6 +124,12 @@ public class ExecDumpClientTest {
 		client.dump((String) null, port);
 		assertFalse(dumpRequested);
 		assertTrue(resetRequested);
+	}
+
+	@Test(expected = IOException.class)
+	public void testNopServer() throws IOException {
+		int port = createNopServer();
+		client.dump((String) null, port);
 	}
 
 	private int getFreePort() throws IOException {
@@ -159,11 +165,27 @@ public class ExecDumpClientTest {
 				dumpRequested = dump;
 				resetRequested = reset;
 				if (dump) {
-					writer.visitSessionInfo(new SessionInfo("TestId", 100, 200));
+					writer.visitSessionInfo(
+							new SessionInfo("TestId", 100, 200));
 				}
 				writer.sendCmdOk();
 			}
 		});
 		reader.read();
 	}
+
+	private int createNopServer() throws IOException {
+		server = new ServerSocket(0, 0, InetAddress.getByName(null));
+		new Thread(new Runnable() {
+			public void run() {
+				try {
+					server.accept().close();
+				} catch (IOException e) {
+					// ignore
+				}
+			}
+		}).start();
+		return server.getLocalPort();
+	}
+
 }

--- a/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
@@ -123,7 +123,10 @@ public class ExecDumpClient {
 					.setExecutionDataVisitor(loader.getExecutionDataStore());
 
 			remoteWriter.visitDumpCommand(dump, reset);
-			remoteReader.read();
+
+			if (!remoteReader.read()) {
+				throw new IOException("Socket closed unexpectedly.");
+			}
 
 		} finally {
 			socket.close();

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -41,6 +41,9 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/529">#529</a>).</li>
   <li>Maven aggregated reports will now also include modules of runtime dependencies
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/498">#498</a>).</li>
+  <li><code>dump</code> commands now report errors when remote connections are
+      closed unexpectedly
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/538">#538</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -41,8 +41,12 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/529">#529</a>).</li>
   <li>Maven aggregated reports will now also include modules of runtime dependencies
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/498">#498</a>).</li>
-  <li><code>dump</code> commands now report errors when remote connections are
-      closed unexpectedly
+</ul>
+
+<h3>Fixed Bugs</h3>
+<ul>
+  <li><code>dump</code> commands now report error when server unexpectedly
+      closes connection without sending response
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/538">#538</a>).</li>
 </ul>
 

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataClient.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataClient.java
@@ -55,7 +55,9 @@ public final class ExecutionDataClient {
 
 		// Send a dump command and read the response:
 		writer.visitDumpCommand(true, false);
-		reader.read();
+		if (!reader.read()) {
+			throw new IOException("Socket closed unexpectedly.");
+		}
 
 		socket.close();
 		localFile.close();


### PR DESCRIPTION
Ant and Maven `dump` commands use the `ExecDumpClient` class from the `org.jacoco.core` module. This utility does not evaluate the response status after sending a `dump` request. If the remote closes the connection without sending a response this is silently ignored.

Expected behavior is that a `IOException` is thrown when a `dump` request is not answered. 