### PR TITLE
Method Analyzer.analyzeClass(InputStream, String) as others should provide context information when unable to read input during analysis

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -125,6 +125,27 @@ public class AnalyzerTest {
 		}
 	}
 
+	private static class BrokenInputStream extends InputStream {
+		@Override
+		public int read() throws IOException {
+			throw new IOException();
+		}
+	}
+
+	/**
+	 * Triggers exception in
+	 * {@link Analyzer#analyzeClass(InputStream, String)}.
+	 */
+	@Test
+	public void testAnalyzeClass_BrokenStream() throws IOException {
+		try {
+			analyzer.analyzeClass(new BrokenInputStream(), "BrokenStream");
+			fail("exception expected");
+		} catch (IOException e) {
+			assertEquals("Error while analyzing BrokenStream.", e.getMessage());
+		}
+	}
+
 	@Test
 	public void testAnalyzeAll_Class() throws IOException {
 		final int count = analyzer.analyzeAll(
@@ -165,12 +186,7 @@ public class AnalyzerTest {
 	@Test
 	public void testAnalyzeAll_Broken() throws IOException {
 		try {
-			analyzer.analyzeAll(new InputStream() {
-				@Override
-				public int read() throws IOException {
-					throw new IOException();
-				}
-			}, "Test");
+			analyzer.analyzeAll(new BrokenInputStream(), "Test");
 			fail("expected exception");
 		} catch (IOException e) {
 			assertEquals("Error while analyzing Test.", e.getMessage());

--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -143,11 +143,13 @@ public class Analyzer {
 	 */
 	public void analyzeClass(final InputStream input, final String location)
 			throws IOException {
+		final byte[] buffer;
 		try {
-			analyzeClass(Java9Support.readFully(input), location);
-		} catch (final RuntimeException e) {
+			buffer = Java9Support.readFully(input);
+		} catch (final IOException e) {
 			throw analyzerError(location, e);
 		}
+		analyzeClass(buffer, location);
 	}
 
 	private IOException analyzerError(final String location,

--- a/org.jacoco.core/src/org/jacoco/core/internal/Java9Support.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/Java9Support.java
@@ -41,9 +41,6 @@ public final class Java9Support {
 	 */
 	public static byte[] readFully(final InputStream is)
 			throws IOException {
-		if (is == null) {
-			throw new IllegalArgumentException();
-		}
 		final byte[] buf = new byte[1024];
 		final ByteArrayOutputStream out = new ByteArrayOutputStream();
 		while (true) {

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -50,6 +50,9 @@
   <li><code>dump</code> commands now report error when server unexpectedly
       closes connection without sending response
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/538">#538</a>).</li>
+  <li>More information about context is provided when unable to read stream during
+      analysis
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/541">#541</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>


### PR DESCRIPTION
This was forgotten in #400 