### PR TITLE
NullPointerException in CLI when instrumenting single class

### DIFF
--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/InstrumentTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/InstrumentTest.java
@@ -54,7 +54,7 @@ public class InstrumentTest extends CommandTestBase {
 	}
 
 	@Test
-	public void should_instrument_class_files_and_copy_resources()
+	public void should_instrument_class_files_and_copy_resources_when_folder_is_given()
 			throws Exception {
 		File destdir = tmp.getRoot();
 
@@ -70,6 +70,25 @@ public class InstrumentTest extends CommandTestBase {
 
 		assertInstrumented(new File(destdir,
 				"org/jacoco/cli/internal/commands/InstrumentTest.class"));
+	}
+
+	@Test
+	public void should_instrument_class_files_to_dest_folder_when_class_files_are_given()
+			throws Exception {
+		File destdir = tmp.getRoot();
+
+		File src = new File(getClassPath(),
+				"org/jacoco/cli/internal/commands/InstrumentTest.class");
+
+		execute("instrument", "--dest", destdir.getAbsolutePath(),
+				src.getAbsolutePath());
+
+		assertOk();
+		assertContains(
+				"[INFO] 1 classes instrumented to " + destdir.getAbsolutePath(),
+				out);
+
+		assertInstrumented(new File(destdir, "InstrumentTest.class"));
 	}
 
 	@Test

--- a/org.jacoco.cli/src/org/jacoco/cli/internal/commands/Instrument.java
+++ b/org.jacoco.cli/src/org/jacoco/cli/internal/commands/Instrument.java
@@ -49,14 +49,19 @@ public class Instrument extends Command {
 	@Override
 	public int execute(final PrintWriter out, final PrintWriter err)
 			throws IOException {
+		final File absoluteDest = dest.getAbsoluteFile();
 		instrumenter = new Instrumenter(
 				new OfflineInstrumentationAccessGenerator());
 		int total = 0;
 		for (final File s : source) {
-			total += instrumentRecursive(s, dest);
+			if (s.isFile()) {
+				total += instrument(s, new File(absoluteDest, s.getName()));
+			} else {
+				total += instrumentRecursive(s, absoluteDest);
+			}
 		}
 		out.printf("[INFO] %s classes instrumented to %s.%n",
-				Integer.valueOf(total), dest.getAbsolutePath());
+				Integer.valueOf(total), absoluteDest);
 		return 0;
 	}
 


### PR DESCRIPTION
```
java -jar jacococli.jar instrument Example.class --dest instrumented
```

leads to

```
Exception in thread "main" java.lang.NullPointerException
	at org.jacoco.cli.internal.commands.Instrument.instrument(Instrument.java:78)
	at org.jacoco.cli.internal.commands.Instrument.instrumentRecursive(Instrument.java:72)
	at org.jacoco.cli.internal.commands.Instrument.execute(Instrument.java:56)
	at org.jacoco.cli.internal.Main.execute(Main.java:89)
	at org.jacoco.cli.internal.Main.main(Main.java:104)
```

while

```
java -jar jacococli.jar instrument Example.class --dest ./instrumented
```

works and produces file `/tmp/./instrumented`

```
[INFO] 1 classes instrumented to /tmp/./instrumented.
```

however description of `--dest` option:

```
--dest <dir>  : path to write instrumented Java classes to
```
