### PR TITLE
Reduce chance of conflict with other agents

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
@@ -52,7 +52,7 @@ public final class PreMain {
 
 	private static IRuntime createRuntime(final Instrumentation inst)
 			throws Exception {
-		return ModifiedSystemClassRuntime.createFor(inst, "java/util/UUID");
+		return ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError");
 	}
 
 }

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -53,6 +53,8 @@
   <li>More information about context is provided when unable to read stream during
       analysis
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/541">#541</a>).</li>
+  <li>Reduced chance of conflict with other agents
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/555">#555</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>

--- a/org.jacoco.doc/docroot/doc/implementation.html
+++ b/org.jacoco.doc/docroot/doc/implementation.html
@@ -215,7 +215,9 @@ boolean[] probes = (boolean[]) args[0];
 <p>
   The current JaCoCo Java agent implementation uses the 
   <code>ModifiedSystemClassRuntime</code> adding a field to the class
-  <code>java.util.UUID</code>.
+  <code>java.lang.UnknownError</code>. Versions 0.5.0 - 0.7.9 were adding field
+  to the class <code>java.util.UUID</code>, having bigger chance of conflict
+  with other agents.
 </p>
 
 


### PR DESCRIPTION
As was discussed in #551 : `java/lang/UnknownError` is intended for use by Virtual Machine and in rare situations, so seems that probability that it is used by other Java agents is lower compared to `java/util/UUID` and hence we should change code to use it for communication between instrumented classes and agent. In case if even this class is used by other agents, recommendation remains the same - JaCoCo agent should be the first one specified on the command line. Page "Implementation Design" in documentation should be updated accordingly.