### PR TITLE
Update documentation for published Maven artifacts

### DIFF
--- a/org.jacoco.doc/docroot/doc/repo.html
+++ b/org.jacoco.doc/docroot/doc/repo.html
@@ -48,7 +48,7 @@
 <h2>Artifacts</h2>
 
 <p>
-  JaCoCo is split into several separate projects, the artifact ids are:   
+  Following JAR files are available:
 </p>
 
 <table class="coverage">
@@ -56,6 +56,7 @@
     <tr>
       <td>Group ID</td>
       <td>Artifact ID</td>
+      <td>Classifier</td>
       <td>Description</td>
     </tr>
   </thead>
@@ -63,26 +64,55 @@
     <tr>
       <td><code>org.jacoco</code></td>
       <td><code>jacoco-maven-plugin</code></td>
-      <td>Plug-in for Maven builds</td>
+      <td></td>
+      <td>Plug-in for Maven</td>
     </tr>
     <tr>
       <td><code>org.jacoco</code></td>
       <td><code>org.jacoco.agent</code></td>
+      <td></td>
       <td>API to get a local copy of the agent</td>
     </tr>
     <tr>
       <td><code>org.jacoco</code></td>
+      <td><code>org.jacoco.agent</code></td>
+      <td><code>runtime</code></td>
+      <td>Agent</td>
+    </tr>
+    <tr>
+      <td><code>org.jacoco</code></td>
       <td><code>org.jacoco.ant</code></td>
+      <td></td>
       <td>Ant Tasks</td>
     </tr>
     <tr>
       <td><code>org.jacoco</code></td>
+      <td><code>org.jacoco.ant</code></td>
+      <td><code>nodeps</code></td>
+      <td>Ant Tasks <i>(all dependencies included)</i></td>
+    </tr>
+    <tr>
+      <td><code>org.jacoco</code></td>
+      <td><code>org.jacoco.cli</code></td>
+      <td></td>
+      <td>Command Line Interface</td>
+    </tr>
+    <tr>
+      <td><code>org.jacoco</code></td>
+      <td><code>org.jacoco.cli</code></td>
+      <td><code>nodeps</code></td>
+      <td>Command Line Interface <i>(all dependencies included)</i></td>
+    </tr>
+    <tr>
+      <td><code>org.jacoco</code></td>
       <td><code>org.jacoco.core</code></td>
+      <td></td>
       <td>Core APIs and implementations</td>
     </tr>
     <tr>
       <td><code>org.jacoco</code></td>
       <td><code>org.jacoco.report</code></td>
+      <td></td>
       <td>Reporting implementation</td>
     </tr>
   </tbody>


### PR DESCRIPTION
In [`repo.html`](http://www.jacoco.org/jacoco/trunk/doc/repo.html) we describe some of the artifacts we deliver to maven. The list should be completed to list all artifacts along with their respective Maven classifiers - see https://github.com/jacoco/jacoco/pull/525#discussion_r117549648