### PR TITLE
Regression in 0.7.9: "help" goal is not available in jacoco-maven-plugin

### DIFF
--- a/jacoco-maven-plugin.test/it/setup-parent/invoker.properties
+++ b/jacoco-maven-plugin.test/it/setup-parent/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = org.jacoco:jacoco-maven-plugin:${project.version}:help install

--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -116,13 +116,9 @@
           <execution>
             <id>default-descriptor</id>
             <phase>process-classes</phase>
-            <goals>
-              <goal>descriptor</goal>
-            </goals>
           </execution>
           <execution>
-            <id>help-mojo</id>
-            <phase>process-classes</phase>
+            <id>help-goal</id>
             <goals>
               <goal>helpmojo</goal>
             </goals>

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -337,7 +337,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.3</version>
+          <version>3.5</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -55,6 +55,8 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/541">#541</a>).</li>
   <li>Reduced chance of conflict with other agents
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/555">#555</a>).</li>
+  <li>Restored Maven <code>help</code> goal that was missing in version 0.7.9
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/559">#559</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>


### PR DESCRIPTION
```
mvn org.jacoco:jacoco-maven-plugin:0.7.8:help
```

works, while

```
mvn org.jacoco:jacoco-maven-plugin:0.7.9:help
```

fails as well as

```
mvn org.jacoco:jacoco-maven-plugin:0.7.10-SNAPSHOT:help
```
