### PR TITLE
Improve FAQ about "ClassNotFoundException: org.jacoco.agent[...]Offline"

### DIFF
--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -141,7 +141,9 @@
   <code>-Xshareclasses:none</code>.
 </p>
 
-<h3>Why do I get an error "<code>ClassNotFoundException: org.jacoco.agent[...]Offline</code>"?</h3>
+<h3>Why do I get a <code>NoClassDefFoundError</code> or
+    <code>ClassNotFoundException</code> for class
+    <code>org.jacoco.agent[...]Offline</code>?</h3>
 <p>
   If you use <a href="offline.html">offline instrumentation</a> the instrumented
   classes get a direct dependency on the JaCoCo runtime. Therefore


### PR DESCRIPTION
According to documentation of [`java.lang.ClassNotFoundException`](https://docs.oracle.com/javase/8/docs/api/java/lang/ClassNotFoundException.html):

> Thrown when an application tries to load in a class through its string name using:
> * The forName method in class Class.
> * The findSystemClass method in class ClassLoader .
> * The loadClass method in class ClassLoader.

and we do not use directly/explicitly any of them for `org/jacoco/agent/rt/.../Offline` that is part of direct method call. Situation described in FAQ:

```
$ cat <<END > App.java
class App {
  public static void main(String[] args) {
  }
}
END

$ javac App.java

$ java -jar jacococli.jar instrument App.class --dest instrumented

$ java -cp instrumented App
```

leads to:

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/jacoco/agent/rt/internal_8087725/Offline
        at App.$jacocoInit(App.java)
        at App.main(App.java)
Caused by: java.lang.ClassNotFoundException: org.jacoco.agent.rt.internal_8087725.Offline
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 2 more
```

which is consistent with documentation of outermost [`java.lang.NoClassDefFoundError`](https://docs.oracle.com/javase/8/docs/api/java/lang/NoClassDefFoundError.html):

> Thrown if the Java Virtual Machine or a ClassLoader instance tries to load in the definition of a class (as part of a normal method call or as part of creating a new instance using the new expression) and no definition of the class could be found.

and as it is outermost, it is seen by users most of the time instead of nested `java.lang.ClassNotFoundException`, espectially when test runners hide nested exceptions - see for example https://stackoverflow.com/a/44855628/244993

Also maybe we can wrap access to class into `try-catch` to provide more user-friendly error message, but of course at a cost of few additional bytecode instructions and entries in constant pool.