### PR TITLE
Fix build for JDK 9 >= b175

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -328,11 +328,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.10.4</version>
           <configuration>
             <quiet>true</quiet>
             <detectOfflineLinks>false</detectOfflineLinks>
           </configuration>
+          <dependencies>
+            <dependency>
+              <!-- Workaround to be able to use JDK 9 >= b175 -->
+              <groupId>commons-lang</groupId>
+              <artifactId>commons-lang</artifactId>
+              <version>2.6</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -413,9 +421,9 @@
         </plugin>
         <!-- Third-party plugins -->
         <plugin>
-          <groupId>org.codehaus.groovy.maven</groupId>
-          <artifactId>gmaven-plugin</artifactId>
-          <version>1.0</version>
+          <groupId>com.github.genthaler</groupId>
+          <artifactId>beanshell-maven-plugin</artifactId>
+          <version>1.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -586,28 +594,38 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.groovy.maven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
+        <groupId>com.github.genthaler</groupId>
+        <artifactId>beanshell-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>parse-version</id>
             <phase>validate</phase>
             <goals>
-              <goal>execute</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <source>
-                major = project.properties['parsedVersion.majorVersion']
-                minor = project.properties['parsedVersion.minorVersion']
-                incremental = project.properties['parsedVersion.incrementalVersion']
-                qualifier = "${maven.build.timestamp}"
-                project.properties['buildQualifier'] = qualifier
-                project.properties['unqualifiedVersion'] = major + '.' + minor + '.' + incremental
-                project.properties['qualified.bundle.version'] = project.properties['unqualifiedVersion'] + '.' + project.properties['buildQualifier']
-                project.properties['build.date'] = qualifier.substring(0, 4) + '/' + qualifier.substring(4, 6) + '/' + qualifier.substring(6, 8)
-                buildNumber = project.properties['buildNumber']
-                project.properties['jacoco.runtime.package.name'] = "org.jacoco.agent.rt.internal_" + buildNumber.substring(buildNumber.length() - 7, buildNumber.length())
-              </source>
+              <quiet>true</quiet>
+              <script><![CDATA[
+                major = project.getProperties().get("parsedVersion.majorVersion");
+                minor = project.getProperties().get("parsedVersion.minorVersion");
+                incremental = project.getProperties().get("parsedVersion.incrementalVersion");
+                unqualifiedVersion = major + "." + minor + "." + incremental;
+                project.getProperties().setProperty("unqualifiedVersion", unqualifiedVersion);
+
+                qualifier = "${maven.build.timestamp}";
+                project.getProperties().setProperty("buildQualifier", qualifier);
+
+                qualifiedVersion = unqualifiedVersion + "." + qualifier;
+                project.getProperties().setProperty("qualified.bundle.version", qualifiedVersion);
+
+                buildDate = qualifier.substring(0, 4) + "/" + qualifier.substring(4, 6) + "/" + qualifier.substring(6, 8);
+                project.getProperties().setProperty("build.date", buildDate);
+
+                buildNumber = project.getProperties().get("buildNumber");
+                pkgName = buildNumber.substring(buildNumber.length() - 7, buildNumber.length());
+                project.getProperties().setProperty("jacoco.runtime.package.name", "org.jacoco.agent.rt.internal_" + pkgName);
+              ]]>
+              </script>
             </configuration>
           </execution>
         </executions>

--- a/org.jacoco.core.test/src-java7/org/jacoco/core/test/filter/TryWithResourcesTest.java
+++ b/org.jacoco.core.test/src-java7/org/jacoco/core/test/filter/TryWithResourcesTest.java
@@ -164,7 +164,7 @@ public class TryWithResourcesTest extends ValidationTestBase {
 		// empty when EJC:
 		if (isJDKCompiler) {
 			final String jdkVersion = System.getProperty("java.version");
-			if (jdkVersion.startsWith("9-")) {
+			if (jdkVersion.startsWith("9")) {
 				assertLine("empty.close", ICounter.FULLY_COVERED, 0, 0);
 			} else {
 				// branches with javac 7 and 8


### PR DESCRIPTION
`java.version` in JDK 9 < b175 was `9-ea`, while for >= b175 it is `9`, which causes

```
Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 1
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3116)
	at java.base/java.lang.String.substring(String.java:1885)
	at org.apache.commons.lang.SystemUtils.getJavaVersionAsFloat(SystemUtils.java:1133)
```

in version of `commons-lang` that is used by some Maven plugins:

* maven-javadoc-plugin - https://issues.apache.org/jira/browse/MJAVADOC-485
* gmaven-plugin
