### PR TITLE
For Java 9 add "Automatic-Module-Name" to manifests of JAR files

### DIFF
--- a/org.jacoco.agent.rt/pom.xml
+++ b/org.jacoco.agent.rt/pom.xml
@@ -72,6 +72,7 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Premain-Class>${jacoco.runtime.package.name}.PreMain</Premain-Class>
+                    <Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
                     <Implementation-Title>${project.description}</Implementation-Title>
                     <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                     <Implementation-Version>${project.version}</Implementation-Version>

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -636,6 +636,7 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
+            <Automatic-Module-Name>${project.artifactId}</Automatic-Module-Name>
             <Bundle-Version>${qualified.bundle.version}</Bundle-Version>
             <Bundle-Name>${project.description}</Bundle-Name>
             <Export-Package>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -43,6 +43,8 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/498">#498</a>).</li>
   <li>JaCoCo now comes with a simple command line interface
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/525">#525</a>).</li>
+  <li>Manifests of JAR files now have <code>Automatic-Module-Name</code> for Java 9
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/565">#565</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>


### PR DESCRIPTION
There is no doubts about module names and their usefulness for the following JARs:
* `org.jacoco.core` for `org.jacoco.core-<VERSION>.jar`
* `org.jacoco.report` for `org.jacoco.report-<VERSION>.jar`
* `org.jacoco.ant` for `org.jacoco.ant-<VERSION>.jar`

Also seems that module name is useful for agent (see #545). While there might be debate about its name and name for `org.jacoco.agent-<VERSION>.jar` that contains first one as a resource and whose existence might also be a subject of discussion, we can start with
* `org.jacoco.agent.rt` for `jacocoagent.jar` - consistent with names of packages inside JARs. 
Should also be noted that I don't think that existence of class `com.vladium.emma.RT` in this JAR is a problem - anyway can be solved later when/if it will turn out to be a problem
* `org.jacoco.agent` for `org.jacoco.agent-<VERSION>.jar` - consistent with name of package inside JAR and OSGi bundle name
