### PR TITLE
Add Artifact.SCOPE_PROVIDED artifacts to aggregate report

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -42,8 +42,8 @@ import org.jacoco.report.IReportGroupVisitor;
  * </p>
  * 
  * <ul>
- * <li><code>compile</code>, <code>runtime</code>: Project source and execution
- * data is included in the report.</li>
+ * <li><code>compile</code>, <code>runtime</code>, <code>provided</code>:
+ * Project source and execution data is included in the report.</li>
  * <li><code>test</code>: Only execution data is considered for the report.</li>
  * </ul>
  * 
@@ -106,7 +106,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 		loadExecutionData(support, filter, getProject().getBasedir());
 		for (final MavenProject dependency : findDependencies(
 				Artifact.SCOPE_COMPILE, Artifact.SCOPE_RUNTIME,
-				Artifact.SCOPE_TEST)) {
+				Artifact.SCOPE_PROVIDED, Artifact.SCOPE_TEST)) {
 			loadExecutionData(support, filter, dependency.getBasedir());
 		}
 	}
@@ -130,7 +130,8 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 			final ReportSupport support) throws IOException {
 		final IReportGroupVisitor group = visitor.visitGroup(title);
 		for (final MavenProject dependency : findDependencies(
-				Artifact.SCOPE_COMPILE, Artifact.SCOPE_RUNTIME)) {
+				Artifact.SCOPE_COMPILE, Artifact.SCOPE_RUNTIME,
+				Artifact.SCOPE_PROVIDED)) {
 			support.processProject(group, dependency.getArtifactId(),
 					dependency, getIncludes(), getExcludes(), sourceEncoding);
 		}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -39,8 +39,10 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/513">#513</a>).</li>
   <li>Exclude from a report private empty constructors that do not have arguments
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/529">#529</a>).</li>
-  <li>Maven aggregated reports will now also include modules of runtime dependencies
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/498">#498</a>).</li>
+  <li>Maven aggregated reports will now also include modules of <code>runtime</code>
+      and <code>provided</code> dependencies
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/498">#498</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/572">#572</a>).</li>
   <li>JaCoCo now comes with a simple command line interface
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/525">#525</a>).</li>
   <li>Manifests of JAR files now have <code>Automatic-Module-Name</code> for Java 9


### PR DESCRIPTION
I have an aggregate maven project where one of the projects must be scoped as 'provided'.  I would like it to be still considered for inclusion in the aggregate report.