### PR TITLE
Add --verbose option to classinfo

### DIFF
--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/CommandTestBase.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/CommandTestBase.java
@@ -12,6 +12,7 @@
 package org.jacoco.cli.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.PrintWriter;
@@ -57,6 +58,11 @@ public abstract class CommandTestBase {
 	protected void assertContains(String expected, StringWriter buffer) {
 		final String content = buffer.toString();
 		assertTrue(content, content.contains(expected));
+	}
+
+	protected void assertContainsNot(String expected, StringWriter buffer) {
+		final String content = buffer.toString();
+		assertFalse(content, content.contains(expected));
 	}
 
 	protected String getClassPath() {

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ClassInfoTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ClassInfoTest.java
@@ -45,10 +45,19 @@ public class ClassInfoTest extends CommandTestBase {
 		execute("classinfo", getClassPath());
 
 		assertOk();
-		assertContains(
-				"class name:   org/jacoco/cli/internal/commands/ClassInfoTest",
-				out);
-		assertContains("methods:      4", out);
+		assertContains("class", out);
+		assertContains("org/jacoco/cli/internal/commands/ClassInfoTest", out);
+		assertContainsNot("method", out);
+	}
+
+	@Test
+	public void should_print_class_details_when_verbose() throws Exception {
+		execute("classinfo", "--verbose", getClassPath());
+
+		assertOk();
+		assertContains("line", out);
+		assertContains("method", out);
+		assertContains("line", out);
 	}
 
 }


### PR DESCRIPTION
While analyzing reported issue I extended the `classinfo` command to provide details about every method and line. As this was useful to quickly spot an issue I decided to provide an official option for this.