### PR TITLE
Support system properties when using Maven

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
@@ -35,7 +35,7 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 	 * use wildcard characters (* and ?). When not specified everything will be
 	 * included.
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.includes")
 	private List<String> includes;
 
 	/**
@@ -43,7 +43,7 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 	 * May use wildcard characters (* and ?). When not specified nothing will be
 	 * excluded.
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.excludes")
 	private List<String> excludes;
 
 	/**

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -50,7 +50,7 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 	 *
 	 * @since 0.7.7
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.footer")
 	String footer;
 
 	/**
@@ -63,14 +63,14 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 	 * A list of class files to include in the report. May use wildcard
 	 * characters (* and ?). When not specified everything will be included.
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.excludes")
 	List<String> includes;
 
 	/**
 	 * A list of class files to exclude from the report. May use wildcard
 	 * characters (* and ?). When not specified nothing will be excluded.
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.includes")
 	List<String> excludes;
 
 	/**

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -63,14 +63,14 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 	 * A list of class files to include in the report. May use wildcard
 	 * characters (* and ?). When not specified everything will be included.
 	 */
-	@Parameter(property = "jacoco.excludes")
+	@Parameter(property = "jacoco.includes")
 	List<String> includes;
 
 	/**
 	 * A list of class files to exclude from the report. May use wildcard
 	 * characters (* and ?). When not specified nothing will be excluded.
 	 */
-	@Parameter(property = "jacoco.includes")
+	@Parameter(property = "jacoco.excludes")
 	List<String> excludes;
 
 	/**

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -57,7 +57,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	 * project. May use wildcard characters (* and ?). When not specified all
 	 * *.exec files from the target folder will be included.
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.dataFileIncludes")
 	List<String> dataFileIncludes;
 
 	/**
@@ -65,7 +65,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	 * wildcard characters (* and ?). When not specified nothing will be
 	 * excluded.
 	 */
-	@Parameter
+	@Parameter(property = "jacoco.dataFileExcludes")
 	List<String> dataFileExcludes;
 
 	/**


### PR DESCRIPTION
This is a nice to have, support for using `-Djacoco.excludes`.  