### PR TITLE
[dev] enable coverage reporting on a per-commit level

### DIFF
--- a/jacoco-maven-plugin/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/jacoco-maven-plugin/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -19,6 +19,7 @@
           <goal>report</goal>
           <goal>report-integration</goal>
           <goal>report-aggregate</goal>
+          <goal>report-on-commit-coverage</goal>
           <goal>check</goal>
           <goal>dump</goal>
           <goal>instrument</goal>

--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -84,6 +84,31 @@
       <!-- annotations are needed only to build the plugin: -->
       <scope>provided</scope>
     </dependency>
+
+
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit.java7</artifactId>
+      <version>3.7.1.201504261725-r</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <!-- version for Java 7 -->
+      <version>0.6.5.201403032054</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -131,6 +156,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <!-- explicitly make this work with a JDK 7 compiler -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.2</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportOnCommitCoverageMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportOnCommitCoverageMojo.java
@@ -1,0 +1,445 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Julian Gamble - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.maven;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.diff.Edit;
+import org.eclipse.jgit.diff.RawTextComparator;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.DepthWalk;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.io.DisabledOutputStream;
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.tools.ExecFileLoader;
+import org.jacoco.maven.domain.LineContentDiffInfo;
+import org.jacoco.maven.domain.LineDiffInfo;
+import org.jacoco.maven.util.JGitUtils;
+import org.jacoco.report.IReportGroupVisitor;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.*;
+
+/**
+ * Creates a code coverage report showing uncovered lines in each commit
+ *
+ */
+@Mojo(name = "report-on-commit-coverage", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+public class ReportOnCommitCoverageMojo extends AbstractReportMojo {
+
+	private String PROJECT_DIR;
+
+	private String GIT_PATH;
+
+	@Parameter(property = "jacoco.daysBackToCheck", defaultValue = "60")
+	private int daysBackToCheck;
+
+	private DiffFormatter DIFF_FORMATTER = new DiffFormatter(DisabledOutputStream.INSTANCE);
+
+	private Set<LineContentDiffInfo> coverageDiffs;
+
+	/**
+	 * Output directory for the reports. Note that this parameter is only
+	 * relevant if the goal is run from the command line or from the default
+	 * build lifecycle. If the goal is run indirectly as part of a site
+	 * generation, the output directory configured in the Maven Site Plugin is
+	 * used instead.
+	 */
+	@Parameter(defaultValue = "${project.reporting.outputDirectory}/jacoco")
+	private File outputDirectory;
+
+	/**
+	 * File with execution data.
+	 */
+	@Parameter(property = "jacoco.dataFile", defaultValue = "${project.build.directory}/jacoco.exec")
+	private File dataFile;
+
+	/**
+	 * Target directory.
+	 */
+	@Parameter(property = "jacoco.targetDirectory", defaultValue = "${project.build.directory}/")
+	private File targetDir;
+
+	/**
+	 * Report file
+	 */
+	private FileOutputStream fos;
+
+	@Override
+	boolean canGenerateReportRegardingDataFiles() {
+		return dataFile.exists();
+	}
+
+	@Override
+	boolean canGenerateReportRegardingClassesDirectory() {
+		return new File(getProject().getBuild().getOutputDirectory()).exists();
+	}
+
+	@Override
+	void loadExecutionData(final ReportSupport support) throws IOException {
+		support.loadExecutionData(dataFile);
+	}
+
+	@Override
+	void addFormatters(final ReportSupport support, final Locale locale)
+			throws IOException {
+	}
+
+	@Override
+	void createReport(final IReportGroupVisitor visitor,
+			final ReportSupport support) throws IOException {
+		List<RevCommit> commits = getListOfCommits();
+		setupOutputFile();
+
+		Collections.reverse(commits); // show the most recent commit at the end (opposite of git log)
+		System.out.println("----");
+		for (RevCommit commit:commits) {
+			System.out.println("Commit: " + commit.getName() + " - " + commit.getAuthorIdent().getWhen() + " - " + commit.getAuthorIdent().getName() + " - " + commit.getFullMessage());
+			Set<LineContentDiffInfo> unionDiffs = getCoverageOnCommitLines(commit);
+		}
+		fos.close();
+	}
+
+	private void setupOutputFile() {
+		try {
+			File f = new File(outputDirectory,"coverage-per-commit.txt");
+			fos = new FileOutputStream(f);
+			//we will want to print in standard "System.out" and in "file"
+			TeeOutputStream myOut=new TeeOutputStream(System.out, fos);
+			PrintStream ps = new PrintStream(myOut, true); //true - auto-flush after println
+			System.setOut(ps);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected String getOutputDirectory() {
+		return outputDirectory.getAbsolutePath();
+	}
+
+	@Override
+	public void setReportOutputDirectory(final File reportOutputDirectory) {
+		if (reportOutputDirectory != null
+				&& !reportOutputDirectory.getAbsolutePath().endsWith("jacoco")) {
+			outputDirectory = new File(reportOutputDirectory, "jacoco");
+		} else {
+			outputDirectory = reportOutputDirectory;
+		}
+	}
+
+	public String getOutputName() {
+		return "jacoco/index";
+	}
+
+	public String getName(final Locale locale) {
+		return "JaCoCo";
+	}
+
+	private void loadTargetDir() {
+
+		this.PROJECT_DIR = getProject().getBasedir().getAbsolutePath();
+		this.GIT_PATH = PROJECT_DIR + "/.git";
+	}
+
+	private List<RevCommit> getListOfCommits() {
+		loadTargetDir();
+
+		List<RevCommit> result = new ArrayList<RevCommit>();
+
+		FileRepositoryBuilder builder = new FileRepositoryBuilder();
+
+		Repository repository = null;
+		try {
+			repository = builder.setGitDir(new File(GIT_PATH))
+					.readEnvironment() // scan environment GIT_* variables
+					.findGitDir() // scan up the file system tree
+					.build();
+
+			Date date = getDateNDaysAgo(daysBackToCheck);
+
+			String startingCommit = null;//no starting commits
+			result.addAll(JGitUtils.getRevLog(repository, startingCommit, date));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			if (repository != null) {
+				try {
+					repository.close();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+
+			}
+		}
+
+		return result;
+	}
+
+	public int getDaysBackToCheck() {
+		return daysBackToCheck;
+	}
+
+	public void setDaysBackToCheck(int daysBackToCheck) {
+		this.daysBackToCheck = daysBackToCheck;
+	}
+
+	private Date getDateNDaysAgo(int days) {
+		long DAY_IN_MS = 1000 * 60 * 60 * 24;
+		return new Date(System.currentTimeMillis() - (days * DAY_IN_MS));
+	}
+
+	private Set<LineContentDiffInfo> getCoverageOnCommitLines(RevCommit commit) {
+		String commitHash = commit.getName();
+
+		Set<LineDiffInfo> UnFilteredCommitDiffs = getCommitLineDiffs(commitHash);
+
+		Set<LineDiffInfo> commitDiffs = filterOutTestsInDiffs(UnFilteredCommitDiffs);
+
+		//note externalised for caching
+		if (coverageDiffs == null) {
+			coverageDiffs = getCoverageLineDiffs(PROJECT_DIR);
+		}
+
+		Set<LineContentDiffInfo> lineDiffsIntersectingWithCoberturaLines = new HashSet(coverageDiffs);
+		lineDiffsIntersectingWithCoberturaLines.retainAll(commitDiffs);
+		System.out.println("Intersection of line changes with coverage (lines we care about): " + lineDiffsIntersectingWithCoberturaLines.size());
+
+		Set<LineContentDiffInfo> lineDiffsFromCoberturaWithCoverage = getLineDiffsFromCoberturaWithCoverage(lineDiffsIntersectingWithCoberturaLines, true, true);
+		System.out.println("covered lines: " + lineDiffsFromCoberturaWithCoverage.size());
+
+		double coverage = ((double)lineDiffsFromCoberturaWithCoverage.size()) / lineDiffsIntersectingWithCoberturaLines.size();
+		int coveragePercent = (int) Math.ceil(coverage * 100);
+
+		System.out.println("Coverage for commit: " + coveragePercent + "%");
+		Set<LineContentDiffInfo> lineDiffsFromCoberturaWithoutCoverage = getLineDiffsFromCoberturaWithCoverage(lineDiffsIntersectingWithCoberturaLines, false, true);
+		System.out.println("Lines not covered: " + lineDiffsFromCoberturaWithoutCoverage.size());
+
+		if (lineDiffsFromCoberturaWithoutCoverage.size() > 0) {
+			printLineDiffs(lineDiffsFromCoberturaWithoutCoverage);
+		}
+		System.out.println("----");
+
+		return lineDiffsIntersectingWithCoberturaLines;
+	}
+
+	private Set<LineDiffInfo> getCommitLineDiffs(String lastCommit) {
+		Set<LineDiffInfo> result = new HashSet<>();
+
+		Repository repo = getRepository(PROJECT_DIR);
+
+		List<DiffEntry> diffs = getDiffEntries(repo, PROJECT_DIR, lastCommit);
+
+		result = getDiffEntriesToLineDiffInfo(diffs);
+
+
+		return result;
+	}
+
+	private Repository getRepository(String projectDir) {
+		Git git = null;
+		try {
+			git = Git.open(new File(projectDir));
+		} catch (IOException e1) {
+			e1.printStackTrace();
+		}
+		Repository repo = git.getRepository();
+		return repo;
+	}
+
+	private List<DiffEntry> getDiffEntries(Repository repo, String path, String commit) {
+		List<DiffEntry> diffs= new ArrayList<>();
+
+		try {
+			repo = new FileRepository(new File(path + "/.git"));
+			DepthWalk.RevWalk rw = new DepthWalk.RevWalk(repo, 20);
+			RevCommit revCommit = rw.parseCommit(repo.resolve(commit));
+			RevCommit parent = null;
+			if (revCommit.getParents().length != 0) {
+				parent = rw.parseCommit(revCommit.getParent(0).getId());
+			}
+			DIFF_FORMATTER.setRepository(repo);
+			DIFF_FORMATTER.setDiffComparator(RawTextComparator.DEFAULT);
+			DIFF_FORMATTER.setDetectRenames(true);
+
+			RevTree parentTree = parent == null ? null : parent.getTree();
+			diffs = DIFF_FORMATTER.scan(parentTree, revCommit.getTree());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return diffs;
+	}
+
+	private Set<LineDiffInfo> getDiffEntriesToLineDiffInfo(List<DiffEntry> diffs) {
+		Set<LineDiffInfo> result = new HashSet();
+
+		int linesAdded = 0;
+		int linesDeleted = 0;
+
+		for (DiffEntry diff : diffs) {
+			try {
+				for (Edit edit : DIFF_FORMATTER.toFileHeader(diff).toEditList()) {
+					linesDeleted += edit.getEndA() - edit.getBeginA();
+					linesAdded += edit.getEndB() - edit.getBeginB();
+					for (int i = edit.getBeginB(); i<=edit.getEndB();i++) {
+						result.add(new LineDiffInfo(i, diff.getNewPath()));
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+
+		return result;
+	}
+
+	private  Set<LineDiffInfo> filterOutTestsInDiffs(Set<LineDiffInfo> commitDiffs) {
+		Set<LineDiffInfo> result = new HashSet<>(commitDiffs);
+		Set<LineDiffInfo> removalSet = new HashSet<>();
+		for (LineDiffInfo lineDiffInfo: commitDiffs) {
+			if (lineDiffInfo.getFilePackagePathName().contains("Test.java")) {
+				removalSet.add(lineDiffInfo);
+			}
+		}
+		result.removeAll(removalSet);
+		return result;
+	}
+
+	private  Set<LineContentDiffInfo> getCoverageLineDiffs(String projectDir) {
+		Set<LineContentDiffInfo> result = new HashSet<LineContentDiffInfo>();
+
+		Collection<File> sourceFiles = getSourceFiles(projectDir);
+
+		result = getLineDiffInfoFromSourceFiles(sourceFiles);
+
+		return result;
+	}
+
+	private  Collection<File> getSourceFiles(String projectDir) {
+		Collection<File> result = new ArrayList();
+		File directory = new File(projectDir + "/src/main/");
+
+		IOFileFilter fileFilter = new IOFileFilter() {
+			@Override
+			public boolean accept(File file) {
+				if (file.exists()) {
+					return file.getName().contains(".java");
+				}
+				return false;
+			}
+
+			@Override
+			public boolean accept(File dir, String name) {
+				File file = new File(dir, name);
+				if (file.exists()) {
+					return file.getName().contains(".java");
+				}
+				return false;
+			}
+		};
+
+		Collection<File> files = FileUtils.listFiles(directory, fileFilter, TrueFileFilter.INSTANCE);
+
+		return files;
+	}
+
+	private Set<LineContentDiffInfo> getLineDiffInfoFromSourceFiles(Collection<File> sourceFiles) {
+		ExecFileLoader execFileLoader = new ExecFileLoader();
+		try {
+			execFileLoader.load(dataFile);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		final CoverageBuilder coverageBuilder = new CoverageBuilder();
+		final Analyzer analyzer = new Analyzer(
+				execFileLoader.getExecutionDataStore(), coverageBuilder);
+
+		File classesDirectory = new File(targetDir, "/classes");
+
+		try {
+			analyzer.analyzeAll(classesDirectory);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		Set<LineContentDiffInfo> result = new HashSet<LineContentDiffInfo>();
+
+		for (final IClassCoverage cc : coverageBuilder.getClasses()) {
+
+			String className = cc.getName();
+			String fileName = '/' + className.replace('.', '/') + ".java";
+			System.out.println("source file name: " + fileName);
+			File sourceFile = new File(PROJECT_DIR, "src/main/java" + fileName);
+
+			Charset charset = Charset.defaultCharset();
+			List<String> stringList = null;
+			try {
+				stringList = Files.readAllLines(sourceFile.toPath(), charset);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			String[] stringArray = stringList.toArray(new String[]{});
+
+			for (int i = cc.getFirstLine(); i <= cc.getLastLine(); i++) {
+				int lineNumber = i;
+				String codeLine = stringArray[i-1];
+				boolean isCovered = cc.getLine(i).getStatus() == ICounter.FULLY_COVERED;
+				boolean isCoverageApplicable = cc.getLine(i).getStatus() != 0;
+				if (isCoverageApplicable) {
+					result.add(new LineContentDiffInfo(lineNumber, "src/main/java" + fileName, codeLine, isCovered, isCoverageApplicable));
+				}
+			}
+		}
+		return result;
+	}
+
+	private void printLineDiffs(Collection<? extends LineDiffInfo> lineDiffs) {
+		for (LineDiffInfo lineDiff:lineDiffs) {
+			System.out.println(lineDiff.toLineDifferenceString());
+		}
+		System.out.println("");
+	}
+
+	private Set<LineContentDiffInfo> getLineDiffsFromCoberturaWithCoverage(Set<LineContentDiffInfo> lineDiffsIntersectingWithCoberturaLines, boolean isCoveredVal, boolean isCoverageApplicableVal) {
+		Set<LineContentDiffInfo> result = new HashSet<>();
+
+		for (LineContentDiffInfo lineContentDiffInfo: lineDiffsIntersectingWithCoberturaLines) {
+			if (lineContentDiffInfo.isCovered() == isCoveredVal && lineContentDiffInfo.isCoverageApplicable() == isCoverageApplicableVal) {
+				result.add(lineContentDiffInfo);
+			}
+		}
+
+		return result;
+	}
+
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/domain/LineContentDiffInfo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/domain/LineContentDiffInfo.java
@@ -1,0 +1,68 @@
+package org.jacoco.maven.domain;
+
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Julian Gamble - initial API and implementation
+ *
+ *******************************************************************************/
+/**
+ * Retain information from cobertura about covered and uncovered lines we care about
+ * Created by juliangamble on 16/7/17.
+ */
+public class LineContentDiffInfo extends LineDiffInfo {
+    private String content;
+
+    private boolean isCovered;
+
+    private boolean isCoverageApplicable;
+
+    public LineContentDiffInfo(Integer lineNumber, String filePackagePathName, String contentArg, boolean isCoveredArg, boolean isCoverageApplicableArg) {
+        super(lineNumber, filePackagePathName);
+        content = contentArg;
+        isCovered = isCoveredArg;
+        isCoverageApplicable = isCoverageApplicableArg;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public boolean isCovered() {
+        return isCovered;
+    }
+
+    public boolean isCoverageApplicable() {
+        return isCoverageApplicable;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "LineContentDiffInfo{" +
+                "lineNumber=" + lineNumber +
+                ", filePackagePathName='" + filePackagePathName + '\'' +
+                ", content='" + content + '\'' +
+                ", isCovered=" + isCovered +
+                ", isCoverageApplicable=" + isCoverageApplicable +
+                '}';
+    }
+
+    public String toLineDifferenceString() {
+        return filePackagePathName + ":" + lineNumber + " " + content;
+    }
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/domain/LineDiffInfo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/domain/LineDiffInfo.java
@@ -1,0 +1,64 @@
+package org.jacoco.maven.domain;
+
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Julian Gamble - initial API and implementation
+ *
+ *******************************************************************************/
+/**
+ * Retain information from JGit about lines of code that have changed.
+ * Created by juliangamble on 16/7/17.
+ */
+public class LineDiffInfo {
+    protected Integer lineNumber;
+    protected String filePackagePathName;
+
+    public LineDiffInfo(Integer lineNumber, String filePackagePathName) {
+        this.lineNumber = lineNumber;
+        this.filePackagePathName = filePackagePathName;
+    }
+
+    public Integer getLineNumber() {
+        return lineNumber;
+    }
+
+    public String getFilePackagePathName() {
+        return filePackagePathName;
+    }
+
+    @Override
+    public String toString() {
+        return "LineDiffInfo{" +
+                "lineNumber=" + lineNumber +
+                ", filePackagePathName='" + filePackagePathName + '\'' +
+                '}';
+    }
+
+    public String toLineDifferenceString() {
+        return filePackagePathName + ":" + lineNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LineDiffInfo)) return false;
+
+        LineDiffInfo that = (LineDiffInfo) o;
+
+        if (!lineNumber.equals(that.lineNumber)) return false;
+        return filePackagePathName.equals(that.filePackagePathName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = lineNumber.hashCode();
+        result = 31 * result + filePackagePathName.hashCode();
+        return result;
+    }
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/util/JGitUtils.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/util/JGitUtils.java
@@ -1,0 +1,226 @@
+package org.jacoco.maven.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevObject;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.CommitTimeRevFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.*;
+
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    James Moger - initial API and implementation
+ *
+ *******************************************************************************/
+/**
+ * Collection of static methods for retrieving information from a repository.
+ *
+ * @author James Moger
+ *
+ */
+public class JGitUtils {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(JGitUtils.class);
+
+    /**
+     * Returns a list of commits since the minimum date starting from the
+     * specified object id.
+     *
+     * @param repository
+     * @param objectId
+     *            if unspecified, HEAD is assumed.
+     * @param minimumDate
+     * @return list of commits
+     */
+    public static List<RevCommit> getRevLog(Repository repository, String objectId, Date minimumDate) {
+        List<RevCommit> list = new ArrayList<RevCommit>();
+        if (!hasCommits(repository)) {
+            return list;
+        }
+        try {
+            // resolve branch
+            ObjectId branchObject;
+            if (StringUtils.isEmpty(objectId)) {
+                branchObject = getDefaultBranch(repository);
+            } else {
+                branchObject = repository.resolve(objectId);
+            }
+
+            RevWalk rw = new RevWalk(repository);
+            rw.markStart(rw.parseCommit(branchObject));
+            rw.setRevFilter(CommitTimeRevFilter.after(minimumDate));
+            Iterable<RevCommit> revlog = rw;
+            for (RevCommit rev : revlog) {
+                list.add(rev);
+            }
+            rw.dispose();
+        } catch (Throwable t) {
+            error(t, repository, "{0} failed to get {1} revlog for minimum date {2}", objectId,
+                    minimumDate);
+        }
+        return list;
+    }
+
+    /**
+     * Determine if a repository has any commits. This is determined by checking
+     * the for loose and packed objects.
+     *
+     * @param repository
+     * @return true if the repository has commits
+     */
+    public static boolean hasCommits(Repository repository) {
+        if (repository != null && repository.getDirectory().exists()) {
+            return (new File(repository.getDirectory(), "objects").list().length > 2)
+                    || (new File(repository.getDirectory(), "objects/pack").list().length > 0);
+        }
+        return false;
+    }
+
+    /**
+     * Returns the default branch to use for a repository. Normally returns
+     * whatever branch HEAD points to, but if HEAD points to nothing it returns
+     * the most recently updated branch.
+     *
+     * @param repository
+     * @return the objectid of a branch
+     * @throws Exception
+     */
+    public static ObjectId getDefaultBranch(Repository repository) throws Exception {
+        ObjectId object = repository.resolve(Constants.HEAD);
+        if (object == null) {
+            // no HEAD
+            // perhaps non-standard repository, try local branches
+            List<RefModel> branchModels = getLocalBranches(repository, true, -1);
+            if (branchModels.size() > 0) {
+                // use most recently updated branch
+                RefModel branch = null;
+                Date lastDate = new Date(0);
+                for (RefModel branchModel : branchModels) {
+                    if (branchModel.getDate().after(lastDate)) {
+                        branch = branchModel;
+                        lastDate = branch.getDate();
+                    }
+                }
+                object = branch.getReferencedObjectId();
+            }
+        }
+        return object;
+    }
+
+    /**
+     * Returns the list of local branches in the repository. If repository does
+     * not exist or is empty, an empty list is returned.
+     *
+     * @param repository
+     * @param fullName
+     *            if true, /refs/heads/yadayadayada is returned. If false,
+     *            yadayadayada is returned.
+     * @param maxCount
+     *            if < 0, all local branches are returned
+     * @return list of local branches
+     */
+    public static List<RefModel> getLocalBranches(Repository repository, boolean fullName,
+                                                  int maxCount) {
+        return getRefs(repository, Constants.R_HEADS, fullName, maxCount);
+    }
+
+    /**
+     * Retrieves a Java Date from a Git commit.
+     *
+     * @param commit
+     * @return date of the commit or Date(0) if the commit is null
+     */
+    public static Date getAuthorDate(RevCommit commit) {
+        if (commit == null) {
+            return new Date(0);
+        }
+        return commit.getAuthorIdent().getWhen();
+    }
+
+    /**
+     * Returns a list of references in the repository matching "refs". If the
+     * repository is null or empty, an empty list is returned.
+     *
+     * @param repository
+     * @param refs
+     *            if unspecified, all refs are returned
+     * @param fullName
+     *            if true, /refs/something/yadayadayada is returned. If false,
+     *            yadayadayada is returned.
+     * @param maxCount
+     *            if < 0, all references are returned
+     * @return list of references
+     */
+    private static List<RefModel> getRefs(Repository repository, String refs, boolean fullName,
+                                          int maxCount) {
+        List<RefModel> list = new ArrayList<RefModel>();
+        if (maxCount == 0) {
+            return list;
+        }
+        if (!hasCommits(repository)) {
+            return list;
+        }
+        try {
+            Map<String, Ref> map = repository.getRefDatabase().getRefs(refs);
+            RevWalk rw = new RevWalk(repository);
+            for (Map.Entry<String, Ref> entry : map.entrySet()) {
+                Ref ref = entry.getValue();
+                RevObject object = rw.parseAny(ref.getObjectId());
+                String name = entry.getKey();
+                if (fullName && !StringUtils.isEmpty(refs)) {
+                    name = refs + name;
+                }
+                list.add(new RefModel(name, ref, object));
+            }
+            rw.dispose();
+            Collections.sort(list);
+            Collections.reverse(list);
+            if (maxCount > 0 && list.size() > maxCount) {
+                list = new ArrayList<RefModel>(list.subList(0, maxCount));
+            }
+        } catch (IOException e) {
+            error(e, repository, "{0} failed to retrieve {1}", refs);
+        }
+        return list;
+    }
+
+    /**
+     * Log an error message and exception.
+     *
+     * @param t
+     * @param repository
+     *            if repository is not null it MUST be the {0} parameter in the
+     *            pattern.
+     * @param pattern
+     * @param objects
+     */
+    private static void error(Throwable t, Repository repository, String pattern, Object... objects) {
+        List<Object> parameters = new ArrayList<Object>();
+        if (objects != null && objects.length > 0) {
+            for (Object o : objects) {
+                parameters.add(o);
+            }
+        }
+        if (repository != null) {
+            parameters.add(0, repository.getDirectory().getAbsolutePath());
+        }
+        LOGGER.error(MessageFormat.format(pattern, parameters.toArray()), t);
+    }
+
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/util/RefModel.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/util/RefModel.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2011 gitblit.com.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jacoco.maven.util;
+
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevObject;
+import org.eclipse.jgit.revwalk.RevTag;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    James Moger - initial API and implementation
+ *
+ *******************************************************************************/
+/**
+ * RefModel is a serializable model class that represents a tag or branch and
+ * includes the referenced object.
+ *
+ * @author James Moger
+ *
+ */
+public class RefModel implements Serializable, Comparable<RefModel> {
+
+	private static final long serialVersionUID = 1L;
+	public final String displayName;
+	public final RevObject referencedObject;
+	public transient Ref reference;
+
+	public RefModel(String displayName, Ref ref, RevObject refObject) {
+		this.displayName = displayName;
+		this.reference = ref;
+		this.referencedObject = refObject;
+	}
+
+	public Date getDate() {
+		Date date = new Date(0);
+		if (referencedObject != null) {
+			if (referencedObject instanceof RevTag) {
+				RevTag tag = (RevTag) referencedObject;
+				PersonIdent tagger = tag.getTaggerIdent();
+				if (tagger != null) {
+					date = tagger.getWhen();
+				}
+			} else if (referencedObject instanceof RevCommit) {
+				RevCommit commit = (RevCommit) referencedObject;
+				date = JGitUtils.getAuthorDate(commit);
+			}
+		}
+		return date;
+	}
+
+	public String getName() {
+		if (reference == null) {
+			return displayName;
+		}
+		return reference.getName();
+	}
+
+	public int getReferencedObjectType() {
+		int type = referencedObject.getType();
+		if (referencedObject instanceof RevTag) {
+			type = ((RevTag) referencedObject).getObject().getType();
+		}
+		return type;
+	}
+
+	public ObjectId getReferencedObjectId() {
+		if (referencedObject instanceof RevTag) {
+			return ((RevTag) referencedObject).getObject().getId();
+		}
+		return referencedObject.getId();
+	}
+
+	public String getShortMessage() {
+		String message = "";
+		if (referencedObject instanceof RevTag) {
+			message = ((RevTag) referencedObject).getShortMessage();
+		} else if (referencedObject instanceof RevCommit) {
+			message = ((RevCommit) referencedObject).getShortMessage();
+		}
+		return message;
+	}
+
+	public String getFullMessage() {
+		String message = "";
+		if (referencedObject instanceof RevTag) {
+			message = ((RevTag) referencedObject).getFullMessage();
+		} else if (referencedObject instanceof RevCommit) {
+			message = ((RevCommit) referencedObject).getFullMessage();
+		}
+		return message;
+	}
+
+	public PersonIdent getAuthorIdent() {
+		if (referencedObject instanceof RevTag) {
+			return ((RevTag) referencedObject).getTaggerIdent();
+		} else if (referencedObject instanceof RevCommit) {
+			return ((RevCommit) referencedObject).getAuthorIdent();
+		}
+		return null;
+	}
+
+	public ObjectId getObjectId() {
+		return reference.getObjectId();
+	}
+
+	public boolean isAnnotatedTag() {
+		if (referencedObject instanceof RevTag) {
+			return !getReferencedObjectId().equals(getObjectId());
+		}
+		return reference.getPeeledObjectId() != null;
+	}
+
+	@Override
+	public int hashCode() {
+		return getReferencedObjectId().hashCode() + getName().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof RefModel) {
+			RefModel other = (RefModel) o;
+			return getName().equals(other.getName());
+		}
+		return super.equals(o);
+	}
+
+	@Override
+	public int compareTo(RefModel o) {
+		return getDate().compareTo(o.getDate());
+	}
+
+	@Override
+	public String toString() {
+		return displayName;
+	}
+}


### PR DESCRIPTION
This is a new Jacoco Report that shows coverage at a commit level. 

To see an example of this - please see the example project here:
https://github.com/juliangamble/jacoco-example-project

The usage scenario is for large teams on large projects. In this situation, individual team members care less about overall coverage and more about the coverage on the lines they have touched. This plugin enables that team members to say "I'm working on the overall coverage incrementally - for now my commits have 80% coverage."

I'm open to suggestions and feedback about how this could be improved. Please tell me what needs to happen to get this merged into the mainline. 
