### PR TITLE
Yak shaving: determine covered branches for each instruction

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -162,6 +162,66 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		assertLine(1003, 0, 2, 0, 0);
 	}
 
+	// === Scenario: branch before unconditional probe ===
+
+	/**
+	 * Covers case of {@link MethodAnalyzer#visitProbe(int)} after
+	 * {@link MethodAnalyzer#visitJumpInsnWithProbe(int, Label, int, org.jacoco.core.internal.flow.IFrame)}.
+	 */
+	private void createIfBranchBeforeProbe() {
+		final Label l0 = new Label();
+		final Label l1 = new Label();
+		final Label l2 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
+		method.visitVarInsn(Opcodes.ILOAD, 1);
+		method.visitJumpInsn(Opcodes.IFNE, l1);
+		method.visitLabel(l2);
+		method.visitLineNumber(1002, l2);
+		method.visitMethodInsn(Opcodes.INVOKESTATIC, "Foo", "foo", "()V",
+				false);
+		method.visitLabel(l1);
+		method.visitLineNumber(1003, l1);
+		method.visitInsn(Opcodes.RETURN);
+	}
+
+	@Test
+	public void testIfBranchBeforeProbeNotCovered() {
+		createIfBranchBeforeProbe();
+		runMethodAnalzer();
+		assertEquals(4, nextProbeId);
+
+		assertLine(1001, 2, 0, 2, 0);
+	}
+
+	@Test
+	public void testIfBranchBeforeProbeCovered1() {
+		createIfBranchBeforeProbe();
+		probes[0] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 2, 1, 1);
+	}
+
+	@Test
+	public void testIfBranchBeforeProbeCovered2() {
+		createIfBranchBeforeProbe();
+		probes[1] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 2, 1, 1);
+	}
+
+	@Test
+	public void testIfBranchBeforeProbeCovered3() {
+		createIfBranchBeforeProbe();
+		probes[0] = true;
+		probes[1] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 2, 0, 2);
+	}
+
 	// === Scenario: branch which merges back ===
 
 	private void createIfBranchMerge() {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/InstructionTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/InstructionTest.java
@@ -56,22 +56,40 @@ public class InstructionTest {
 	public void testSetPredecessor() {
 		final Instruction predecessor = new Instruction(
 				new InsnNode(Opcodes.NOP), 122);
-		instruction.setPredecessor(predecessor);
+		instruction.setPredecessor(predecessor, 0);
 		assertEquals(1, predecessor.getBranches());
 	}
 
 	@Test
-	public void testSetCovered() {
-		final Instruction predecessor = new Instruction(
-				new InsnNode(Opcodes.NOP), 122);
-		instruction.setPredecessor(predecessor);
-		instruction.setCovered();
-		assertEquals(1, instruction.getCoveredBranches());
-		assertEquals(1, predecessor.getCoveredBranches());
+	public void setCovered_should_mark_branch_in_predecessor() {
+		final Instruction i = new Instruction(new InsnNode(Opcodes.NOP), 122);
+		i.setCovered(2);
+		assertEquals(1, i.getCoveredBranches());
+		assertEquals("{2}", i.toString());
 
-		instruction.setCovered();
-		assertEquals(2, instruction.getCoveredBranches());
-		assertEquals(1, predecessor.getCoveredBranches());
+		final Instruction s1 = new Instruction(new InsnNode(Opcodes.NOP), 123);
+		s1.setPredecessor(i, 1);
+		s1.setCovered(0);
+		assertEquals("{0}", s1.toString());
+		assertEquals(1, s1.getCoveredBranches());
+		assertEquals("{1, 2}", i.toString());
+		assertEquals(2, i.getCoveredBranches());
+
+		final Instruction s2 = new Instruction(new InsnNode(Opcodes.NOP), 124);
+		s2.setPredecessor(i, 0);
+		s2.setCovered(1);
+		assertEquals("{0}", s1.toString());
+		assertEquals(1, s2.getCoveredBranches());
+		assertEquals("{0, 1, 2}", i.toString());
+		assertEquals(3, i.getCoveredBranches());
+	}
+
+	@Test
+	public void should_use_BitSet_to_hold_information_about_branches_of_big_switches() {
+		for (int branch = 0; branch < 256; branch++) {
+			instruction.setCovered(branch);
+		}
+		assertEquals(256, instruction.getCoveredBranches());
 	}
 
 	@Test
@@ -81,13 +99,13 @@ public class InstructionTest {
 		for (int i = 0; i < 0x10000; i++) {
 			final Instruction insn = new Instruction(new InsnNode(Opcodes.NOP),
 					i);
-			insn.setPredecessor(next);
+			insn.setPredecessor(next, 0);
 			next = insn;
 		}
 
 		// The implementation must not cause an StackOverflowError even on very
 		// long sequences:
-		next.setCovered();
+		next.setCovered(0);
 		assertEquals(1, first.getCoveredBranches());
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/Instruction.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/Instruction.java
@@ -13,6 +13,8 @@ package org.jacoco.core.internal.flow;
 
 import org.objectweb.asm.tree.AbstractInsnNode;
 
+import java.util.BitSet;
+
 /**
  * Representation of a byte code instruction for analysis. Internally used for
  * analysis.
@@ -25,9 +27,11 @@ public class Instruction {
 
 	private int branches;
 
-	private int coveredBranches;
+	private final BitSet coveredBranches;
 
 	private Instruction predecessor;
+
+	private int predecessorBranch;
 
 	/**
 	 * New instruction at the given line.
@@ -41,7 +45,7 @@ public class Instruction {
 		this.node = node;
 		this.line = line;
 		this.branches = 0;
-		this.coveredBranches = 0;
+		this.coveredBranches = new BitSet();
 	}
 
 	/**
@@ -59,26 +63,42 @@ public class Instruction {
 	}
 
 	/**
-	 * Sets the given instruction as a predecessor of this instruction. This
-	 * will add an branch to the predecessor.
+	 * Sets the given instruction as a predecessor of this instruction and adds
+	 * branch to the predecessor. Probes are inserted in a way that every
+	 * instruction has at most one direct predecessor.
 	 * 
 	 * @see #addBranch()
 	 * @param predecessor
 	 *            predecessor instruction
+	 * @param branch
+	 *            branch number in predecessor that should be marked as covered
+	 *            when this instruction marked as covered
 	 */
-	public void setPredecessor(final Instruction predecessor) {
+	public void setPredecessor(final Instruction predecessor,
+			final int branch) {
 		this.predecessor = predecessor;
 		predecessor.addBranch();
+		this.predecessorBranch = branch;
 	}
 
 	/**
 	 * Marks one branch of this instruction as covered. Also recursively marks
 	 * all predecessor instructions as covered if this is the first covered
 	 * branch.
+	 *
+	 * @param branch
+	 *            branch number to mark as covered
 	 */
-	public void setCovered() {
+	public void setCovered(final int branch) {
 		Instruction i = this;
-		while (i != null && i.coveredBranches++ == 0) {
+		int b = branch;
+		while (i != null) {
+			if (!i.coveredBranches.isEmpty()) {
+				i.coveredBranches.set(b);
+				break;
+			}
+			i.coveredBranches.set(b);
+			b = i.predecessorBranch;
 			i = i.predecessor;
 		}
 	}
@@ -107,7 +127,12 @@ public class Instruction {
 	 * @return number of covered branches
 	 */
 	public int getCoveredBranches() {
-		return coveredBranches;
+		return coveredBranches.cardinality();
+	}
+
+	@Override
+	public String toString() {
+		return coveredBranches.toString();
 	}
 
 }


### PR DESCRIPTION
I propose to do one more baby step in story of filtering - determine covered branches for each instruction. This is non-functional change (in terms of visibility for users), but required for implementation of filter for `finally` blocks to properly merge instructions that cover different branches. This change separated from filter to allow focus on actual implementation of filter rather than on internal mechanics.