### PR TITLE
Improve test of filter to show that it works even if string in switch represented by complex expression

### DIFF
--- a/org.jacoco.core.test/src-java7/org/jacoco/core/test/filter/targets/StringSwitch.java
+++ b/org.jacoco.core.test/src-java7/org/jacoco/core/test/filter/targets/StringSwitch.java
@@ -18,8 +18,8 @@ import static org.jacoco.core.test.validation.targets.Stubs.nop;
  */
 public class StringSwitch {
 
-	private static void covered(String s) {
-		switch (s) { // $line-covered.switch$
+	private static void covered(Object s) {
+		switch (String.valueOf(s)) { // $line-covered.switch$
 		case "a":
 			nop("case a"); // $line-covered.case1$
 			break;
@@ -35,8 +35,8 @@ public class StringSwitch {
 		}
 	}
 
-	private static void notCovered(String s) {
-		switch (s) { // $line-notCovered$
+	private static void notCovered(Object s) {
+		switch (String.valueOf(s)) { // $line-notCovered$
 		case "a":
 			nop("case a");
 			break;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/StringSwitchJavacFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/StringSwitchJavacFilter.java
@@ -65,6 +65,8 @@ public final class StringSwitchJavacFilter implements IFilter {
 				return false;
 			}
 			nextIsVar(Opcodes.ISTORE, "c");
+			// Even if expression is not a variable, its result will be
+			// precomputed before the previous two instructions:
 			nextIsVar(Opcodes.ALOAD, "s");
 			nextIsInvokeVirtual("java/lang/String", "hashCode");
 			next();


### PR DESCRIPTION
During implementation of filter in #596, we made it strict, and today I started to wonder - isn't it too strict to cover cases such as:

```
switch (Objects.requireNonNull(s)) {
  case "...":
    ...
}
```

And actually it works fine! :thumbsup:
Will be better to include this case in test to avoid similar questions in future.
