### PR TITLE
Clean-up MethodAnalyzerTest

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
@@ -405,7 +405,7 @@ public class MethodAnalyzer extends MethodProbesVisitor
 		final Instruction instruction;
 		final int branch;
 
-		private CoveredProbe(Instruction instruction, int branch) {
+		private CoveredProbe(final Instruction instruction, final int branch) {
 			this.instruction = instruction;
 			this.branch = branch;
 		}


### PR DESCRIPTION
As a follow up to #601 this PR seeks to clean-up the `MethodAnalyzerTest`:

* Use new naming conventions
* cleanup and separate existing tests
* new tests for use cases not yet covered

There are still some opcodes (i.e. `visit()` methods) which are not yet covered.