### PR TITLE
Descriptive test names for FrameSnapshotTest

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/FrameSnapshotTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/FrameSnapshotTest.java
@@ -49,40 +49,48 @@ public class FrameSnapshotTest {
 	}
 
 	@Test
-	public void testNullAnalyzer() {
+	public void should_not_capture_frame_when_no_analyzer_is_given() {
 		frame = FrameSnapshot.create(null, 0);
 	}
 
 	@Test
-	public void testNoFrame() {
+	public void should_not_capture_frame_when_no_frame_is_defined() {
 		analyzer.visitJumpInsn(Opcodes.GOTO, new Label());
 		frame = FrameSnapshot.create(analyzer, 0);
 	}
 
 	@Test
-	public void testFrame() {
+	public void should_capture_frame_when_frame_is_defined() {
+		analyzer.visitInsn(Opcodes.FCONST_0);
+		analyzer.visitVarInsn(Opcodes.FSTORE, 1);
 		analyzer.visitInsn(Opcodes.ICONST_0);
 		frame = FrameSnapshot.create(analyzer, 0);
 
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, arr("Foo"), 1,
-				arr(Opcodes.INTEGER));
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 2, arr("Foo", Opcodes.FLOAT),
+				1, arr(Opcodes.INTEGER));
 	}
 
 	@Test
-	public void testReduce() {
+	public void should_combine_slots_when_doube_or_long_types_are_given() {
+		analyzer.visitInsn(Opcodes.DCONST_0);
+		analyzer.visitVarInsn(Opcodes.DSTORE, 1);
+		analyzer.visitInsn(Opcodes.FCONST_0);
+		analyzer.visitVarInsn(Opcodes.FSTORE, 3);
+
 		analyzer.visitInsn(Opcodes.ICONST_0);
 		analyzer.visitInsn(Opcodes.LCONST_0);
 		analyzer.visitInsn(Opcodes.ICONST_0);
 		analyzer.visitInsn(Opcodes.DCONST_0);
 		frame = FrameSnapshot.create(analyzer, 0);
 
+		final Object[] vars = arr("Foo", Opcodes.DOUBLE, Opcodes.FLOAT);
 		final Object[] stack = arr(Opcodes.INTEGER, Opcodes.LONG,
 				Opcodes.INTEGER, Opcodes.DOUBLE);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, arr("Foo"), 4, stack);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 3, vars, 4, stack);
 	}
 
 	@Test
-	public void testPop() {
+	public void should_decrease_stack_when_popCount_is_given() {
 		analyzer.visitInsn(Opcodes.ICONST_0);
 		analyzer.visitInsn(Opcodes.LCONST_0);
 		analyzer.visitInsn(Opcodes.ICONST_0);


### PR DESCRIPTION
Follow-up for #606: Consistently use descriptive test names for all tests.