### PR TITLE
Remove unnecessary phase definition for report goal

### DIFF
--- a/jacoco-maven-plugin.test/it/it-includes-excludes/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes/pom.xml
@@ -41,7 +41,6 @@
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-java9-offline-instrumentation/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-java9-offline-instrumentation/pom.xml
@@ -59,7 +59,6 @@
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-multi-module/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-multi-module/pom.xml
@@ -42,7 +42,6 @@
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-offline-instrumentation/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-offline-instrumentation/pom.xml
@@ -62,7 +62,6 @@
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-report-nomatch/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-nomatch/pom.xml
@@ -29,7 +29,6 @@
         <executions>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-report-unreadable-dump/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-unreadable-dump/pom.xml
@@ -29,7 +29,6 @@
         <executions>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-report-without-debug/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-without-debug/pom.xml
@@ -35,7 +35,6 @@
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/jacoco-maven-plugin.test/it/it-report-without-dump/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-without-dump/pom.xml
@@ -29,7 +29,6 @@
         <executions>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/org.jacoco.examples/build/pom-offline.xml
+++ b/org.jacoco.examples/build/pom-offline.xml
@@ -64,7 +64,6 @@
           </execution>
           <execution>
             <id>default-report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/org.jacoco.examples/build/pom.xml
+++ b/org.jacoco.examples/build/pom.xml
@@ -51,7 +51,6 @@
           </execution>
           <execution>
             <id>default-report</id>
-            <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
             </goals>


### PR DESCRIPTION
Since version 0.6.2 the `report` binds to phase `verify`. No need to specify phase in tests and examples. 