### PR TITLE
Fix ExecutionData.merge JavaDoc

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
@@ -141,7 +141,7 @@ public final class ExecutionData {
 	 * A or B
 	 * </pre>
 	 * 
-	 * For <code>flag==true</code> this can be considered as a subtraction
+	 * For <code>flag==false</code> this can be considered as a subtraction
 	 * 
 	 * <pre>
 	 * A and not B


### PR DESCRIPTION
Previously the behaviour when flag is true was specified twice but not at all when flag is false. (Looks like a typo.)