### PR TITLE
Offline instrumentation should not damage module-info

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -211,6 +211,19 @@ public class ProbeArrayStrategyFactoryTest {
 				true, 0);
 	}
 
+	@Test
+	public void testModule() {
+		final ClassWriter writer = new ClassWriter(0);
+		writer.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null,
+				null);
+		writer.visitModule("module", 0, null).visitEnd();
+		writer.visitEnd();
+
+		final IProbeArrayStrategy strategy = ProbeArrayStrategyFactory
+				.createFor(new ClassReader(writer.toByteArray()), generator);
+		assertEquals(NoneProbeArrayStrategy.class, strategy.getClass());
+	}
+
 	private IProbeArrayStrategy test(int version, int access, boolean clinit,
 			boolean method, boolean abstractMethod) {
 		final ClassWriter writer = new ClassWriter(0);

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -45,7 +45,7 @@ public final class ProbeArrayStrategyFactory {
 		final long classId = CRC64.checksum(reader.b);
 		final boolean withFrames = version >= Opcodes.V1_6;
 
-		if (isInterface(reader)) {
+		if (isInterfaceOrModule(reader)) {
 			final ProbeCounter counter = getProbeCounter(reader);
 			if (counter.getCount() == 0) {
 				return new NoneProbeArrayStrategy();
@@ -63,8 +63,9 @@ public final class ProbeArrayStrategyFactory {
 		}
 	}
 
-	private static boolean isInterface(final ClassReader reader) {
-		return (reader.getAccess() & Opcodes.ACC_INTERFACE) != 0;
+	private static boolean isInterfaceOrModule(final ClassReader reader) {
+		return (reader.getAccess()
+				& (Opcodes.ACC_INTERFACE | Opcodes.ACC_MODULE)) != 0;
 	}
 
 	private static int getVersion(final ClassReader reader) {


### PR DESCRIPTION
Given

```
$ mkdir -p src/org/example

$ cat <<END > src/module-info.java
module org.example {
}
END

$ cat <<END > src/org/example/HelloWorld.java
package org.example;

class HelloWorld {
  public static void main(String[] args) {
    System.out.println("Hello, World");
  }
}
END

$ javac -d mods/org.example \
        src/module-info.java \
        src/org/example/HelloWorld.java
```

after #600 we are able to instrument `module-info.class`

```
$ java -jar jacococli.jar \
       instrument mods \
       --dest mods-instrumented
```

and after #565 execute instrumented module using `--add-reads`

```
$ java \
       --module-path mods-instrumented:jacocoagent.jar \
       --add-modules org.jacoco.agent.rt \
       --add-reads org.example=org.jacoco.agent.rt \
       --module org.example/org.example.HelloWorld
```

however test #608 lacks such execution and following exception went unnoticed

```
Error occurred during initialization of boot layer
java.lang.module.FindException: Error reading module: mods-instrumented/org.example
Caused by: java.lang.module.InvalidModuleDescriptorException: Bad #fields
```

cause of exception

```
$ javap -p mods-instrumented/org.example/module-info.class
Compiled from "module-info.java"
module org.example {
  requires java.base;
  private static transient boolean[] $jacocoData;
  private static boolean[] $jacocoInit();
}
```
