### PR TITLE
Restore exec files compatibility regarding Java 9 class files

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/ClassFileDumper.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/ClassFileDumper.java
@@ -64,7 +64,7 @@ class ClassFileDumper {
 				localname = name;
 			}
 			outputdir.mkdirs();
-			final Long id = Long.valueOf(CRC64.checksum(contents));
+			final Long id = Long.valueOf(CRC64.classId(contents));
 			final File file = new File(outputdir, String.format(
 					"%s.%016x.class", localname, id));
 			final OutputStream out = new FileOutputStream(file);

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -94,7 +94,7 @@ public class AnalyzerTest {
 		// class IDs are always calculated after downgrade of the version
 		final byte[] bytes = TargetLoader
 				.getClassDataAsBytes(AnalyzerTest.class);
-		executionData.get(Long.valueOf(CRC64.checksum(bytes)),
+		executionData.get(Long.valueOf(CRC64.classId(bytes)),
 				"org/jacoco/core/analysis/AnalyzerTest", 200);
 		analyzer.analyzeClass(bytes, "Test");
 		assertFalse(classes.get("org/jacoco/core/analysis/AnalyzerTest")

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/data/CRC64Test.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/data/CRC64Test.java
@@ -15,7 +15,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.UnsupportedEncodingException;
 
+import org.jacoco.core.data.ExecutionDataWriter;
 import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Unit tests for {@link CRC64}.
@@ -23,8 +26,32 @@ import org.junit.Test;
 public class CRC64Test {
 
 	@Test
+	public void testJava9() {
+		// should remove workaround for Java 9
+		// during change of exec file version
+		assertEquals(0x1007, ExecutionDataWriter.FORMAT_VERSION);
+
+		assertEquals(0xB5284860A572741CL,
+				CRC64.classId(createClass(Opcodes.V9)));
+
+		assertEquals(0xB5284860A572741CL,
+				CRC64.classId(createClass(Opcodes.V1_8)));
+
+		assertEquals(0x45284D30A572741AL,
+				CRC64.classId(createClass(Opcodes.V1_7)));
+	}
+
+	private static byte[] createClass(final int version) {
+		final ClassWriter cw = new ClassWriter(0);
+		cw.visit(version, 0, "Foo", null, "java/lang/Object", null);
+		cw.visitEnd();
+		cw.toByteArray();
+		return cw.toByteArray();
+	}
+
+	@Test
 	public void test0() {
-		final long sum = CRC64.checksum(new byte[0]);
+		final long sum = CRC64.classId(new byte[0]);
 		assertEquals(0L, sum);
 	}
 
@@ -35,7 +62,7 @@ public class CRC64Test {
 	 */
 	@Test
 	public void test1() throws UnsupportedEncodingException {
-		final long sum = CRC64.checksum("IHATEMATH".getBytes("ASCII"));
+		final long sum = CRC64.classId("IHATEMATH".getBytes("ASCII"));
 		assertEquals(0xE3DCADD69B01ADD1L, sum);
 	}
 
@@ -46,7 +73,7 @@ public class CRC64Test {
 	 */
 	@Test
 	public void test2() {
-		final long sum = CRC64.checksum(new byte[] { (byte) 0xff, (byte) 0xff,
+		final long sum = CRC64.classId(new byte[] { (byte) 0xff, (byte) 0xff,
 				(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
 				(byte) 0xff, (byte) 0xff });
 		assertEquals(0x5300000000000000L, sum);
@@ -59,7 +86,7 @@ public class CRC64Test {
 	 */
 	@Test
 	public void test3() throws UnsupportedEncodingException {
-		final long sum = CRC64.checksum("JACOCO_JACOCO_JACOCO_JACOCO"
+		final long sum = CRC64.classId("JACOCO_JACOCO_JACOCO_JACOCO"
 				.getBytes("ASCII"));
 		assertEquals(0xD8016B38AAD48308L, sum);
 	}

--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -107,7 +107,7 @@ public class Analyzer {
 	 */
 	public void analyzeClass(final ClassReader reader) {
 		final ClassVisitor visitor = createAnalyzingVisitor(
-				CRC64.checksum(reader.b), reader.getClassName());
+				CRC64.classId(reader.b), reader.getClassName());
 		reader.accept(visitor, 0);
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/data/CRC64.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/data/CRC64.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.jacoco.core.internal.data;
 
+import org.objectweb.asm.Opcodes;
+
 /**
  * CRC64 checksum calculator based on the polynom specified in ISO 3309. The
  * implementation is based on the following publications:
@@ -42,19 +44,57 @@ public final class CRC64 {
 	}
 
 	/**
-	 * Calculates the CRC64 checksum for the given data array.
-	 * 
-	 * @param data
-	 *            data to calculate checksum for
-	 * @return checksum value
+	 * Updates given checksum by given byte.
+	 *
+	 * @param sum
+	 *            initial checksum value
+	 * @param b
+	 *            byte to update the checksum with
+	 * @return updated checksum value
 	 */
-	public static long checksum(final byte[] data) {
-		long sum = 0;
-		for (final byte b : data) {
-			final int lookupidx = ((int) sum ^ b) & 0xff;
-			sum = (sum >>> 8) ^ LOOKUPTABLE[lookupidx];
+	private static long update(final long sum, final byte b) {
+		final int lookupidx = ((int) sum ^ b) & 0xff;
+		return (sum >>> 8) ^ LOOKUPTABLE[lookupidx];
+	}
+
+	/**
+	 * Updates given checksum by bytes from given array.
+	 *
+	 * @param sum
+	 *            initial checksum value
+	 * @param bytes
+	 *            byte array to update the checksum with
+	 * @param fromIndexInclusive
+	 *            start index in array, inclusive
+	 * @param toIndexExclusive
+	 *            end index in array, exclusive
+	 * @return updated checksum value
+	 */
+	private static long update(long sum, final byte[] bytes,
+			final int fromIndexInclusive, final int toIndexExclusive) {
+		for (int i = fromIndexInclusive; i < toIndexExclusive; i++) {
+			sum = update(sum, bytes[i]);
 		}
 		return sum;
+	}
+
+	/**
+	 * Calculates class identifier for the given class bytes.
+	 *
+	 * @param bytes
+	 *            class bytes
+	 * @return class identifier
+	 */
+	public static long classId(final byte[] bytes) {
+		if (bytes.length > 7 && bytes[6] == 0x00 && bytes[7] == Opcodes.V9) {
+			// To support early versions of Java 9 we did a trick - change of
+			// Java 9 class files version on Java 8. Unfortunately this also
+			// affected class identifiers.
+			long sum = update(0, bytes, 0, 7);
+			sum = update(sum, (byte) Opcodes.V1_8);
+			return update(sum, bytes, 8, bytes.length);
+		}
+		return update(0, bytes, 0, bytes.length);
 	}
 
 	private CRC64() {

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -42,7 +42,7 @@ public final class ProbeArrayStrategyFactory {
 
 		final String className = reader.getClassName();
 		final int version = getVersion(reader);
-		final long classId = CRC64.checksum(reader.b);
+		final long classId = CRC64.classId(reader.b);
 		final boolean withFrames = version >= Opcodes.V1_6;
 
 		if (isInterfaceOrModule(reader)) {


### PR DESCRIPTION
https://groups.google.com/d/msg/jacoco-dev/uPwM10Ia4Ks/x4CC4hd0CwAJ

```
$ cat <<END > Example.java
class Example {
  public static void main(String[] args) {
  }
}
END

$ javac -source 9 -target 9 Example.java

$ java -javaagent:jacoco-0.7.9/lib/jacocoagent.jar=includes=Example,destfile=1.exec Example

$ java -javaagent:jacoco-0.7.10-20171220.225235-84/lib/jacocoagent.jar=includes=Example,destfile=2.exec Example

$ java -jar jacoco-0.7.10-20171220.225235-84/lib/jacococli.jar execinfo 1.exec 2.exec
[INFO] Loading exec file 1.exec.
CLASS ID         HITS/PROBES   CLASS NAME
Session "Godins-iMac.lrc.sonarsource.com-2c84a6d3": Thu Dec 21 20:53:29 CET 2017 - Thu Dec 21 20:53:29 CET 2017
2cc2366f70618d57    1 of   2   Example

[INFO] Loading exec file 2.exec.
CLASS ID         HITS/PROBES   CLASS NAME
Session "Godins-iMac.lrc.sonarsource.com-4cd2ef2e": Thu Dec 21 20:53:24 CET 2017 - Thu Dec 21 20:53:24 CET 2017
d9c2366f35618d57    1 of   2   Example
```

before #600 computation of Java 9 class identifier was happening after modification of version from 53 on 52 in bytecode,  this was unfortunately overlooked/underestimated in #406.

---

Even if our changelog only claimed "experimental Java 9 support", this support [leaked into downstream projects](https://jira.sonarsource.com/browse/SONARJAVA-1716). So change of class identifiers will affect at least users of SonarQube and Jenkins plugins in a way similar to change of exec-file version, but limited by Java 9 class files: in order to get report for Java 9 class files will be required to produce exec file with the same version of JaCoCo that is embedded in SonarQube and Jenkins plugins.

In case of a real change of exec file version such situation will be easy to diagnose, but this will affect all users and not only ones who use Java 9 class files, which will negatively impact adoption of JaCoCo version 0.8.0.

And maybe will be hard to diagnose such situation in absence of a real change of exec file version and given absence of messages about class versions and [mismatch of class IDs in SonarQube](https://jira.sonarsource.com/browse/SONARJAVA-2601) and Jenkins.

So for now I would prefer to keep compatibility and to not change Java 9 class IDs.

Code to keep compatibility is well localized, can be removed after change of exec file version or maybe even just after JDK 10 release - according to http://www.oracle.com/technetwork/java/eol-135779.html Java 9 is not an LTS release and users advised to immediately transition to the next version once it will be released:

> Java SE 9 will be a short term release, and users should immediately transition to the next release

as another example - https://www.elastic.co/blog/this-week-in-elasticsearch-and-apache-lucene-2017-12-18 :

> When JDK 9 is end-of-life in March 2018, releases of Elasticsearch will stop supporting JDK 9
