### PR TITLE
Adjust test to reflect fix of JDK-8180141 in JDK 10

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/filter/FinallyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/filter/FinallyTest.java
@@ -220,7 +220,12 @@ public class FinallyTest extends ValidationTestBase {
 
 		expected.add("breakStatement.for");
 		if (isJDKCompiler) {
-			expected.add("breakStatement.1");
+			if (JAVA_VERSION.isBefore("10")) {
+				// https://bugs.openjdk.java.net/browse/JDK-8180141
+				expected.add("breakStatement.1");
+			} else {
+				expected.add("breakStatement");
+			}
 			expected.add("breakStatement.2");
 		} else {
 			expected.add("breakStatement");


### PR DESCRIPTION
Execution of
```
$ java -version
java version "10-ea" 2018-03-20
Java(TM) SE Runtime Environment 18.3 (build 10-ea+42)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10-ea+42, mixed mode)

$ mvn clean verify -Dbytecode.version=1.9 -Djacoco.skip
```

currently fails on `gotos(org.jacoco.core.test.filter.FinallyTest)`
```
expected:<[emptyCatch.2, catchNotExecuted.2, breakStatement.for, example.2, nested.5, nested.6, breakStatement.2, breakStatement.1]>
 but was:<[emptyCatch.2, catchNotExecuted.2, breakStatement.for, example.2, nested.5, breakStatement, nested.6, breakStatement.2]>
```
because [JDK-8180141](https://bugs.openjdk.java.net/browse/JDK-8180141) was fixed.
