### PR TITLE
Support JDK 10

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -61,8 +61,8 @@ case "$JDK" in
 9)
   install_jdk $JDK9_URL
   ;;
-10-ea)
-  install_jdk $JDK10_EA_URL
+10)
+  install_jdk $JDK10_URL
   ;;
 esac
 
@@ -98,8 +98,8 @@ case "$JDK" in
   mvn -V -B -e verify -Dbytecode.version=1.9 \
     -Dinvoker.mavenOpts="-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts"
   ;;
-10-ea)
-  mvn -V -B -e verify -Dbytecode.version=1.9
+10)
+  mvn -V -B -e verify -Dbytecode.version=10
   ;;
 *)
   echo "Incorrect JDK [$JDK]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ env:
     ECJ=true
   - JDK=8-ea
   - JDK=9
-  - JDK=10-ea
+  - JDK=10
 
 matrix:
   allow_failures:
     - env: JDK=8-ea
-    - env: JDK=10-ea
 
 script: ./.travis.sh

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -742,6 +742,24 @@
         <maven.compiler.target>1.8</maven.compiler.target>
       </properties>
     </profile>
+    <profile>
+      <id>java10-validation</id>
+      <activation>
+        <property>
+          <name>bytecode.version</name>
+          <value>10</value>
+        </property>
+      </activation>
+      <properties>
+        <!--
+        Compile into bytecode version 8 by default,
+        because maven-bundle-plugin is unable to proceess bytecode version >=9,
+        this is overridden for tests
+        -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+      </properties>
+    </profile>
 
     <!-- This profile is used for compilation with ECJ. -->
     <profile>

--- a/org.jacoco.core.test/pom.xml
+++ b/org.jacoco.core.test/pom.xml
@@ -138,6 +138,42 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java10-validation</id>
+      <activation>
+        <!-- for some reason activation should be presented here, even if already defined in parent -->
+        <property>
+          <name>bytecode.version</name>
+          <value>10</value>
+        </property>
+      </activation>
+      <properties>
+        <maven.compiler.target>10</maven.compiler.target>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src-java7</source>
+                    <source>src-java8</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/AnnotationOnLocalVariableTest.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/AnnotationOnLocalVariableTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation;
+
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.test.validation.targets.AnnotationOnLocalVariable;
+import org.junit.Test;
+
+/**
+ * Test of ASM bug
+ * <a href="https://gitlab.ow2.org/asm/asm/issues/317815">#317815</a>
+ */
+public class AnnotationOnLocalVariableTest extends ValidationTestBase {
+
+	public AnnotationOnLocalVariableTest() {
+		super("src-java8", AnnotationOnLocalVariable.class);
+	}
+
+	@Test
+	public void testCoverageResult() {
+
+		assertLine("var", ICounter.FULLY_COVERED);
+
+	}
+
+}

--- a/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/AnnotationOnLocalVariable.java
+++ b/org.jacoco.core.test/src-java8/org/jacoco/core/test/validation/targets/AnnotationOnLocalVariable.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.targets;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This test target contains annotation on local variable.
+ */
+public class AnnotationOnLocalVariable {
+
+	@Documented
+	@Retention(RetentionPolicy.CLASS)
+	@Target(ElementType.TYPE_USE)
+	@interface NonNull {
+	}
+
+	private static Object legacy() {
+		return new Object();
+	}
+
+	public static void main(String[] args) {
+		@NonNull
+		Object o = legacy(); // $line-var$
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.jacoco.core.instr;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -34,12 +35,16 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 import org.jacoco.core.analysis.AnalyzerTest;
-import org.jacoco.core.runtime.RuntimeData;
-import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.jacoco.core.internal.BytecodeVersion;
+import org.jacoco.core.internal.data.CRC64;
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
 import org.jacoco.core.test.TargetLoader;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Unit tests for {@link Instrumenter}.
@@ -66,20 +71,51 @@ public class InstrumenterTest {
 
 	}
 
-	private SystemPropertiesRuntime runtime;
+	private static final class AccessorGenerator
+			implements IExecutionDataAccessorGenerator {
 
+		long classId;
+
+		public int generateDataAccessor(final long classId,
+				final String classname, final int probeCount,
+				final MethodVisitor mv) {
+			this.classId = classId;
+			InstrSupport.push(mv, probeCount);
+			mv.visitIntInsn(Opcodes.NEWARRAY, Opcodes.T_BOOLEAN);
+			return 1;
+		}
+
+	}
+
+	private AccessorGenerator accessorGenerator;
 	private Instrumenter instrumenter;
 
 	@Before
 	public void setup() throws Exception {
-		runtime = new SystemPropertiesRuntime();
-		instrumenter = new Instrumenter(runtime);
-		runtime.startup(new RuntimeData());
+		accessorGenerator = new AccessorGenerator();
+		instrumenter = new Instrumenter(accessorGenerator);
 	}
 
-	@After
-	public void teardown() {
-		runtime.shutdown();
+	@Test
+	public void should_instrument_java10_class() throws Exception {
+		final byte[] originalBytes = createClass(BytecodeVersion.V10);
+		final byte[] bytes = new byte[originalBytes.length];
+		System.arraycopy(originalBytes, 0, bytes, 0, originalBytes.length);
+		final long expectedClassId = CRC64.classId(bytes);
+
+		final byte[] instrumentedBytes = instrumenter.instrument(bytes, "");
+
+		assertArrayEquals(originalBytes, bytes);
+		assertEquals(BytecodeVersion.V10,
+				BytecodeVersion.read(instrumentedBytes));
+		assertEquals(expectedClassId, accessorGenerator.classId);
+	}
+
+	private static byte[] createClass(final int version) {
+		final ClassWriter cw = new ClassWriter(0);
+		cw.visit(version, 0, "Foo", null, "java/lang/Object", null);
+		cw.visitEnd();
+		return cw.toByteArray();
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/BytecodeVersionTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/BytecodeVersionTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal;
+
+import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class BytecodeVersionTest {
+
+	@Test
+	public void should_return_original_when_not_java10() {
+		final byte[] originalBytes = createClass(Opcodes.V9);
+
+		final byte[] bytes = BytecodeVersion.downgradeIfNeeded(Opcodes.V9,
+				originalBytes);
+
+		assertSame(originalBytes, bytes);
+	}
+
+	@Test
+	public void should_return_copy_when_java10() {
+		final byte[] originalBytes = createClass(BytecodeVersion.V10);
+
+		final byte[] bytes = BytecodeVersion
+				.downgradeIfNeeded(BytecodeVersion.V10, originalBytes);
+
+		assertNotSame(originalBytes, bytes);
+		assertEquals(Opcodes.V9, BytecodeVersion.read(bytes));
+		assertEquals(BytecodeVersion.V10, BytecodeVersion.read(originalBytes));
+	}
+
+	private static byte[] createClass(final int version) {
+		final ClassWriter cw = new ClassWriter(0);
+		cw.visit(version, 0, "Foo", null, "java/lang/Object", null);
+		cw.visitEnd();
+		return cw.toByteArray();
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
@@ -115,6 +115,13 @@ public class ContentTypeDetectorTest {
 	}
 
 	@Test
+	public void should_detect_java_10() throws IOException {
+		initData(0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x36);
+		assertEquals(ContentTypeDetector.CLASSFILE, detector.getType());
+		assertContent();
+	}
+
+	@Test
 	public void testMachObjectFile() throws IOException {
 		initData(0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02);
 		assertEquals(ContentTypeDetector.UNKNOWN, detector.getType());

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/data/CRC64Test.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/data/CRC64Test.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.UnsupportedEncodingException;
 
 import org.jacoco.core.data.ExecutionDataWriter;
+import org.jacoco.core.internal.BytecodeVersion;
 import org.junit.Test;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
@@ -27,6 +28,9 @@ public class CRC64Test {
 
 	@Test
 	public void testJava9() {
+		assertEquals(0x589E9080A572741EL,
+				CRC64.classId(createClass(BytecodeVersion.V10)));
+
 		// should remove workaround for Java 9
 		// during change of exec file version
 		assertEquals(0x1007, ExecutionDataWriter.FORMAT_VERSION);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -220,7 +220,7 @@ public class ProbeArrayStrategyFactoryTest {
 		writer.visitEnd();
 
 		final IProbeArrayStrategy strategy = ProbeArrayStrategyFactory
-				.createFor(new ClassReader(writer.toByteArray()), generator);
+				.createFor(0, new ClassReader(writer.toByteArray()), generator);
 		assertEquals(NoneProbeArrayStrategy.class, strategy.getClass());
 	}
 
@@ -254,7 +254,7 @@ public class ProbeArrayStrategyFactoryTest {
 		writer.visitEnd();
 
 		final IProbeArrayStrategy strategy = ProbeArrayStrategyFactory
-				.createFor(new ClassReader(writer.toByteArray()), generator);
+				.createFor(0, new ClassReader(writer.toByteArray()), generator);
 
 		strategy.addMembers(cv, 123);
 		return strategy;

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/ModifiedSystemClassRuntimeTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/ModifiedSystemClassRuntimeTest.java
@@ -25,8 +25,12 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.tree.ClassNode;
 
 /**
  * Unit tests for {@link ModifiedSystemClassRuntime}.
@@ -43,6 +47,28 @@ public class ModifiedSystemClassRuntimeTest extends RuntimeTestBase {
 	public void testCreateForNegative() throws Exception {
 		Instrumentation inst = newInstrumentationMock();
 		ModifiedSystemClassRuntime.createFor(inst, TARGET_CLASS_NAME);
+	}
+
+	@Test
+	public void should_instrument_java10_class() {
+		final byte[] bytes = createClass(BytecodeVersion.V10);
+
+		byte[] instrumented = ModifiedSystemClassRuntime.instrument(bytes,
+				"accessField");
+
+		assertEquals(BytecodeVersion.V10, BytecodeVersion.read(instrumented));
+		instrumented = BytecodeVersion.downgradeIfNeeded(BytecodeVersion.V10,
+				instrumented);
+		final ClassNode classNode = new ClassNode();
+		new ClassReader(instrumented).accept(classNode, 0);
+		assertEquals("accessField", classNode.fields.get(0).name);
+	}
+
+	private static byte[] createClass(final int version) {
+		final ClassWriter cw = new ClassWriter(0);
+		cw.visit(version, 0, "Foo", null, "java/lang/Object", null);
+		cw.visitEnd();
+		return cw.toByteArray();
 	}
 
 	/** This static member emulate the instrumented system class. */

--- a/org.jacoco.core.test/src/org/jacoco/core/test/filter/FinallyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/filter/FinallyTest.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.test.TargetLoader;
 import org.jacoco.core.test.filter.targets.Finally;
 import org.jacoco.core.test.validation.Source;
@@ -181,9 +182,11 @@ public class FinallyTest extends ValidationTestBase {
 	public void gotos() throws IOException {
 		final Source source = Source.getSourceFor("src", Finally.class);
 
+		byte[] b = TargetLoader.getClassDataAsBytes(Finally.class);
+		b = BytecodeVersion.downgradeIfNeeded(BytecodeVersion.read(b), b);
+
 		final ClassNode classNode = new ClassNode();
-		new ClassReader(TargetLoader.getClassDataAsBytes(Finally.class))
-				.accept(classNode, 0);
+		new ClassReader(b).accept(classNode, 0);
 		final Set<String> tags = new HashSet<String>();
 		for (final MethodNode m : classNode.methods) {
 			if ("main".equals(m.name)) {

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/FramesTest.java
@@ -18,6 +18,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
@@ -87,6 +88,9 @@ public class FramesTest {
 	}
 
 	private byte[] calculateFrames(byte[] source) {
+		source = BytecodeVersion.downgradeIfNeeded(BytecodeVersion.read(source),
+				source);
+
 		ClassReader rc = new ClassReader(source);
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ResizeInstructionsTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.RuntimeData;
@@ -59,9 +60,13 @@ public class ResizeInstructionsTest {
 	public void should_not_loose_InnerClasses_attribute() throws Exception {
 		// FIXME fails without COMPUTE_FRAMES because of
 		// https://gitlab.ow2.org/asm/asm/issues/317800
+
+		byte[] source = TargetLoader.getClassDataAsBytes(Inner.class);
+		final int version = BytecodeVersion.read(source);
+		source = BytecodeVersion.downgradeIfNeeded(version, source);
+
+		final ClassReader cr = new ClassReader(source);
 		final ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-		final ClassReader cr = new ClassReader(
-				TargetLoader.getClassDataAsBytes(Inner.class));
 		cr.accept(new ClassVisitor(InstrSupport.ASM_API_VERSION, cw) {
 			@Override
 			public void visitEnd() {
@@ -75,7 +80,10 @@ public class ResizeInstructionsTest {
 				super.visitEnd();
 			}
 		}, 0);
-		final byte[] bytes = instrumenter.instrument(cw.toByteArray(), "");
+		source = cw.toByteArray();
+		BytecodeVersion.set(source, version);
+
+		final byte[] bytes = instrumenter.instrument(source, "");
 
 		final TargetLoader targetLoader = new TargetLoader();
 		final Class<?> outer = targetLoader.add(ResizeInstructionsTest.class,

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/StructuredLockingTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/StructuredLockingTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
 import org.jacoco.core.test.TargetLoader;
@@ -66,6 +67,9 @@ public class StructuredLockingTest {
 		IRuntime runtime = new SystemPropertiesRuntime();
 		Instrumenter instrumenter = new Instrumenter(runtime);
 		byte[] instrumented = instrumenter.instrument(source, "TestTarget");
+
+		final int version = BytecodeVersion.read(instrumented);
+		instrumented = BytecodeVersion.downgradeIfNeeded(version, instrumented);
 
 		ClassNode cn = new ClassNode();
 		new ClassReader(instrumented).accept(cn, 0);

--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -22,6 +22,7 @@ import java.util.zip.ZipInputStream;
 
 import org.jacoco.core.data.ExecutionData;
 import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.internal.ContentTypeDetector;
 import org.jacoco.core.internal.InputStreams;
 import org.jacoco.core.internal.Pack200Streams;
@@ -106,8 +107,16 @@ public class Analyzer {
 	 *            reader with class definitions
 	 */
 	public void analyzeClass(final ClassReader reader) {
-		final ClassVisitor visitor = createAnalyzingVisitor(
-				CRC64.classId(reader.b), reader.getClassName());
+		analyzeClass(reader.b);
+	}
+
+	private void analyzeClass(final byte[] source) {
+		final long classId = CRC64.classId(source);
+		final int version = BytecodeVersion.read(source);
+		final byte[] b = BytecodeVersion.downgradeIfNeeded(version, source);
+		final ClassReader reader = new ClassReader(b);
+		final ClassVisitor visitor = createAnalyzingVisitor(classId,
+				reader.getClassName());
 		reader.accept(visitor, 0);
 	}
 
@@ -124,7 +133,7 @@ public class Analyzer {
 	public void analyzeClass(final byte[] buffer, final String location)
 			throws IOException {
 		try {
-			analyzeClass(new ClassReader(buffer));
+			analyzeClass(buffer);
 		} catch (final RuntimeException cause) {
 			throw analyzerError(location, cause);
 		}

--- a/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
@@ -21,9 +21,11 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.internal.ContentTypeDetector;
 import org.jacoco.core.internal.InputStreams;
 import org.jacoco.core.internal.Pack200Streams;
+import org.jacoco.core.internal.data.CRC64;
 import org.jacoco.core.internal.flow.ClassProbesAdapter;
 import org.jacoco.core.internal.instr.ClassInstrumenter;
 import org.jacoco.core.internal.instr.IProbeArrayStrategy;
@@ -76,6 +78,15 @@ public class Instrumenter {
 	 * 
 	 */
 	public byte[] instrument(final ClassReader reader) {
+		return instrument(reader.b);
+	}
+
+	private byte[] instrument(final byte[] source) {
+		final long classId = CRC64.classId(source);
+		final int originalVersion = BytecodeVersion.read(source);
+		final byte[] b = BytecodeVersion.downgradeIfNeeded(originalVersion,
+				source);
+		final ClassReader reader = new ClassReader(b);
 		final ClassWriter writer = new ClassWriter(reader, 0) {
 			@Override
 			protected String getCommonSuperClass(final String type1,
@@ -84,11 +95,13 @@ public class Instrumenter {
 			}
 		};
 		final IProbeArrayStrategy strategy = ProbeArrayStrategyFactory
-				.createFor(reader, accessorGenerator);
+				.createFor(classId, reader, accessorGenerator);
 		final ClassVisitor visitor = new ClassProbesAdapter(
 				new ClassInstrumenter(strategy, writer), true);
 		reader.accept(visitor, ClassReader.EXPAND_FRAMES);
-		return writer.toByteArray();
+		final byte[] instrumented = writer.toByteArray();
+		BytecodeVersion.set(instrumented, originalVersion);
+		return instrumented;
 	}
 
 	/**
@@ -105,7 +118,7 @@ public class Instrumenter {
 	public byte[] instrument(final byte[] buffer, final String name)
 			throws IOException {
 		try {
-			return instrument(new ClassReader(buffer));
+			return instrument(buffer);
 		} catch (final RuntimeException e) {
 			throw instrumentError(name, e);
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/BytecodeVersion.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/BytecodeVersion.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal;
+
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Utilities to read and modify bytecode version in bytes of class.
+ */
+public final class BytecodeVersion {
+
+	private static final int VERSION_INDEX = 6;
+
+	/**
+	 * Version of the Java 10 class file format.
+	 */
+	public static final int V10 = Opcodes.V9 + 1;
+
+	private BytecodeVersion() {
+	}
+
+	/**
+	 * Reads bytecode version from given bytes of class.
+	 * 
+	 * @param b
+	 *            bytes of class
+	 * @return version of bytecode
+	 */
+	public static int read(final byte[] b) {
+		return (short) (((b[VERSION_INDEX] & 0xFF) << 8)
+				| (b[VERSION_INDEX + 1] & 0xFF));
+	}
+
+	/**
+	 * Sets bytecode version in given bytes of class.
+	 *
+	 * @param b
+	 *            bytes of class
+	 * @param version
+	 *            version of bytecode to set
+	 */
+	public static void set(final byte[] b, final int version) {
+		b[VERSION_INDEX] = (byte) (version >>> 8);
+		b[VERSION_INDEX + 1] = (byte) version;
+	}
+
+	/**
+	 * Returns given bytes of class if version is less that {@link #V10},
+	 * otherwise copy where version set to {@link Opcodes#V9}.
+	 * 
+	 * @param version
+	 *            version of bytecode
+	 * @param source
+	 *            bytes of class
+	 * @return given bytes of class if version is less than {@link #V10},
+	 *         otherwise copy where version set to {@link Opcodes#V9}
+	 */
+	public static byte[] downgradeIfNeeded(final int version,
+			final byte[] source) {
+		if (V10 != version) {
+			return source;
+		}
+		final byte[] b = new byte[source.length];
+		System.arraycopy(source, 0, b, 0, source.length);
+		set(b, Opcodes.V9);
+		return b;
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
@@ -83,6 +83,7 @@ public class ContentTypeDetector {
 			case Opcodes.V1_7:
 			case Opcodes.V1_8:
 			case Opcodes.V9:
+			case BytecodeVersion.V10:
 				return CLASSFILE;
 			}
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.jacoco.core.internal.instr;
 
-import org.jacoco.core.internal.data.CRC64;
 import org.jacoco.core.internal.flow.ClassProbesAdapter;
 import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
 import org.objectweb.asm.ClassReader;
@@ -30,19 +29,21 @@ public final class ProbeArrayStrategyFactory {
 	 * Creates a suitable strategy instance for the class described by the given
 	 * reader. Created instance must be used only to process a class or
 	 * interface for which it has been created and must be used only once.
-	 * 
+	 *
+	 * @param classId
+	 *            class identifier
 	 * @param reader
 	 *            reader to get information about the class
 	 * @param accessorGenerator
 	 *            accessor to the coverage runtime
 	 * @return strategy instance
 	 */
-	public static IProbeArrayStrategy createFor(final ClassReader reader,
+	public static IProbeArrayStrategy createFor(final long classId,
+			final ClassReader reader,
 			final IExecutionDataAccessorGenerator accessorGenerator) {
 
 		final String className = reader.getClassName();
 		final int version = getVersion(reader);
-		final long classId = CRC64.classId(reader.b);
 		final boolean withFrames = version >= Opcodes.V1_6;
 
 		if (isInterfaceOrModule(reader)) {

--- a/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
@@ -19,6 +19,7 @@ import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Field;
 import java.security.ProtectionDomain;
 
+import org.jacoco.core.internal.BytecodeVersion;
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -153,7 +154,10 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 	 */
 	public static byte[] instrument(final byte[] source,
 			final String accessFieldName) {
-		final ClassReader reader = new ClassReader(source);
+		final int originalVersion = BytecodeVersion.read(source);
+		final byte[] b = BytecodeVersion.downgradeIfNeeded(originalVersion,
+				source);
+		final ClassReader reader = new ClassReader(b);
 		final ClassWriter writer = new ClassWriter(reader, 0);
 		reader.accept(new ClassVisitor(InstrSupport.ASM_API_VERSION, writer) {
 
@@ -164,7 +168,9 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 			}
 
 		}, ClassReader.EXPAND_FRAMES);
-		return writer.toByteArray();
+		final byte[] instrumented = writer.toByteArray();
+		BytecodeVersion.set(instrumented, originalVersion);
+		return instrumented;
 	}
 
 	private static void createDataField(final ClassVisitor visitor,

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -22,6 +22,8 @@
 
 <h3>New Features</h3>
 <ul>
+  <li>JaCoCo now supports Java 10
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/629">#629</a>).</li>
   <li>Empty constructor without parameters in enum is filtered out during
       generation of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/649">#649</a>).</li>

--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -45,7 +45,7 @@
 
 <h3>What Java versions are supported by JaCoCo?</h3>
 <p>
-  JaCoCo supports Java class files from version 1.0 to 9. However the minimum
+  JaCoCo supports Java class files from version 1.0 to 10. However the minimum
   JRE version required by the JaCoCo runtime (e.g. the agent) and the JaCoCo
   tools is 1.5. Also note that class files under test from version 1.6 and above
   have to contain valid stackmap frames.


### PR DESCRIPTION
Classes of JDK 10 EA b35 use new classfile version number ( https://bugs.openjdk.java.net/browse/JDK-8188870 ) and so JaCoCo Agent 0.7.9 as well as agent from current build of master branch fail to start:
```
$ java -version
java version "10-ea"
Java(TM) SE Runtime Environment (build 10-ea+35)
Java HotSpot(TM) 64-Bit Server VM (build 10-ea+35, mixed mode)

$ java -javaagent:jacoco-0.7.9/lib/jacocoagent.jar     
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:564)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:510)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:522)
Caused by: java.lang.RuntimeException: Class java/util/UUID could not be instrumented.
        at org.jacoco.agent.rt.internal_8ff85ea.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:140)
        at org.jacoco.agent.rt.internal_8ff85ea.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:101)
        at org.jacoco.agent.rt.internal_8ff85ea.PreMain.createRuntime(PreMain.java:55)
        at org.jacoco.agent.rt.internal_8ff85ea.PreMain.premain(PreMain.java:47)
        ... 6 more
Caused by: java.lang.NoSuchFieldException: $jacocoAccess
        at java.base/java.lang.Class.getField(Class.java:1958)
        at org.jacoco.agent.rt.internal_8ff85ea.core.runtime.ModifiedSystemClassRuntime.createFor(ModifiedSystemClassRuntime.java:138)
        ... 9 more
FATAL ERROR in native method: processing of -javaagent failed
```

So to support JDK 10 we'll need to do similar workarounds that were done for JDK 9 in #406 and removed in #600 or wait for ASM release containing https://gitlab.ow2.org/asm/asm/merge_requests/74
