### PR TITLE
Use coverage id instead of class name as a key

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/analysis/CoverageBuilder.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/CoverageBuilder.java
@@ -36,7 +36,7 @@ import org.jacoco.core.internal.analysis.SourceFileCoverageImpl;
  */
 public class CoverageBuilder implements ICoverageVisitor {
 
-	private final Map<String, IClassCoverage> classes;
+	private final Map<Long, IClassCoverage> classes;
 
 	private final Map<String, ISourceFileCoverage> sourcefiles;
 
@@ -45,7 +45,7 @@ public class CoverageBuilder implements ICoverageVisitor {
 	 * 
 	 */
 	public CoverageBuilder() {
-		this.classes = new HashMap<String, IClassCoverage>();
+		this.classes = new HashMap<Long, IClassCoverage>();
 		this.sourcefiles = new HashMap<String, ISourceFileCoverage>();
 	}
 
@@ -100,13 +100,13 @@ public class CoverageBuilder implements ICoverageVisitor {
 	public void visitCoverage(final IClassCoverage coverage) {
 		// Only consider classes that actually contain code:
 		if (coverage.getInstructionCounter().getTotalCount() > 0) {
-			final String name = coverage.getName();
-			final IClassCoverage dup = classes.put(name, coverage);
+			final long id = coverage.getId();
+			final IClassCoverage dup = classes.put(id, coverage);
 			if (dup != null) {
 				if (dup.getId() != coverage.getId()) {
 					throw new IllegalStateException(
-							"Can't add different class with same name: "
-									+ name);
+							"Can't add different class with same id: " + id + ", names are: "
+									+ coverage.getName() + ", " + dup.getName());
 				}
 			} else {
 				final String source = coverage.getSourceFileName();


### PR DESCRIPTION
Hello! On some of our projects we have conflicting jars and jacococli is unable to build proper report. The classes on which we're failing is irrelevant for us (we only need our source files to be covered).

```
Exception in thread "main" java.io.IOException: Error while analyzing /opt/our-app/libs/our-app-1.0.jar@lib/tomcat-embed-logging-juli-8.0.30.jar@org/apache/juli/logging/LogConfigurationException.class.
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzerError(Analyzer.java:166)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:138)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:161)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:197)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeZip(Analyzer.java:269)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:200)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeZip(Analyzer.java:269)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:200)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:230)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:225)
	at org.jacoco.cli.internal.commands.Report.analyze(Report.java:109)
	at org.jacoco.cli.internal.commands.Report.execute(Report.java:83)
	at org.jacoco.cli.internal.Main.execute(Main.java:89)
	at org.jacoco.cli.internal.Main.main(Main.java:104)
Caused by: java.lang.IllegalStateException: Can't add different class with same name: org/apache/juli/logging/LogConfigurationException
	at org.jacoco.cli.internal.core.analysis.CoverageBuilder.visitCoverage(CoverageBuilder.java:107)
	at org.jacoco.cli.internal.core.analysis.Analyzer$1.visitEnd(Analyzer.java:97)
	at org.jacoco.cli.internal.asm.ClassVisitor.visitEnd(ClassVisitor.java:339)
	at org.jacoco.cli.internal.core.internal.flow.ClassProbesAdapter.visitEnd(ClassProbesAdapter.java:98)
	at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:702)
	at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:500)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:120)
	at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:136)
	... 12 more
```