### PR TITLE
Remove unused dependencies on asm-analysis and asm-util in org.jacoco.core

### DIFF
--- a/org.jacoco.core.test/pom.xml
+++ b/org.jacoco.core.test/pom.xml
@@ -33,6 +33,14 @@
       <artifactId>org.jacoco.core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/org.jacoco.core/pom.xml
+++ b/org.jacoco.core/pom.xml
@@ -37,14 +37,6 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-tree</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-analysis</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-util</artifactId>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
[Historically we used `asm-debug-all`](https://github.com/jacoco/jacoco/commit/351b20ee84db15e054b01c3a5e7b4234cecad890) due to lack of debug info in other JARs. Starting from [ASM 6.0 other JARs finally have debug info and `asm-debug-all` was removed](https://gitlab.ow2.org/asm/asm/commit/4c449bea1e3fb980238c61d60103fe1be76e77e5). During [upgrade to ASM 6.0](https://github.com/jacoco/jacoco/commit/caa820ed62133f47bacba06ea931bf5d7c43dcd6) dependency on `asm-debug-all` was simply replaced by dependencies on all ASM JARs, while we  use `asm-analysis` and `asm-util` only in tests.