### PR TITLE
Add ExcludeFromCodeCoverage filter

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ExcludeFromCodeCoverageFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ExcludeFromCodeCoverageFilterTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Phi Lieu - add ExcludeFromCodeCoverage annotation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class ExcludeFromCodeCoverageFilterTest implements IFilterOutput {
+    private final IFilter filter = new ExcludeFromCodeCoverageFilter();
+
+    private AbstractInsnNode fromInclusive;
+    private AbstractInsnNode toInclusive;
+
+    @Test
+    public void testNoAnnotations() {
+        final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+                "hashCode", "()I", null, null);
+
+        m.visitInsn(Opcodes.ICONST_0);
+        m.visitInsn(Opcodes.IRETURN);
+
+        filter.filter("Foo", "java/lang/Object", m, this);
+
+        assertNull(fromInclusive);
+        assertNull(toInclusive);
+    }
+
+    @Test
+    public void testOtherAnnotation() {
+        final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+                "hashCode", "()I", null, null);
+        m.visitAnnotation("Lother/Annotation;", false);
+
+        m.visitInsn(Opcodes.ICONST_0);
+        m.visitInsn(Opcodes.IRETURN);
+
+        filter.filter("Foo", "java/lang/Object", m, this);
+
+        assertNull(fromInclusive);
+        assertNull(toInclusive);
+    }
+
+    @Test
+    public void testExcludeFromCodeCoverageAnnotationWithPackage() {
+        final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+                "hashCode", "()I", null, null);
+        m.visitAnnotation("Lsomething/anything/ExcludeFromCodeCoverage;", false);
+
+        m.visitInsn(Opcodes.ICONST_0);
+        m.visitInsn(Opcodes.IRETURN);
+
+        filter.filter("Foo", "java/lang/Object", m, this);
+
+        assertEquals(m.instructions.getFirst(), fromInclusive);
+        assertEquals(m.instructions.getLast(), toInclusive);
+    }
+
+    public void ignore(final AbstractInsnNode fromInclusive,
+                       final AbstractInsnNode toInclusive) {
+        assertNull(this.fromInclusive);
+        this.fromInclusive = fromInclusive;
+        this.toInclusive = toInclusive;
+    }
+
+    public void merge(final AbstractInsnNode i1, final AbstractInsnNode i2) {
+        fail();
+    }
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/AbstractAnnotatedMethodFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/AbstractAnnotatedMethodFilter.java
@@ -11,7 +11,9 @@
  *******************************************************************************/
 package org.jacoco.core.internal.analysis.filter;
 
+import java.text.MessageFormat;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -20,17 +22,6 @@ import org.objectweb.asm.tree.MethodNode;
  * Filters annotated methods.
  */
 abstract class AbstractAnnotatedMethodFilter implements IFilter {
-	private final String descType;
-
-	/**
-	 * Configures a new filter instance.
-	 * 
-	 * @param annotationType
-	 *            VM type of the annotation
-	 */
-	protected AbstractAnnotatedMethodFilter(final String annotationType) {
-		this.descType = "L" + annotationType + ";";
-	}
 
 	public void filter(final String className, final String superClassName,
 			final MethodNode methodNode, final IFilterOutput output) {
@@ -44,13 +35,22 @@ abstract class AbstractAnnotatedMethodFilter implements IFilter {
 		final List<AnnotationNode> annotations = getAnnotations(methodNode);
 		if (annotations != null) {
 			for (final AnnotationNode annotation : annotations) {
-				if (descType.equals(annotation.desc)) {
+				if (isMatchingAnnotation(annotation)) {
 					return true;
 				}
 			}
 		}
 		return false;
 	}
+
+	/**
+	 * Test if the annotation matches certain criteria for a method to be filtered out.
+	 *
+	 * @param annotationNode
+	 *            the annontation to test against
+	 * @return true if the annotation matches. Otherwise, false.
+	 */
+	protected abstract boolean isMatchingAnnotation(AnnotationNode annotationNode);
 
 	/**
 	 * Retrieves the annotations to search from a method. Depending on the

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/ExcludeFromCodeCoverageFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/ExcludeFromCodeCoverageFilter.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Phi Lieu - add ExcludeFromCodeCoverage annotation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Filters methods annotated with <code>ExcludeFromCodeCoverage</code>. The annotation class can be from any
+ * Java package.
+ */
+public class ExcludeFromCodeCoverageFilter extends AbstractAnnotatedMethodFilter {
+
+    @Override
+    protected boolean isMatchingAnnotation(AnnotationNode annotationNode) {
+		return Pattern.matches("L[a-zA-Z0-9/]*ExcludeFromCodeCoverage;", annotationNode.desc);
+    }
+
+    @Override
+    List<AnnotationNode> getAnnotations(final MethodNode methodNode) {
+        return methodNode.invisibleAnnotations;
+    }
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
@@ -31,7 +31,8 @@ public final class Filters implements IFilter {
 			new TryWithResourcesJavacFilter(), new TryWithResourcesEcjFilter(),
 			new FinallyFilter(), new PrivateEmptyNoArgConstructorFilter(),
 			new StringSwitchJavacFilter(), new LombokGeneratedFilter(),
-			new GroovyGeneratedFilter(), new EnumEmptyConstructorFilter());
+			new GroovyGeneratedFilter(), new EnumEmptyConstructorFilter(),
+			new ExcludeFromCodeCoverageFilter());
 
 	private final IFilter[] filters;
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/GroovyGeneratedFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/GroovyGeneratedFilter.java
@@ -21,11 +21,9 @@ import org.objectweb.asm.tree.MethodNode;
  */
 public final class GroovyGeneratedFilter extends AbstractAnnotatedMethodFilter {
 
-	/**
-	 * New filter.
-	 */
-	public GroovyGeneratedFilter() {
-		super("groovy/transform/Generated");
+	@Override
+	protected boolean isMatchingAnnotation(AnnotationNode annotationNode) {
+		return "Lgroovy/transform/Generated;".equals(annotationNode.desc);
 	}
 
 	@Override

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/LombokGeneratedFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/LombokGeneratedFilter.java
@@ -21,11 +21,9 @@ import org.objectweb.asm.tree.MethodNode;
  */
 public final class LombokGeneratedFilter extends AbstractAnnotatedMethodFilter {
 
-	/**
-	 * New filter.
-	 */
-	public LombokGeneratedFilter() {
-		super("lombok/Generated");
+	@Override
+	protected boolean isMatchingAnnotation(AnnotationNode annotationNode) {
+		return "Llombok/Generated;".equals(annotationNode.desc);
 	}
 
 	@Override


### PR DESCRIPTION
This PR is to allow filter methods that are annotated with a class named ExcludeFromCodeCoverage. The Java package of the class is not important. 
It will allow the end users the flexibility to create this annotation class themselves and use it to filter out methods from code coverage. 

Ref. #14 