### PR TITLE
Add current module to aggregated report

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -129,6 +129,8 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	void createReport(final IReportGroupVisitor visitor,
 			final ReportSupport support) throws IOException {
 		final IReportGroupVisitor group = visitor.visitGroup(title);
+		support.processProject(group, project.getArtifactId(), getProject(),
+				getIncludes(), getExcludes(), sourceEncoding);
 		for (final MavenProject dependency : findDependencies(
 				Artifact.SCOPE_COMPILE, Artifact.SCOPE_RUNTIME,
 				Artifact.SCOPE_PROVIDED)) {


### PR DESCRIPTION
Previously only coverage data from dependent modules participated in aggregated report. After this change current module data is added as well.

In some cases this will simplify multi-module project configuration. Dedicated module for aggregated report will not be required. There will be possibility to generate aggregated report for the module depending on all other (if there is such).