### PR TITLE
Adding new filter for methods annotated with @kotlin.Generated by Kotlin compiler

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilterTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Andrey Fomenkov
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+public class KotlinGeneratedFilterTest implements IFilterOutput {
+
+	private final IFilter filter = new KotlinGeneratedFilter();
+
+	private AbstractInsnNode fromInclusive;
+	private AbstractInsnNode toInclusive;
+
+	@Test
+	public void testNoAnnotations() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"hashCode", "()I", null, null);
+
+		m.visitInsn(Opcodes.ICONST_0);
+		m.visitInsn(Opcodes.IRETURN);
+
+		filter.filter("Foo", "java/lang/Object", m, this);
+
+		assertNull(fromInclusive);
+		assertNull(toInclusive);
+	}
+
+	@Test
+	public void testOtherAnnotation() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"hashCode", "()I", null, null);
+		m.visitAnnotation("Lother/Annotation;", false);
+
+		m.visitInsn(Opcodes.ICONST_0);
+		m.visitInsn(Opcodes.IRETURN);
+
+		filter.filter("Foo", "java/lang/Object", m, this);
+
+		assertNull(fromInclusive);
+		assertNull(toInclusive);
+	}
+
+	@Test
+	public void testKotlinGeneratedAnnotation() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"hashCode", "()I", null, null);
+		m.visitAnnotation("Lkotlin/Generated;", false);
+
+		m.visitInsn(Opcodes.ICONST_0);
+		m.visitInsn(Opcodes.IRETURN);
+
+		filter.filter("Foo", "java/lang/Object", m, this);
+
+		assertEquals(m.instructions.getFirst(), fromInclusive);
+		assertEquals(m.instructions.getLast(), toInclusive);
+	}
+
+	public void ignore(final AbstractInsnNode fromInclusive,
+			final AbstractInsnNode toInclusive) {
+		assertNull(this.fromInclusive);
+		this.fromInclusive = fromInclusive;
+		this.toInclusive = toInclusive;
+	}
+
+	public void merge(final AbstractInsnNode i1, final AbstractInsnNode i2) {
+		fail();
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
@@ -31,7 +31,8 @@ public final class Filters implements IFilter {
 			new TryWithResourcesJavacFilter(), new TryWithResourcesEcjFilter(),
 			new FinallyFilter(), new PrivateEmptyNoArgConstructorFilter(),
 			new StringSwitchJavacFilter(), new LombokGeneratedFilter(),
-			new GroovyGeneratedFilter(), new EnumEmptyConstructorFilter());
+			new GroovyGeneratedFilter(), new EnumEmptyConstructorFilter(),
+			new KotlinGeneratedFilter());
 
 	private final IFilter[] filters;
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilter.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Andrey Fomenkov
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import java.util.List;
+
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.MethodNode;
+
+/**
+ * Filters Kotlin compiler generated methods annotated with <code>@kotlin.Generated</code>.
+ */
+public final class KotlinGeneratedFilter extends AbstractAnnotatedMethodFilter {
+
+	/**
+	 * New filter.
+	 */
+	public KotlinGeneratedFilter() {
+		super("kotlin/Generated");
+	}
+
+	@Override
+	List<AnnotationNode> getAnnotations(final MethodNode methodNode) {
+		return methodNode.invisibleAnnotations;
+	}
+
+}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -24,6 +24,8 @@
 <ul>
   <li>Synthetic classes are filtered out during generation of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/668">#668</a>).</li>
+  <li>Skip methods annotated with <code>@kotlin.Generated</code> produced by Kotlin compiler
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/681">#681</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>


### PR DESCRIPTION
The related PR in JetBrains repository: [#1655](https://github.com/JetBrains/kotlin/pull/1655)
Could be a good start to solve this opened issue: **_Recognize and ignore Kotlin-generated code_** #552 
Post on Medium: [Kotlin + JaCoCo: Tuning Compiler to Skip Generated Code.](https://medium.com/@andrey.fomenkov/kotlin-jacoco-tuning-compiler-to-skip-generated-code-935fcaeaa391)