### PR TITLE
CLI tests should not depend on current locale

### DIFF
--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/MainTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/MainTest.java
@@ -24,7 +24,7 @@ public class MainTest extends CommandTestBase {
 
 		assertFailure();
 		assertNoOutput(out);
-		assertContains("Argument \"<command>\" is required", err);
+		assertContains("\"<command>\"", err);
 		assertContains("Usage: java -jar jacococli.jar --help | <command>",
 				err);
 		assertContains("Command line interface for JaCoCo.", err);

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ClassInfoTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ClassInfoTest.java
@@ -25,7 +25,7 @@ public class ClassInfoTest extends CommandTestBase {
 		execute("classinfo", "--invalid");
 
 		assertFailure();
-		assertContains("\"--invalid\" is not a valid option", err);
+		assertContains("\"--invalid\"", err);
 		assertContains(
 				"java -jar jacococli.jar classinfo [<classlocations> ...]",
 				err);

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/DumpTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/DumpTest.java
@@ -51,7 +51,7 @@ public class DumpTest extends CommandTestBase {
 			throws Exception {
 		execute("dump");
 		assertFailure();
-		assertContains("Option \"--destfile\" is required", err);
+		assertContains("\"--destfile\"", err);
 		assertContains("java -jar jacococli.jar dump [--address <address>]",
 				err);
 	}

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ExecInfoTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ExecInfoTest.java
@@ -37,7 +37,7 @@ public class ExecInfoTest extends CommandTestBase {
 		execute("execinfo", "--invalid");
 
 		assertFailure();
-		assertContains("\"--invalid\" is not a valid option", err);
+		assertContains("\"--invalid\"", err);
 		assertContains("java -jar jacococli.jar execinfo [<execfiles> ...]",
 				err);
 	}

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/InstrumentTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/InstrumentTest.java
@@ -47,7 +47,7 @@ public class InstrumentTest extends CommandTestBase {
 			throws Exception {
 		execute("instrument");
 		assertFailure();
-		assertContains("Option \"--dest\" is required", err);
+		assertContains("\"--dest\"", err);
 		assertContains(
 				"Usage: java -jar jacococli.jar instrument [<sourcefiles> ...]",
 				err);

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/MergeTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/MergeTest.java
@@ -43,7 +43,7 @@ public class MergeTest extends CommandTestBase {
 		execute("merge");
 
 		assertFailure();
-		assertContains("Option \"--destfile\" is required", err);
+		assertContains("\"--destfile\"", err);
 		assertContains("java -jar jacococli.jar merge [<execfiles> ...]", err);
 	}
 

--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ReportTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/ReportTest.java
@@ -37,7 +37,7 @@ public class ReportTest extends CommandTestBase {
 		execute("report");
 
 		assertFailure();
-		assertContains("Option \"--classfiles\" is required", err);
+		assertContains("\"--classfiles\"", err);
 		assertContains(
 				"Usage: java -jar jacococli.jar report [<execfiles> ...]", err);
 	}


### PR DESCRIPTION
As mentioned in out mailing list our CLI tests fail for locales other than english:

https://groups.google.com/d/msg/jacoco/zOw0llfraAM/wMiYu5CUEAAJ

The build should therefore configure english as the default locale.