### PR TITLE
Remove partial localization of CLI

### DIFF
--- a/org.jacoco.cli/pom.xml
+++ b/org.jacoco.cli/pom.xml
@@ -101,6 +101,14 @@
                   </manifestEntries>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>args4j:args4j</artifact>
+                  <excludes>
+                    <exclude>**/Messages_*.properties</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Follow up on https://github.com/jacoco/jacoco/pull/682#issuecomment-395540141

Before this change:

```
$ java -Duser.language=ru -Duser.country=RU -jar org.jacoco.cli/target/org.jacoco.cli-0.8.2-SNAPSHOT-nodeps.jar
Command line interface for JaCoCo.

Usage: java -jar jacococli.jar --help | <command>
 <command> : dump|instrument|merge|report|classinfo|execinfo|version
 --help    : show help
 --quiet   : suppress all output on stdout

Требуется аргумент "<command>"
```

After this change:

```
$ java -Duser.language=ru -Duser.country=RU -jar org.jacoco.cli/target/org.jacoco.cli-0.8.2-SNAPSHOT-nodeps.jar
Command line interface for JaCoCo.

Usage: java -jar jacococli.jar --help | <command>
 <command> : dump|instrument|merge|report|classinfo|execinfo|version
 --help    : show help
 --quiet   : suppress all output on stdout

Argument "<command>" is required
```
