### PR TITLE
Improve error message when working on instrumented classes

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/InstrSupportTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/InstrSupportTest.java
@@ -56,17 +56,17 @@ public class InstrSupportTest {
 	}
 
 	@Test
-	public void testAssertNotIntrumentedPositive() {
+	public void assertNotIntrumented_should_accept_non_jacoco_memebers() {
 		InstrSupport.assertNotInstrumented("run", "Foo");
 	}
 
 	@Test(expected = IllegalStateException.class)
-	public void testAssertNotIntrumentedField() {
+	public void assertNotIntrumented_should_throw_exception_when_jacoco_data_field_is_present() {
 		InstrSupport.assertNotInstrumented("$jacocoData", "Foo");
 	}
 
 	@Test(expected = IllegalStateException.class)
-	public void testAssertNotIntrumentedMethod() {
+	public void assertNotIntrumented_should_throw_exception_when_jacoco_init_method_is_present() {
 		InstrSupport.assertNotInstrumented("$jacocoInit", "Foo");
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/InstrSupportTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/InstrSupportTest.java
@@ -17,7 +17,9 @@ import static org.junit.Assert.assertTrue;
 
 import org.jacoco.core.internal.BytecodeVersion;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.util.Printer;
 import org.objectweb.asm.util.Textifier;
@@ -30,6 +32,9 @@ public class InstrSupportTest {
 
 	private Printer printer;
 	private TraceMethodVisitor trace;
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	@Before
 	public void setup() {
@@ -60,13 +65,21 @@ public class InstrSupportTest {
 		InstrSupport.assertNotInstrumented("run", "Foo");
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void assertNotIntrumented_should_throw_exception_when_jacoco_data_field_is_present() {
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage(
+				"Cannot process instrumented class Foo. Please supply original non-instrumented classes.");
+
 		InstrSupport.assertNotInstrumented("$jacocoData", "Foo");
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void assertNotIntrumented_should_throw_exception_when_jacoco_init_method_is_present() {
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage(
+				"Cannot process instrumented class Foo. Please supply original non-instrumented classes.");
+
 		InstrSupport.assertNotInstrumented("$jacocoInit", "Foo");
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
@@ -185,8 +185,9 @@ public final class InstrSupport {
 	public static void assertNotInstrumented(final String member,
 			final String owner) throws IllegalStateException {
 		if (member.equals(DATAFIELD_NAME) || member.equals(INITMETHOD_NAME)) {
-			throw new IllegalStateException(
-					format("Class %s is already instrumented.", owner));
+			throw new IllegalStateException(format(
+					"Cannot process instrumented class %s. Please supply original non-instrumented classes.",
+					owner));
 		}
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -38,6 +38,13 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/672">#672</a>).</li>
 </ul>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>Improved error message when already instrumented classes are used for
+      instrumentation or analysis.
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/700">#700</a>).</li>
+</ul>
+
 <h2>Release 0.8.1 (2018/03/21)</h2>
 
 <h3>New Features</h3>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -41,8 +41,8 @@
 <h3>Non-functional Changes</h3>
 <ul>
   <li>Improved error message when already instrumented classes are used for
-      instrumentation or analysis.
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/700">#700</a>).</li>
+      instrumentation or analysis
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/703">#703</a>).</li>
 </ul>
 
 <h2>Release 0.8.1 (2018/03/21)</h2>


### PR DESCRIPTION
The instrumentation and analysis process expects original, uninstrumented classes. This seems to be a common configuration issue - see #700. Therefore the error message should be improved to be more helpful:

`Cannot process instrumented class X. Please supply original non-instrumented classes.`