### PR TITLE
Add module for Kotlin validation tests

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -265,6 +265,7 @@
         <filtering>false</filtering>
         <excludes>
           <exclude>**/*.java</exclude>
+          <exclude>**/*.kt</exclude>
           <exclude>**/*.properties</exclude>
         </excludes>
       </resource>
@@ -554,6 +555,7 @@
             <configuration>
               <target>
                 <fileset dir="${basedir}" includes="**/*.java,**/*.xml,**/*.bsh" excludes="target/**,.idea/**,nb-configuration.xml" id="missinglicense.fileset">
+                  <include name="**/*.kt"/>
                   <not>
                     <and>
                       <contains text="Copyright (c) 2009, 2018 Mountainminds GmbH &amp; Co. KG and Contributors"/>

--- a/org.jacoco.core.test.validation.kotlin/.classpath
+++ b/org.jacoco.core.test.validation.kotlin/.classpath
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/org.jacoco.core.test.validation.kotlin/.project
+++ b/org.jacoco.core.test.validation.kotlin/.project
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.jacoco.core.test.validation.kotlin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>.settings</name>
+			<type>2</type>
+			<locationURI>PARENT-1-PROJECT_LOC/org.jacoco.core.test/.settings</locationURI>
+		</link>
+	</linkedResources>
+</projectDescription>

--- a/org.jacoco.core.test.validation.kotlin/pom.xml
+++ b/org.jacoco.core.test.validation.kotlin/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jacoco</groupId>
+    <artifactId>org.jacoco.core.test.validation</artifactId>
+    <version>0.8.2-SNAPSHOT</version>
+    <relativePath>../org.jacoco.core.test.validation</relativePath>
+  </parent>
+
+  <artifactId>org.jacoco.core.test.validation.kotlin</artifactId>
+
+  <name>JaCoCo :: Test :: Core :: Validation Kotlin</name>
+
+  <properties>
+    <bytecode.version>6</bytecode.version>
+    <kotlin.version>1.2.60</kotlin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>org.jacoco.core.test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinTopLevelFunctionTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinTopLevelFunctionTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinTopLevelFunctionTargetKt;
+import org.junit.Test;
+
+/**
+ * Test of top level function.
+ */
+public class KotlinTopLevelFunctionTest extends ValidationTestBase {
+
+	public KotlinTopLevelFunctionTest() {
+		super(KotlinTopLevelFunctionTargetKt.class);
+	}
+
+	@Test
+	public void test() {
+		assertLine("fun", ICounter.FULLY_COVERED);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinTopLevelFunctionTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinTopLevelFunctionTarget.kt
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+/**
+ * This test target is top level function.
+ */
+fun main(args: Array<String>) {
+} // $line-fun$

--- a/org.jacoco.core.test.validation/pom.xml
+++ b/org.jacoco.core.test.validation/pom.xml
@@ -62,6 +62,9 @@
           <value>6</value>
         </property>
       </activation>
+      <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
+      </modules>
     </profile>
 
     <profile>
@@ -72,6 +75,9 @@
           <value>6</value>
         </property>
       </activation>
+      <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
+      </modules>
     </profile>
 
     <profile>
@@ -83,6 +89,7 @@
         </property>
       </activation>
       <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
       </modules>
     </profile>
@@ -96,6 +103,7 @@
         </property>
       </activation>
       <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
       </modules>
     </profile>
@@ -109,7 +117,11 @@
           <value>8</value>
         </property>
       </activation>
+      <properties>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+      </properties>
       <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
       </modules>
@@ -124,11 +136,13 @@
         </property>
       </activation>
       <properties>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <!-- see respective profile in org.jacoco.build about this override -->
         <maven.compiler.source>10</maven.compiler.source>
         <maven.compiler.target>10</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
       </modules>
@@ -143,11 +157,13 @@
         </property>
       </activation>
       <properties>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <!-- see respective profile in org.jacoco.build about this override -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
       </modules>
@@ -162,11 +178,13 @@
         </property>
       </activation>
       <properties>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <!-- see respective profile in org.jacoco.build about this override -->
         <maven.compiler.source>12</maven.compiler.source>
         <maven.compiler.target>12</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
       </modules>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -105,6 +105,11 @@
   </thead>
   <tbody>
   <tr>
+    <th>org.jacoco.core.test.validation.kotlin</th>
+    <td colspan="1">excluded from build</td>
+    <td colspan="5">compiled into bytecode version 50 (Java 6)</td>
+  </tr>
+  <tr>
     <th>org.jacoco.core.test.validation.java7</th>
     <td colspan="2">excluded from build</td>
     <td colspan="4">compiled into bytecode version 51 (Java 7)</td>


### PR DESCRIPTION
PR #709 contains more/other tests, however
* it was done before #711 and so doesn't execute them on JDKs and bytecode versions other than 8
* these tests require some rework/cleanup

This PR
* allows to compile Kotlin source files into all bytecode versions supported by `kolinc` (6 and 8) 
* and execute them in all JDKs >= 6
* uses more recent version of Kotlin - most recent as of today
* allows addition of new filters and corresponding tests (#704) without waiting cleanup of tests in #709
* adds basic test that utilizes/validates #714
* adds check of presence of license info in Kotlin source files
