### PR TITLE
`assertLine(String, int)` should imply zero number of branches

### DIFF
--- a/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/EnumImplicitMethodsTest.java
+++ b/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/EnumImplicitMethodsTest.java
@@ -33,7 +33,7 @@ public class EnumImplicitMethodsTest extends ValidationTestBase {
         assertLine("customValueOfMethod", ICounter.NOT_COVERED);
         assertLine("customValuesMethod", ICounter.NOT_COVERED);
 
-        assertLine("const", ICounter.PARTLY_COVERED);
+        assertLine("const", ICounter.PARTLY_COVERED, 1, 1);
         assertLine("staticblock", ICounter.FULLY_COVERED);
         assertLine("super", ICounter.FULLY_COVERED);
         assertLine("constructor", ICounter.FULLY_COVERED);

--- a/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/FinallyTest.java
+++ b/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/FinallyTest.java
@@ -117,7 +117,7 @@ public class FinallyTest extends ValidationTestBase {
 		}
 		assertLine("twoRegions.2", ICounter.EMPTY);
 
-		assertLine("twoRegions.if", ICounter.FULLY_COVERED);
+		assertLine("twoRegions.if", ICounter.FULLY_COVERED, 1, 1);
 		assertLine("twoRegions.region.1", ICounter.FULLY_COVERED);
 		assertLine("twoRegions.region.2", ICounter.NOT_COVERED);
 	}

--- a/org.jacoco.core.test.validation.java7/src/org/jacoco/core/test/validation/java7/StringSwitchTest.java
+++ b/org.jacoco.core.test.validation.java7/src/org/jacoco/core/test/validation/java7/StringSwitchTest.java
@@ -36,10 +36,10 @@ public class StringSwitchTest extends ValidationTestBase {
 		} else {
 			assertLine("covered.switch", ICounter.PARTLY_COVERED, 2, 7);
 		}
-		assertLine("covered.case1", ICounter.FULLY_COVERED, 0, 0);
-		assertLine("covered.case2", ICounter.FULLY_COVERED, 0, 0);
-		assertLine("covered.case3", ICounter.FULLY_COVERED, 0, 0);
-		assertLine("covered.default", ICounter.FULLY_COVERED, 0, 0);
+		assertLine("covered.case1", ICounter.FULLY_COVERED);
+		assertLine("covered.case2", ICounter.FULLY_COVERED);
+		assertLine("covered.case3", ICounter.FULLY_COVERED);
+		assertLine("covered.default", ICounter.FULLY_COVERED);
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class StringSwitchTest extends ValidationTestBase {
 	@Test
 	public void handwritten() {
 		assertLine("handwritten.firstSwitch", ICounter.FULLY_COVERED, 2, 1);
-		assertLine("handwritten.ignored", ICounter.FULLY_COVERED);
+		assertLine("handwritten.ignored", ICounter.FULLY_COVERED, 1, 1);
 		assertLine("handwritten.secondSwitch", ICounter.FULLY_COVERED, 3, 1);
 		assertLine("handwritten.case1", ICounter.FULLY_COVERED);
 		assertLine("handwritten.case2", ICounter.NOT_COVERED);

--- a/org.jacoco.core.test.validation.java7/src/org/jacoco/core/test/validation/java7/TryWithResourcesTest.java
+++ b/org.jacoco.core.test.validation.java7/src/org/jacoco/core/test/validation/java7/TryWithResourcesTest.java
@@ -89,7 +89,7 @@ public class TryWithResourcesTest extends ValidationTestBase {
 			// https://bugs.openjdk.java.net/browse/JDK-8134759
 			// javac 7 and 8 up to 8u92 are affected
 			if (JAVA_VERSION.isBefore("1.8.0_92")) {
-				assertLine("returnInBody.close", ICounter.FULLY_COVERED, 0, 0);
+				assertLine("returnInBody.close", ICounter.FULLY_COVERED);
 			} else {
 				assertLine("returnInBody.close", ICounter.EMPTY);
 			}
@@ -130,10 +130,10 @@ public class TryWithResourcesTest extends ValidationTestBase {
 		} else {
 			assertLine("nested.try3", ICounter.EMPTY);
 		}
-		assertLine("nested.open3", ICounter.FULLY_COVERED, 0, 0);
-		assertLine("nested.body3", ICounter.FULLY_COVERED, 0, 0);
+		assertLine("nested.open3", ICounter.FULLY_COVERED);
+		assertLine("nested.body3", ICounter.FULLY_COVERED);
 		assertLine("nested.catch3", ICounter.NOT_COVERED);
-		assertLine("nested.finally3", ICounter.FULLY_COVERED, 0, 0);
+		assertLine("nested.finally3", ICounter.FULLY_COVERED);
 
 		// without filter next lines have branches:
 		assertLine("nested.close3", ICounter.EMPTY);
@@ -186,14 +186,14 @@ public class TryWithResourcesTest extends ValidationTestBase {
 			assertLine("empty.try", ICounter.EMPTY);
 		}
 		assertLine("empty.open", ICounter.FULLY_COVERED);
-		// empty when EJC:
-		if (isJDKCompiler) {
-			if (JAVA_VERSION.isBefore("9")) {
-				// branches with javac 7 and 8
-				assertLine("empty.close", ICounter.PARTLY_COVERED);
-			} else {
-				assertLine("empty.close", ICounter.FULLY_COVERED, 0, 0);
-			}
+		if (!isJDKCompiler) {
+			assertLine("empty.close", ICounter.PARTLY_COVERED, 7, 1);
+		} else if (JAVA_VERSION.isBefore("8")) {
+			assertLine("empty.close", ICounter.PARTLY_COVERED, 6, 2);
+		} else if (JAVA_VERSION.isBefore("9")) {
+			assertLine("empty.close", ICounter.PARTLY_COVERED, 2, 2);
+		} else {
+			assertLine("empty.close", ICounter.FULLY_COVERED);
 		}
 	}
 
@@ -204,7 +204,11 @@ public class TryWithResourcesTest extends ValidationTestBase {
 	public void throwInBody() {
 		// not filtered
 		assertLine("throwInBody.try", ICounter.NOT_COVERED);
-		if (!isJDKCompiler || JAVA_VERSION.isBefore("11")) {
+		if (!isJDKCompiler){
+			assertLine("throwInBody.close", ICounter.NOT_COVERED, 6, 0);
+		} else if (JAVA_VERSION.isBefore("9")) {
+			assertLine("throwInBody.close", ICounter.NOT_COVERED, 4, 0);
+		} else if (JAVA_VERSION.isBefore("11")) {
 			assertLine("throwInBody.close", ICounter.NOT_COVERED);
 		} else {
 			assertLine("throwInBody.close", ICounter.EMPTY);

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -131,22 +131,28 @@ public abstract class ValidationTestBase {
 	}
 
 	protected void assertLine(final String tag, final int status) {
-		final int nr = source.getLineNumber(tag);
-		final ILine line = sourceCoverage.getLine(nr);
-		final String msg = String.format("Status in line %s: %s",
-				Integer.valueOf(nr), source.getLine(nr));
-		final int insnStatus = line.getInstructionCounter().getStatus();
-		assertEquals(msg, STATUS_NAME[status], STATUS_NAME[insnStatus]);
+		privateAssertLine(tag, status, 0, 0);
 	}
 
 	protected void assertLine(final String tag, final int status,
 			final int missedBranches, final int coveredBranches) {
-		assertLine(tag, status);
+		if (missedBranches == 0 && coveredBranches == 0) {
+			throw new IllegalArgumentException(
+					"Omit redundant specification of zero number of branches");
+		}
+		privateAssertLine(tag, status, missedBranches, coveredBranches);
+	}
+
+	private void privateAssertLine(final String tag, final int status,
+			final int missedBranches, final int coveredBranches) {
 		final int nr = source.getLineNumber(tag);
 		final ILine line = sourceCoverage.getLine(nr);
-		final String msg = String.format("Branches in line %s: %s",
-				Integer.valueOf(nr), source.getLine(nr));
-		assertEquals(msg + " branches",
+		final String lineMsg = String.format("line %s: %s", Integer.valueOf(nr),
+				source.getLine(nr));
+		final int insnStatus = line.getInstructionCounter().getStatus();
+		assertEquals("Instructions in " + lineMsg, STATUS_NAME[status],
+				STATUS_NAME[insnStatus]);
+		assertEquals("Branches in " + lineMsg,
 				CounterImpl.getInstance(missedBranches, coveredBranches),
 				line.getBranchCounter());
 	}


### PR DESCRIPTION
IMO usage of

https://github.com/jacoco/jacoco/blob/bbee0397a1ff4e39bab42c731531d02cc404fc2b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java#L133

is error-prone since it doesn't imply zero number of branches, especially when presence of branch is not obvious like in Kotlin for `when` expressions and `lateinit`. At least I'm constantly stepping on this during implementation of filters, and miss branches that should be filtered out.