### PR TITLE
Upgrade ASM to 6.2.1

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -138,7 +138,7 @@
     <argLine>${jvm.args}</argLine>
 
     <!-- Dependencies versions -->
-    <asm.version>6.2</asm.version>
+    <asm.version>6.2.1</asm.version>
     <ant.version>1.7.1</ant.version>
     <args4j.version>2.0.28</args4j.version>
     <junit.version>4.8.2</junit.version>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -53,8 +53,9 @@
 
 <h3>Non-functional Changes</h3>
 <ul>
-  <li>JaCoCo now depends on ASM 6.2
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/706">#706</a>).</li>
+  <li>JaCoCo now depends on ASM 6.2.1
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/706">#706</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/725">#725</a>).</li>
   <li>Improved error message when already instrumented classes are used for
       instrumentation or analysis
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/703">#703</a>).</li>


### PR DESCRIPTION
As usual classes of JDK 12 EA already compiled into new bytecode version 56, so that `ModifiedSystemClassRuntime` can't be used without downgrade-upgrade workaround or ASM upgrade.

To notice changes in javac 12 EA unrelated to bytecode version such as #669 or even regressions such as [JDK-8180141](https://bugs.openjdk.java.net/browse/JDK-8180141), one currently need to exclude integration tests which use agent:

```
$ java -version
openjdk version "12-ea" 2019-03-19
OpenJDK Runtime Environment 19.3 (build 12-ea+5)
OpenJDK 64-Bit Server VM 19.3 (build 12-ea+5, mixed mode)

$ mvn -V -B -e clean verify -Dbytecode.version=11 \
    -Djacoco.skip \
    -pl \!org.jacoco.ant.test,\!jacoco-maven-plugin.test,\!org.jacoco.examples.test,\!org.jacoco.doc,\!jacoco
```

Fortunately ASM 6.2.1 among other bug fixes and small improvements ( https://asm.ow2.io/versions.html , https://gitlab.ow2.org/asm/asm/compare/ASM_6_2...ASM_6_2_1 ) contains https://gitlab.ow2.org/asm/asm/merge_requests/187 with following interesting comments:

> Eric Bruneton: Are there new bytecode features in this version? [...]
> Remi Forax: None i'm aware of, plan for 12 are only languages changes (at that point). [...]

So to test compiler one can simply do

```
$ mvn clean verify -Dbytecode.version=11 \
    -Dasm.version=6.2.1
```

I propose to upgrade ASM anyway and maybe later think about experimental support for Java 12 class files.