### PR TITLE
Remove useless `jacoco.fileSets` from documentation of `MergeMojo`

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
@@ -59,7 +59,7 @@ public class MergeMojo extends AbstractJacocoMojo {
 	 * </code>
 	 * </pre>
 	 */
-	@Parameter(property = "jacoco.fileSets", required = true)
+	@Parameter(required = true)
 	private List<FileSet> fileSets;
 
 	@Override


### PR DESCRIPTION
Maven can not convert string specified in command line into `List<FileSet>`.

Fixes #438