### PR TITLE
Do not use `~/.m2/settings.xml` provided by Travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -85,20 +85,25 @@ case "$JDK" in
     mvn -V -B -e -f org.jacoco.build verify sonar:sonar deploy:deploy -DdeployAtEnd -Djdk.version=5 --toolchains=./.travis/toolchains.xml --settings=./.travis/settings.xml -Dsonar.host.url=${SONARQUBE_URL} -Dsonar.login=${SONARQUBE_TOKEN}
     python ./.travis/trigger-site-deployment.py
   else
-    mvn -V -B -e verify -Djdk.version=5 --toolchains=./.travis/toolchains.xml
+    mvn -V -B -e verify -Djdk.version=5 --toolchains=./.travis/toolchains.xml \
+      --settings=./.travis/settings.xml
   fi
   ;;
 6 | 7 | 8 | 9)
-  mvn -V -B -e verify -Djdk.version=${JDK} -Dbytecode.version=${JDK} -Decj=${ECJ:-} --toolchains=./.travis/travis-toolchains.xml
+  mvn -V -B -e verify -Djdk.version=${JDK} -Dbytecode.version=${JDK} -Decj=${ECJ:-} --toolchains=./.travis/travis-toolchains.xml \
+    --settings=./.travis/settings.xml
   ;;
 10)
-  mvn -V -B -e verify -Dbytecode.version=10
+  mvn -V -B -e verify -Dbytecode.version=10 \
+    --settings=./.travis/settings.xml
   ;;
 11-ea)
-  mvn -V -B -e verify -Dbytecode.version=11
+  mvn -V -B -e verify -Dbytecode.version=11 \
+    --settings=./.travis/settings.xml
   ;;
 12-ea)
-  mvn -V -B -e verify -Dbytecode.version=12
+  mvn -V -B -e verify -Dbytecode.version=12 \
+    --settings=./.travis/settings.xml
   ;;
 *)
   echo "Incorrect JDK [$JDK]"


### PR DESCRIPTION
In Travis `maven-javadoc-plugin:2.10.4` tries to download some artifacts and causes long build times:

```
...
[INFO] --- maven-javadoc-plugin:2.10.4:jar (attach-javadocs) @ org.jacoco.doc ---
...
[INFO] Downloading from sonatype: https://oss.sonatype.org/content/repositories/releases/org/ow2/asm/asm-commons/6.2.1/asm-commons-6.2.1-javadoc-resources.jar
[INFO] Downloading from sonatype-apache: https://repository.apache.org/releases/org/ow2/asm/asm-commons/6.2.1/asm-commons-6.2.1-javadoc-resources.jar
...
[INFO] JaCoCo :: Documentation ............................ SUCCESS [21:35 min]
...
```

Repositories `sonatype` and `sonatype-apache` are [defined by Travis in its `~/.m2/settings.xml`](https://github.com/travis-ci/travis-cookbooks/blob/b3d510af30ab32835a6738fd6803ee9a57633569/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml) and seems that there is an issue with access to these repositoeis from Travis (can't reproduce locally).

----

Attempts to download disappear after upgrade of `maven-javadoc-plugin` to latest released version `3.0.1`.
But I didn't managed to find ticket or corresponding change to understand why.

Also due to [changes](https://github.com/apache/maven-javadoc-plugin/commit/8023d89be9bac9088128e25bdc02d7c34823f1ec) for [MJAVADOC-498](https://issues.apache.org/jira/browse/MJAVADOC-498) this upgrade causes non fatal error messages

```
...
[INFO] --- maven-javadoc-plugin:3.0.1:jar (attach-javadocs) @ org.jacoco.doc ---
[ERROR] no module descriptor for org.jacoco:org.jacoco.doc
[ERROR] no module descriptor for org.jacoco:org.jacoco.core
[ERROR] no module descriptor for org.jacoco:org.jacoco.report
[ERROR] no module descriptor for org.jacoco:org.jacoco.agent
[ERROR] no module descriptor for org.jacoco:org.jacoco.agent.rt
[ERROR] no module descriptor for org.jacoco:org.jacoco.ant
[ERROR] no module descriptor for org.jacoco:org.jacoco.cli
[ERROR] no module descriptor for org.jacoco:org.jacoco.examples
[ERROR] no module descriptor for org.jacoco:jacoco-maven-plugin
...
[INFO] JaCoCo :: Documentation ............................ SUCCESS [  4.643 s]
[INFO] JaCoCo :: Distribution ............................. SUCCESS [  1.540 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
...
```

even when using JDK 8.

----

Since in absence of custom repositories attempts to download also disappear, I propose to simply stop using `~/.m2/settings.xml` that is provided by Travis.
