### PR TITLE
Modernize JaCoCo Reports design

### DIFF
--- a/org.jacoco.doc/docroot/doc/agent.html
+++ b/org.jacoco.doc/docroot/doc/agent.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Java Agent</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -12,8 +12,8 @@
 <body onload="prettyPrint()">
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;;
   <span class="el_source">Ant Tasks</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/api.html
+++ b/org.jacoco.doc/docroot/doc/api.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">API Usage Examples</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -30,8 +30,8 @@
 <body onload="prettyPrint()">
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Build</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Change History</span>
 </div>
 <div id="content">

--- a/org.jacoco.doc/docroot/doc/classids.html
+++ b/org.jacoco.doc/docroot/doc/classids.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Class Ids</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/conventions.html
+++ b/org.jacoco.doc/docroot/doc/conventions.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Development Conventions</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/counters.html
+++ b/org.jacoco.doc/docroot/doc/counters.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Coverage Counters</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/empty.html
+++ b/org.jacoco.doc/docroot/doc/empty.html
@@ -10,7 +10,7 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
   <span class="el_source">Title</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Development Environment</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/epl-v10.html
+++ b/org.jacoco.doc/docroot/doc/epl-v10.html
@@ -17,7 +17,7 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
   <span class="el_source">Eclipse Public License - Version 1.0</span>
 </div>
 <div id="content">

--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">FAQ</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/flow.html
+++ b/org.jacoco.doc/docroot/doc/flow.html
@@ -12,8 +12,8 @@
 <body onload="prettyPrint()">
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Control Flow Analysis</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/implementation.html
+++ b/org.jacoco.doc/docroot/doc/implementation.html
@@ -12,8 +12,8 @@
 <body onload="prettyPrint()">
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Implementation Design</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/index.html
+++ b/org.jacoco.doc/docroot/doc/index.html
@@ -10,7 +10,7 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
   <span class="el_group">Documentation</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/integrations.html
+++ b/org.jacoco.doc/docroot/doc/integrations.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Integration Matrix</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/license.html
+++ b/org.jacoco.doc/docroot/doc/license.html
@@ -10,7 +10,7 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
   <span class="el_source">License</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/maven.html
+++ b/org.jacoco.doc/docroot/doc/maven.html
@@ -12,8 +12,8 @@
 <body onload="prettyPrint()">
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Maven Plug-in</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/mission.html
+++ b/org.jacoco.doc/docroot/doc/mission.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Mission</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/offline.html
+++ b/org.jacoco.doc/docroot/doc/offline.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Offline Instrumentation</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/repo.html
+++ b/org.jacoco.doc/docroot/doc/repo.html
@@ -12,8 +12,8 @@
 <body onload="prettyPrint()">
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Maven Repository</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/resources/doc.css
+++ b/org.jacoco.doc/docroot/doc/resources/doc.css
@@ -57,9 +57,17 @@ h1 {
 
 .breadcrumb {
   border:#d6d3ce 1px solid;
-  padding:2px 4px 2px 4px;
+  padding:6px 4px 4px 4px;
+  border-radius:3px;
 }
 
+.breadcrumb .info {
+  float:right;
+}
+
+.breadcrumb .info a {
+  margin-left:8px;
+}
 
 .el_report {
   padding-left:18px;
@@ -119,17 +127,19 @@ h1 {
 
 pre.source {
   border:#d6d3ce 1px solid;
+  border-radius:3px;
   font-family:monospace;
 }
 
 pre.source ol {
   margin-bottom: 0px;
   margin-top: 0px;
+  margin-left: 8px
 }
 
 pre.source li {
   border-left: 1px solid #D6D3CE;
-  color: #A0A0A0;
+  color: #cccccc;
   padding-left: 0px;
 }
 
@@ -138,17 +148,49 @@ pre.source span.fc {
 }
 
 pre.source span.nc {
-  background-color:#ffcccc;
+  background-color:#ffaaaa;
 }
 
 pre.source span.pc {
   background-color:#ffffcc;
 }
 
+pre.source span.bfc {
+  background-image: url(branchfc.gif);
+  background-repeat: no-repeat;
+  background-position: 2px center;
+}
+
+pre.source span.bfc:hover {
+  background-color:#80ff80;
+}
+
+pre.source span.bnc {
+  background-image: url(branchnc.gif);
+  background-repeat: no-repeat;
+  background-position: 2px center;
+}
+
+pre.source span.bnc:hover {
+  background-color:#ff8080;
+}
+
+pre.source span.bpc {
+  background-image: url(branchpc.gif);
+  background-repeat: no-repeat;
+  background-position: 2px center;
+}
+
+pre.source span.bpc:hover {
+  background-color:#ffff80;
+}
 
 table.coverage {
   empty-cells:show;
-  border-collapse:collapse; 
+  border-spacing:0;
+  border-collapse:separate; 
+  border-radius:3px;
+  border:#c0c0c0 1px solid;
 }
 
 table.coverage thead {
@@ -157,61 +199,90 @@ table.coverage thead {
 
 table.coverage thead td {
   white-space:nowrap;
-  padding:2px 8px 0px 8px;
-  border-bottom:#b0b0b0 1px solid;
+  padding:4px 14px 2px 6px;
+}
+
+table.coverage thead td.bar {
+  border-left:#cccccc 1px solid;
 }
 
 table.coverage thead td.ctr1 {
   text-align:right;
-  padding-right:4px;
   border-left:#cccccc 1px solid;
 }
 
 table.coverage thead td.ctr2 {
   text-align:right;
-  padding-left:4px;
+  padding-left:2px;
+}
+
+table.coverage thead td.sortable {
+  cursor:pointer;
+  background-image:url(sort.gif);
+  background-position:right center;
+  background-repeat:no-repeat;
+}
+
+table.coverage thead td.up {
+  background-image:url(up.gif);
+}
+
+table.coverage thead td.down {
+  background-image:url(down.gif);
 }
 
 table.coverage tbody td {
-  vertical-align:top;
-  padding:2px 8px 2px 8px;
-  border-bottom:#d6d3ce 1px solid;
+  white-space:nowrap;
+  padding:4px 6px 2px 6px;
+  border-top:#c0c0c0 1px solid;
 }
 
 table.coverage tbody tr:hover { 
   background: #f0f0d0 !important;
 }
 
+table.coverage tbody td.bar {
+  border-left:#e8e8e8 1px solid;
+}
+
 table.coverage tbody td.ctr1 {
   text-align:right;
-  padding-right:4px;
+  padding-right:14px;
   border-left:#e8e8e8 1px solid;
 }
 
 table.coverage tbody td.ctr2 {
   text-align:right;
-  padding-left:4px;
+  padding-right:14px;
+  padding-left:2px;
 }
 
 table.coverage tfoot td {
-  padding:2px 8px 2px 8px;
+  white-space:nowrap;
+  padding:4px 6px 2px 6px;
+  border-top:#c0c0c0 1px solid;  
+}
+
+table.coverage tfoot td.bar {
+  border-left:#e8e8e8 1px solid;
 }
 
 table.coverage tfoot td.ctr1 {
   text-align:right;
-  padding-right:4px;
+  padding-right:14px;
   border-left:#e8e8e8 1px solid;
 }
 
 table.coverage tfoot td.ctr2 {
   text-align:right;
-  padding-left:4px;
+  padding-right:14px;
+  padding-left:2px;
 }
 
 .footer {
   margin-top:20px;
   border-top:#d6d3ce 1px solid;
-  padding-top:2px;
+  padding-top:4px;
   font-size:8pt;
   color:#a0a0a0;
 }

--- a/org.jacoco.doc/docroot/doc/support.html
+++ b/org.jacoco.doc/docroot/doc/support.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Support and Feedback</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/docroot/doc/team.html
+++ b/org.jacoco.doc/docroot/doc/team.html
@@ -10,8 +10,8 @@
 <body>
 
 <div class="breadcrumb">
-  <a href="../index.html" class="el_report">JaCoCo</a> &gt;
-  <a href="index.html" class="el_group">Documentation</a> &gt;
+  <a href="../index.html" class="el_report">JaCoCo</a> &#x25b8;
+  <a href="index.html" class="el_group">Documentation</a> &#x25b8;
   <span class="el_source">Team</span>
 </div>
 <div id="content"> 

--- a/org.jacoco.doc/xsl/cli.xsl
+++ b/org.jacoco.doc/xsl/cli.xsl
@@ -35,8 +35,8 @@
 			</head>
 			<body>
 				<div class="breadcrumb">
-					<a href="../index.html" class="el_report">JaCoCo</a> &gt;
-					<a href="index.html" class="el_group">Documentation</a> &gt;
+					<a href="../index.html" class="el_report">JaCoCo</a>&#xa0;&#x25b8;&#xa0;
+					<a href="index.html" class="el_group">Documentation</a>&#xa0;&#x25b8;&#xa0;
 					<span class="el_source">Command Line Interface</span>
 				</div>
 				<div id="content">

--- a/org.jacoco.doc/xsl/junit-noframes.xsl
+++ b/org.jacoco.doc/xsl/junit-noframes.xsl
@@ -224,7 +224,7 @@
 <!-- Page HEADER -->
 <xsl:template name="pageHeader">
 	<div class="breadcrumb">
-		<a href="../index.html" class="el_report">JaCoCo</a> &gt;
+		<a href="../index.html" class="el_report">JaCoCo</a>&#xa0;&#x25b8;&#xa0;
 		<span class="el_testsuite">JUnit Test Results</span>
 	</div>
     <h1>JUnit Test Results</h1>

--- a/org.jacoco.doc/xsl/maven-goal.xsl
+++ b/org.jacoco.doc/xsl/maven-goal.xsl
@@ -38,11 +38,11 @@
 			<body>
 				<div class="breadcrumb">
 					<a href="../index.html" class="el_report">JaCoCo</a>
-					&gt;
+					&#xa0;&#x25b8;&#xa0;
 					<a href="index.html" class="el_group">Documentation</a>
-					&gt;
+					&#xa0;&#x25b8;&#xa0;
 					<a href="maven.html" class="el_group">Maven</a>
-					&gt;
+					&#xa0;&#x25b8;&#xa0;
 					<span class="el_source">
 						<xsl:value-of select="xdoc:document/xdoc:properties/xdoc:title" />
 					</span>

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/ReportPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/ReportPage.java
@@ -28,6 +28,8 @@ import org.jacoco.report.internal.html.resources.Styles;
  */
 public abstract class ReportPage implements ILinkable {
 
+	private static final String BREADCRUMP_SEPARATOR = " \u25b8 ";
+
 	private final ReportPage parent;
 
 	/** output folder for this node */
@@ -141,7 +143,7 @@ public abstract class ReportPage implements ILinkable {
 		if (page != null) {
 			breadcrumbParent(page.parent, div, base);
 			div.a(page, base);
-			div.text(" > ");
+			div.text(BREADCRUMP_SEPARATOR);
 		}
 	}
 

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/resources/report.css
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/resources/report.css
@@ -10,7 +10,8 @@ h1 {
 
 .breadcrumb {
   border:#d6d3ce 1px solid;
-  padding:2px 4px 2px 4px;
+  padding:6px 4px 4px 4px;
+  border-radius:3px;
 }
 
 .breadcrumb .info {
@@ -79,17 +80,19 @@ h1 {
 
 pre.source {
   border:#d6d3ce 1px solid;
+  border-radius:3px;
   font-family:monospace;
 }
 
 pre.source ol {
   margin-bottom: 0px;
   margin-top: 0px;
+  margin-left: 8px
 }
 
 pre.source li {
   border-left: 1px solid #D6D3CE;
-  color: #A0A0A0;
+  color: #cccccc;
   padding-left: 0px;
 }
 
@@ -137,7 +140,10 @@ pre.source span.bpc:hover {
 
 table.coverage {
   empty-cells:show;
-  border-collapse:collapse; 
+  border-spacing:0;
+  border-collapse:separate; 
+  border-radius:3px;
+  border:#c0c0c0 1px solid;
 }
 
 table.coverage thead {
@@ -146,8 +152,7 @@ table.coverage thead {
 
 table.coverage thead td {
   white-space:nowrap;
-  padding:2px 14px 0px 6px;
-  border-bottom:#b0b0b0 1px solid;
+  padding:4px 14px 2px 6px;
 }
 
 table.coverage thead td.bar {
@@ -181,8 +186,8 @@ table.coverage thead td.down {
 
 table.coverage tbody td {
   white-space:nowrap;
-  padding:2px 6px 2px 6px;
-  border-bottom:#d6d3ce 1px solid;
+  padding:4px 6px 2px 6px;
+  border-top:#c0c0c0 1px solid;
 }
 
 table.coverage tbody tr:hover { 
@@ -207,7 +212,8 @@ table.coverage tbody td.ctr2 {
 
 table.coverage tfoot td {
   white-space:nowrap;
-  padding:2px 6px 2px 6px;
+  padding:4px 6px 2px 6px;
+  border-top:#c0c0c0 1px solid;  
 }
 
 table.coverage tfoot td.bar {
@@ -229,7 +235,7 @@ table.coverage tfoot td.ctr2 {
 .footer {
   margin-top:20px;
   border-top:#d6d3ce 1px solid;
-  padding-top:2px;
+  padding-top:4px;
   font-size:8pt;
   color:#a0a0a0;
 }


### PR DESCRIPTION
By adjusting some CSS the look & feel can be improved a bit:

<img width="1106" alt="report" src="https://user-images.githubusercontent.com/1936262/45513014-d79fec80-b7a1-11e8-8ab8-ff517b515691.png">

* left and right border for tables
* round corners for boxes (header, table, source)
* increased line distance for better horizontal readability
* Use unicode triangles as separators in bread crump header.

