### PR TITLE
Fix Typo issue

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/runtime/CommandLineSupport.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/CommandLineSupport.java
@@ -54,13 +54,13 @@ final class CommandLineSupport {
 	 */
 	static String quote(final List<String> args) {
 		final StringBuilder result = new StringBuilder();
-		boolean seperate = false;
+		boolean separate = false;
 		for (final String arg : args) {
-			if (seperate) {
+			if (separate) {
 				result.append(BLANK);
 			}
 			result.append(quote(arg));
-			seperate = true;
+			separate = true;
 		}
 		return result.toString();
 	}
@@ -70,7 +70,7 @@ final class CommandLineSupport {
 	 * present.
 	 * 
 	 * @param commandline
-	 *            combinded command line
+	 *            combined command line
 	 * @return list of arguments
 	 */
 	static List<String> split(final String commandline) {

--- a/org.jacoco.core/src/org/jacoco/core/runtime/CommandLineSupport.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/CommandLineSupport.java
@@ -79,11 +79,11 @@ final class CommandLineSupport {
 		}
 		final List<String> args = new ArrayList<String>();
 		final StringBuilder current = new StringBuilder();
-		int mode = M_STRIPWHITESPACE;
+		int mode = M_STRIP_WHITESPACE;
 		int endChar = BLANK;
 		for (final char c : commandline.toCharArray()) {
 			switch (mode) {
-			case M_STRIPWHITESPACE:
+			case M_STRIP_WHITESPACE:
 				if (!Character.isWhitespace(c)) {
 					if (c == QUOTE) {
 						endChar = QUOTE;
@@ -91,13 +91,13 @@ final class CommandLineSupport {
 						current.append(c);
 						endChar = BLANK;
 					}
-					mode = M_PARSEARGUMENT;
+					mode = M_PARSE_ARGUMENT;
 				}
 				break;
-			case M_PARSEARGUMENT:
+			case M_PARSE_ARGUMENT:
 				if (c == endChar) {
 					addArgument(args, current);
-					mode = M_STRIPWHITESPACE;
+					mode = M_STRIP_WHITESPACE;
 				} else if (c == SLASH) {
 					current.append(SLASH);
 					mode = M_ESCAPED;
@@ -110,11 +110,11 @@ final class CommandLineSupport {
 					current.setCharAt(current.length() - 1, c);
 				} else if (c == endChar) {
 					addArgument(args, current);
-					mode = M_STRIPWHITESPACE;
+					mode = M_STRIP_WHITESPACE;
 				} else {
 					current.append(c);
 				}
-				mode = M_PARSEARGUMENT;
+				mode = M_PARSE_ARGUMENT;
 				break;
 			}
 		}
@@ -130,8 +130,8 @@ final class CommandLineSupport {
 		}
 	}
 
-	private static final int M_STRIPWHITESPACE = 0;
-	private static final int M_PARSEARGUMENT = 1;
+	private static final int M_STRIP_WHITESPACE = 0;
+	private static final int M_PARSE_ARGUMENT = 1;
 	private static final int M_ESCAPED = 2;
 
 	private CommandLineSupport() {


### PR DESCRIPTION
- Fix typo `separete` and `combined`
- Make `M_STRIPWHITESPACE ` redable by replacing it with `M_STRIP_WHITESPACE `
- Also for `M_PARSEARGUMENT ` with `M_PARSE_ARGUMENT `