### PR TITLE
Remove redundant public modifier in interfaces

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/IExceptionLogger.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/IExceptionLogger.java
@@ -32,6 +32,6 @@ public interface IExceptionLogger {
 	 * @param ex
 	 *            exception to log
 	 */
-	public void logExeption(Exception ex);
+	void logExeption(Exception ex);
 
 }

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/IAgentOutput.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/IAgentOutput.java
@@ -33,8 +33,7 @@ public interface IAgentOutput {
 	 * @throws Exception
 	 *             in case startup fails
 	 */
-	void startup(AgentOptions options, RuntimeData data)
-			throws Exception;
+	void startup(AgentOptions options, RuntimeData data) throws Exception;
 
 	/**
 	 * Shutdown the agent controller and clean up any resources it has created.

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/IAgentOutput.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/IAgentOutput.java
@@ -33,7 +33,7 @@ public interface IAgentOutput {
 	 * @throws Exception
 	 *             in case startup fails
 	 */
-	public void startup(final AgentOptions options, final RuntimeData data)
+	void startup(AgentOptions options, RuntimeData data)
 			throws Exception;
 
 	/**
@@ -42,7 +42,7 @@ public interface IAgentOutput {
 	 * @throws Exception
 	 *             in case shutdown fails
 	 */
-	public void shutdown() throws Exception;
+	void shutdown() throws Exception;
 
 	/**
 	 * Write all execution data in the runtime to a location determined by the
@@ -53,6 +53,6 @@ public interface IAgentOutput {
 	 * @throws IOException
 	 *             in case writing fails
 	 */
-	public void writeExecutionData(boolean reset) throws IOException;
+	void writeExecutionData(boolean reset) throws IOException;
 
 }

--- a/org.jacoco.ant/src/org/jacoco/ant/CoverageTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/CoverageTask.java
@@ -179,7 +179,7 @@ public class CoverageTask extends AbstractCoverageTask implements TaskContainer 
 		 * @return <code>true</code> if this enhancer is capable of enhancing
 		 *         the requested task type
 		 */
-		public boolean supportsTask(String taskname);
+		boolean supportsTask(String taskname);
 
 		/**
 		 * Attempt to enhance the supplied task with coverage information. This
@@ -192,6 +192,6 @@ public class CoverageTask extends AbstractCoverageTask implements TaskContainer 
 		 *             Thrown if this enhancer can handle this type of task, but
 		 *             this instance can not be enhanced for some reason.
 		 */
-		public void enhanceTask(Task task) throws BuildException;
+		void enhanceTask(Task task) throws BuildException;
 	}
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/IPerfOutput.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/IPerfOutput.java
@@ -17,7 +17,7 @@ package org.jacoco.core.test.perf;
 public interface IPerfOutput {
 
 	/** Indicator for no reference time given */
-	public static final long NO_REFERENCE = Long.MIN_VALUE;
+	long NO_REFERENCE = Long.MIN_VALUE;
 
 	/**
 	 * Reports the result of a time measurement with a optional reference time

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/IPerfScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/IPerfScenario.java
@@ -22,6 +22,6 @@ public interface IPerfScenario {
 	 * 
 	 * @param output
 	 */
-	public void run(IPerfOutput output) throws Exception;
+	void run(IPerfOutput output) throws Exception;
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/IBundleCoverage.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/IBundleCoverage.java
@@ -25,6 +25,6 @@ public interface IBundleCoverage extends ICoverageNode {
 	 * 
 	 * @return all packages
 	 */
-	public Collection<IPackageCoverage> getPackages();
+	Collection<IPackageCoverage> getPackages();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/IClassCoverage.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/IClassCoverage.java
@@ -27,7 +27,7 @@ public interface IClassCoverage extends ISourceNode {
 	 * 
 	 * @return class identifier
 	 */
-	public long getId();
+	long getId();
 
 	/**
 	 * Returns if the the analyzed class does match the execution data provided.
@@ -37,14 +37,14 @@ public interface IClassCoverage extends ISourceNode {
 	 * @return <code>true</code> if this class does not match to the provided
 	 *         execution data.
 	 */
-	public boolean isNoMatch();
+	boolean isNoMatch();
 
 	/**
 	 * Returns the VM signature of the class.
 	 * 
 	 * @return VM signature of the class (may be <code>null</code>)
 	 */
-	public String getSignature();
+	String getSignature();
 
 	/**
 	 * Returns the VM name of the superclass.
@@ -52,34 +52,34 @@ public interface IClassCoverage extends ISourceNode {
 	 * @return VM name of the super class (may be <code>null</code>, i.e.
 	 *         <code>java/lang/Object</code>)
 	 */
-	public String getSuperName();
+	String getSuperName();
 
 	/**
 	 * Returns the VM names of implemented/extended interfaces.
 	 * 
 	 * @return VM names of implemented/extended interfaces
 	 */
-	public String[] getInterfaceNames();
+	String[] getInterfaceNames();
 
 	/**
 	 * Returns the VM name of the package this class belongs to.
 	 * 
 	 * @return VM name of the package
 	 */
-	public String getPackageName();
+	String getPackageName();
 
 	/**
 	 * Returns the optional name of the corresponding source file.
 	 * 
 	 * @return name of the corresponding source file
 	 */
-	public String getSourceFileName();
+	String getSourceFileName();
 
 	/**
 	 * Returns the methods included in this class.
 	 * 
 	 * @return methods of this class
 	 */
-	public Collection<IMethodCoverage> getMethods();
+	Collection<IMethodCoverage> getMethods();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ICounter.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ICounter.java
@@ -20,7 +20,7 @@ public interface ICounter {
 	/**
 	 * Different values provided by a counter.
 	 */
-	public enum CounterValue {
+	enum CounterValue {
 
 		/** Total number of items */
 		TOTALCOUNT,
@@ -41,22 +41,22 @@ public interface ICounter {
 	/**
 	 * Status flag for no items (value is 0x00).
 	 */
-	public static final int EMPTY = 0x00;
+	int EMPTY = 0x00;
 
 	/**
 	 * Status flag when all items are not covered (value is 0x01).
 	 */
-	public static final int NOT_COVERED = 0x01;
+	int NOT_COVERED = 0x01;
 
 	/**
 	 * Status flag when all items are covered (value is 0x02).
 	 */
-	public static final int FULLY_COVERED = 0x02;
+	int FULLY_COVERED = 0x02;
 
 	/**
 	 * Status flag when items are partly covered (value is 0x03).
 	 */
-	public static final int PARTLY_COVERED = NOT_COVERED | FULLY_COVERED;
+	int PARTLY_COVERED = NOT_COVERED | FULLY_COVERED;
 
 	/**
 	 * Returns the counter value of the given type.
@@ -65,28 +65,28 @@ public interface ICounter {
 	 *            value type to return
 	 * @return counter value
 	 */
-	public double getValue(CounterValue value);
+	double getValue(CounterValue value);
 
 	/**
 	 * Returns the total count of items.
 	 * 
 	 * @return total count of items
 	 */
-	public int getTotalCount();
+	int getTotalCount();
 
 	/**
 	 * Returns the count of covered items.
 	 * 
 	 * @return count of covered items
 	 */
-	public int getCoveredCount();
+	int getCoveredCount();
 
 	/**
 	 * Returns the count of missed items.
 	 * 
 	 * @return count of missed items
 	 */
-	public int getMissedCount();
+	int getMissedCount();
 
 	/**
 	 * Calculates the ratio of covered to total count items. If total count
@@ -94,7 +94,7 @@ public interface ICounter {
 	 * 
 	 * @return ratio of covered to total count items
 	 */
-	public double getCoveredRatio();
+	double getCoveredRatio();
 
 	/**
 	 * Calculates the ratio of missed to total count items. If total count items
@@ -102,7 +102,7 @@ public interface ICounter {
 	 * 
 	 * @return ratio of missed to total count items
 	 */
-	public double getMissedRatio();
+	double getMissedRatio();
 
 	/**
 	 * Returns the coverage status of this counter.
@@ -114,6 +114,6 @@ public interface ICounter {
 	 * 
 	 * @return status of this line
 	 */
-	public int getStatus();
+	int getStatus();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
@@ -20,7 +20,7 @@ public interface ICoverageNode {
 	/**
 	 * Type of a Java element represented by a {@link ICoverageNode} instance.
 	 */
-	public enum ElementType {
+	enum ElementType {
 
 		/** Method */
 		METHOD,
@@ -45,7 +45,7 @@ public interface ICoverageNode {
 	/**
 	 * Different counter types supported by JaCoCo.
 	 */
-	public enum CounterEntity {
+	enum CounterEntity {
 
 		/** Counter for instructions */
 		INSTRUCTION,
@@ -71,56 +71,56 @@ public interface ICoverageNode {
 	 * 
 	 * @return type of this node
 	 */
-	public abstract ElementType getElementType();
+	ElementType getElementType();
 
 	/**
 	 * Returns the name of this node.
 	 * 
 	 * @return name of this node
 	 */
-	public String getName();
+	String getName();
 
 	/**
 	 * Returns the counter for byte code instructions.
 	 * 
 	 * @return counter for instructions
 	 */
-	public abstract ICounter getInstructionCounter();
+	ICounter getInstructionCounter();
 
 	/**
 	 * Returns the counter for branches.
 	 * 
 	 * @return counter for branches
 	 */
-	public ICounter getBranchCounter();
+	ICounter getBranchCounter();
 
 	/**
 	 * Returns the counter for lines.
 	 * 
 	 * @return counter for lines
 	 */
-	public ICounter getLineCounter();
+	ICounter getLineCounter();
 
 	/**
 	 * Returns the counter for cyclomatic complexity.
 	 * 
 	 * @return counter for complexity
 	 */
-	public ICounter getComplexityCounter();
+	ICounter getComplexityCounter();
 
 	/**
 	 * Returns the counter for methods.
 	 * 
 	 * @return counter for methods
 	 */
-	public ICounter getMethodCounter();
+	ICounter getMethodCounter();
 
 	/**
 	 * Returns the counter for classes.
 	 * 
 	 * @return counter for classes
 	 */
-	public ICounter getClassCounter();
+	ICounter getClassCounter();
 
 	/**
 	 * Generic access to the the counters.
@@ -129,7 +129,7 @@ public interface ICoverageNode {
 	 *            entity we're we want to have the counter for
 	 * @return counter for the given entity
 	 */
-	public ICounter getCounter(CounterEntity entity);
+	ICounter getCounter(CounterEntity entity);
 
 	/**
 	 * Creates a plain copy of this node. While {@link ICoverageNode}
@@ -139,6 +139,6 @@ public interface ICoverageNode {
 	 * 
 	 * @return copy with counters only
 	 */
-	public ICoverageNode getPlainCopy();
+	ICoverageNode getPlainCopy();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageVisitor.java
@@ -23,6 +23,6 @@ public interface ICoverageVisitor {
 	 * @param coverage
 	 *            coverage data for a class
 	 */
-	public void visitCoverage(IClassCoverage coverage);
+	void visitCoverage(IClassCoverage coverage);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ILine.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ILine.java
@@ -22,14 +22,14 @@ public interface ILine {
 	 * 
 	 * @return instruction counter
 	 */
-	public ICounter getInstructionCounter();
+	ICounter getInstructionCounter();
 
 	/**
 	 * Returns the branches counter for this line.
 	 * 
 	 * @return branches counter
 	 */
-	public ICounter getBranchCounter();
+	ICounter getBranchCounter();
 
 	/**
 	 * Returns the coverage status of this line, calculated from the
@@ -42,6 +42,6 @@ public interface ILine {
 	 * 
 	 * @return status of this line
 	 */
-	public int getStatus();
+	int getStatus();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/IMethodCoverage.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/IMethodCoverage.java
@@ -22,13 +22,13 @@ public interface IMethodCoverage extends ISourceNode {
 	 * 
 	 * @return descriptor
 	 */
-	public String getDesc();
+	String getDesc();
 
 	/**
 	 * Returns the generic signature of the method if defined.
 	 * 
 	 * @return generic signature or <code>null</code>
 	 */
-	public String getSignature();
+	String getSignature();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/IPackageCoverage.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/IPackageCoverage.java
@@ -28,13 +28,13 @@ public interface IPackageCoverage extends ICoverageNode {
 	 * 
 	 * @return all classes
 	 */
-	public Collection<IClassCoverage> getClasses();
+	Collection<IClassCoverage> getClasses();
 
 	/**
 	 * Returns all source files in this package.
 	 * 
 	 * @return all source files
 	 */
-	public Collection<ISourceFileCoverage> getSourceFiles();
+	Collection<ISourceFileCoverage> getSourceFiles();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ISourceFileCoverage.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ISourceFileCoverage.java
@@ -22,6 +22,6 @@ public interface ISourceFileCoverage extends ISourceNode {
 	 * 
 	 * @return package name
 	 */
-	public String getPackageName();
+	String getPackageName();
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ISourceNode.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ISourceNode.java
@@ -18,7 +18,7 @@ package org.jacoco.core.analysis;
 public interface ISourceNode extends ICoverageNode {
 
 	/** Place holder for unknown lines (no debug information) */
-	public static int UNKNOWN_LINE = -1;
+	int UNKNOWN_LINE = -1;
 
 	/**
 	 * The number of the first line coverage information is available for. If no
@@ -26,7 +26,7 @@ public interface ISourceNode extends ICoverageNode {
 	 * 
 	 * @return number of the first line or {@link #UNKNOWN_LINE}
 	 */
-	public int getFirstLine();
+	int getFirstLine();
 
 	/**
 	 * The number of the last line coverage information is available for. If no
@@ -34,7 +34,7 @@ public interface ISourceNode extends ICoverageNode {
 	 * 
 	 * @return number of the last line or {@link #UNKNOWN_LINE}
 	 */
-	public int getLastLine();
+	int getLastLine();
 
 	/**
 	 * Returns the line information for given line.
@@ -43,6 +43,6 @@ public interface ISourceNode extends ICoverageNode {
 	 *            line number of interest
 	 * @return line information
 	 */
-	public ILine getLine(int nr);
+	ILine getLine(int nr);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/data/IExecutionDataVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/IExecutionDataVisitor.java
@@ -24,6 +24,6 @@ public interface IExecutionDataVisitor {
 	 * @param data
 	 *            execution data for a class
 	 */
-	public void visitClassExecution(ExecutionData data);
+	void visitClassExecution(ExecutionData data);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/data/ISessionInfoVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ISessionInfoVisitor.java
@@ -25,6 +25,6 @@ public interface ISessionInfoVisitor {
 	 * @param info
 	 *            session information
 	 */
-	public void visitSessionInfo(final SessionInfo info);
+	void visitSessionInfo(SessionInfo info);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/IFrame.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/IFrame.java
@@ -24,6 +24,6 @@ public interface IFrame {
 	 * @param mv
 	 *            method visitor to emit frame event to
 	 */
-	void accept(final MethodVisitor mv);
+	void accept(MethodVisitor mv);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/IProbeInserter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/IProbeInserter.java
@@ -23,6 +23,6 @@ interface IProbeInserter {
 	 * @param id
 	 *            id of the probe to insert
 	 */
-	void insertProbe(final int id);
+	void insertProbe(int id);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/IProbeInserter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/IProbeInserter.java
@@ -23,6 +23,6 @@ interface IProbeInserter {
 	 * @param id
 	 *            id of the probe to insert
 	 */
-	public void insertProbe(final int id);
+	void insertProbe(final int id);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/IExecutionDataAccessorGenerator.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/IExecutionDataAccessorGenerator.java
@@ -45,7 +45,7 @@ public interface IExecutionDataAccessorGenerator {
 	 * @return additional stack size required by the implementation, including
 	 *         the instance pushed to the stack
 	 */
-	int generateDataAccessor(long classid, String classname,
-							 int probecount, MethodVisitor mv);
+	int generateDataAccessor(long classid, String classname, int probecount,
+			MethodVisitor mv);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/IExecutionDataAccessorGenerator.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/IExecutionDataAccessorGenerator.java
@@ -45,7 +45,7 @@ public interface IExecutionDataAccessorGenerator {
 	 * @return additional stack size required by the implementation, including
 	 *         the instance pushed to the stack
 	 */
-	public int generateDataAccessor(final long classid, final String classname,
-			final int probecount, MethodVisitor mv);
+	int generateDataAccessor(long classid, String classname,
+							 int probecount, MethodVisitor mv);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/IRemoteCommandVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/IRemoteCommandVisitor.java
@@ -28,7 +28,7 @@ public interface IRemoteCommandVisitor {
 	 * @throws IOException
 	 *             in case of problems with the remote connection
 	 */
-	public void visitDumpCommand(final boolean dump, final boolean reset)
+	void visitDumpCommand(boolean dump, boolean reset)
 			throws IOException;
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/IRemoteCommandVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/IRemoteCommandVisitor.java
@@ -28,7 +28,6 @@ public interface IRemoteCommandVisitor {
 	 * @throws IOException
 	 *             in case of problems with the remote connection
 	 */
-	void visitDumpCommand(boolean dump, boolean reset)
-			throws IOException;
+	void visitDumpCommand(boolean dump, boolean reset) throws IOException;
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/IRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/IRuntime.java
@@ -26,12 +26,12 @@ public interface IRuntime extends IExecutionDataAccessorGenerator {
 	 * @throws Exception
 	 *             any internal problem during startup
 	 */
-	public void startup(RuntimeData data) throws Exception;
+	void startup(RuntimeData data) throws Exception;
 
 	/**
 	 * Allows the coverage runtime to cleanup internals. This class should be
 	 * called when classes instrumented for this runtime are not used any more.
 	 */
-	public void shutdown();
+	void shutdown();
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/ILanguageNames.java
+++ b/org.jacoco.report/src/org/jacoco/report/ILanguageNames.java
@@ -39,8 +39,8 @@ public interface ILanguageNames {
 	 *            vm names of interfaces of the class (may be <code>null</code>)
 	 * @return language specific notation of the class
 	 */
-	String getClassName(String vmname, String vmsignature,
-						String vmsuperclass, String[] vminterfaces);
+	String getClassName(String vmname, String vmsignature, String vmsuperclass,
+			String[] vminterfaces);
 
 	/**
 	 * Calculates the language specific qualified name of a class.
@@ -64,8 +64,8 @@ public interface ILanguageNames {
 	 *            vm signature of the method (may be <code>null</code>)
 	 * @return language specific notation for the method
 	 */
-	String getMethodName(String vmclassname, String vmmethodname,
-						 String vmdesc, String vmsignature);
+	String getMethodName(String vmclassname, String vmmethodname, String vmdesc,
+			String vmsignature);
 
 	/**
 	 * Calculates the language specific fully qualified name of a method.
@@ -80,7 +80,7 @@ public interface ILanguageNames {
 	 *            vm signature of the method (may be <code>null</code>)
 	 * @return language specific notation for the method
 	 */
-	String getQualifiedMethodName(String vmclassname,
-								  String vmmethodname, String vmdesc, String vmsignature);
+	String getQualifiedMethodName(String vmclassname, String vmmethodname,
+			String vmdesc, String vmsignature);
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/ILanguageNames.java
+++ b/org.jacoco.report/src/org/jacoco/report/ILanguageNames.java
@@ -23,7 +23,7 @@ public interface ILanguageNames {
 	 *            vm name of a package
 	 * @return language specific notation for the package
 	 */
-	public String getPackageName(String vmname);
+	String getPackageName(String vmname);
 
 	/**
 	 * Calculates the language specific name of a class.
@@ -39,8 +39,8 @@ public interface ILanguageNames {
 	 *            vm names of interfaces of the class (may be <code>null</code>)
 	 * @return language specific notation of the class
 	 */
-	public String getClassName(String vmname, String vmsignature,
-			String vmsuperclass, String[] vminterfaces);
+	String getClassName(String vmname, String vmsignature,
+						String vmsuperclass, String[] vminterfaces);
 
 	/**
 	 * Calculates the language specific qualified name of a class.
@@ -49,7 +49,7 @@ public interface ILanguageNames {
 	 *            vm name of a class
 	 * @return language specific qualified notation of the class
 	 */
-	public String getQualifiedClassName(String vmname);
+	String getQualifiedClassName(String vmname);
 
 	/**
 	 * Calculates the language specific name of a method.
@@ -64,8 +64,8 @@ public interface ILanguageNames {
 	 *            vm signature of the method (may be <code>null</code>)
 	 * @return language specific notation for the method
 	 */
-	public String getMethodName(String vmclassname, String vmmethodname,
-			String vmdesc, String vmsignature);
+	String getMethodName(String vmclassname, String vmmethodname,
+						 String vmdesc, String vmsignature);
 
 	/**
 	 * Calculates the language specific fully qualified name of a method.
@@ -80,7 +80,7 @@ public interface ILanguageNames {
 	 *            vm signature of the method (may be <code>null</code>)
 	 * @return language specific notation for the method
 	 */
-	public String getQualifiedMethodName(String vmclassname,
-			String vmmethodname, String vmdesc, String vmsignature);
+	String getQualifiedMethodName(String vmclassname,
+								  String vmmethodname, String vmdesc, String vmsignature);
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/IMultiReportOutput.java
+++ b/org.jacoco.report/src/org/jacoco/report/IMultiReportOutput.java
@@ -29,7 +29,7 @@ public interface IMultiReportOutput {
 	 * @throws IOException
 	 *             if the creation fails
 	 */
-	public OutputStream createFile(String path) throws IOException;
+	OutputStream createFile(String path) throws IOException;
 
 	/**
 	 * Closes the underlying resource container.
@@ -37,6 +37,6 @@ public interface IMultiReportOutput {
 	 * @throws IOException
 	 *             if closing fails
 	 */
-	public void close() throws IOException;
+	void close() throws IOException;
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/IReportVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/IReportVisitor.java
@@ -38,8 +38,8 @@ public interface IReportVisitor extends IReportGroupVisitor {
 	 * @throws IOException
 	 *             in case of IO problems with the report writer
 	 */
-	public void visitInfo(List<SessionInfo> sessionInfos,
-			Collection<ExecutionData> executionData) throws IOException;
+	void visitInfo(List<SessionInfo> sessionInfos,
+				   Collection<ExecutionData> executionData) throws IOException;
 
 	/**
 	 * Has to be called after all report data has been emitted.
@@ -47,6 +47,6 @@ public interface IReportVisitor extends IReportGroupVisitor {
 	 * @throws IOException
 	 *             in case of IO problems with the report writer
 	 */
-	public void visitEnd() throws IOException;
+	void visitEnd() throws IOException;
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/IReportVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/IReportVisitor.java
@@ -39,7 +39,7 @@ public interface IReportVisitor extends IReportGroupVisitor {
 	 *             in case of IO problems with the report writer
 	 */
 	void visitInfo(List<SessionInfo> sessionInfos,
-				   Collection<ExecutionData> executionData) throws IOException;
+			Collection<ExecutionData> executionData) throws IOException;
 
 	/**
 	 * Has to be called after all report data has been emitted.

--- a/org.jacoco.report/src/org/jacoco/report/ISourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/ISourceFileLocator.java
@@ -31,7 +31,7 @@ public interface ISourceFileLocator {
 	 * @throws IOException
 	 *             in case of problems while opening the file
 	 */
-	public Reader getSourceFile(String packageName, String fileName)
+	Reader getSourceFile(String packageName, String fileName)
 			throws IOException;
 
 	/**
@@ -39,6 +39,6 @@ public interface ISourceFileLocator {
 	 * 
 	 * @return tab width as number of blanks
 	 */
-	public int getTabWidth();
+	int getTabWidth();
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/IHTMLReportContext.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/IHTMLReportContext.java
@@ -28,55 +28,55 @@ public interface IHTMLReportContext {
 	 * 
 	 * @return static resources
 	 */
-	public Resources getResources();
+	Resources getResources();
 
 	/**
 	 * Returns the language names call-back used in this report.
 	 * 
 	 * @return language names
 	 */
-	public ILanguageNames getLanguageNames();
+	ILanguageNames getLanguageNames();
 
 	/**
 	 * Returns a table for rendering coverage nodes.
 	 * 
 	 * @return table for rendering
 	 */
-	public Table getTable();
+	Table getTable();
 
 	/**
 	 * Returns a string of textual information to include in every page footer.
 	 * 
 	 * @return footer text or empty string
 	 */
-	public String getFooterText();
+	String getFooterText();
 
 	/**
 	 * Returns the link to the sessions page.
 	 * 
 	 * @return sessions page link
 	 */
-	public ILinkable getSessionsPage();
+	ILinkable getSessionsPage();
 
 	/**
 	 * Returns the encoding of the generated HTML documents.
 	 * 
 	 * @return encoding for generated HTML documents
 	 */
-	public String getOutputEncoding();
+	String getOutputEncoding();
 
 	/**
 	 * Returns the service for index updates.
 	 * 
 	 * @return sevice for indes updates
 	 */
-	public IIndexUpdate getIndexUpdate();
+	IIndexUpdate getIndexUpdate();
 
 	/**
 	 * Returns the locale used to format numbers and dates.
 	 * 
 	 * @return locale for numbers and dates
 	 */
-	public Locale getLocale();
+	Locale getLocale();
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/ILinkable.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/ILinkable.java
@@ -26,20 +26,20 @@ public interface ILinkable {
 	 *            folder where the link should be inserted
 	 * @return relative link or <code>null</code> if the target does not exist
 	 */
-	public String getLink(final ReportOutputFolder base);
+	String getLink(ReportOutputFolder base);
 
 	/**
 	 * Returns the display label used for the link.
 	 * 
 	 * @return display label
 	 */
-	public String getLinkLabel();
+	String getLinkLabel();
 
 	/**
 	 * Optional style class to be associated with the link.
 	 * 
 	 * @return link style class or <code>null</code>
 	 */
-	public String getLinkStyle();
+	String getLinkStyle();
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/index/IIndexUpdate.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/index/IIndexUpdate.java
@@ -27,6 +27,6 @@ public interface IIndexUpdate {
 	 * @param classid
 	 *            identifier of the class
 	 */
-	public void addClass(ILinkable link, long classid);
+	void addClass(ILinkable link, long classid);
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/table/IColumnRenderer.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/table/IColumnRenderer.java
@@ -52,8 +52,8 @@ public interface IColumnRenderer {
 	 * @throws IOException
 	 *             in case of IO problems with the element output
 	 */
-	void footer(HTMLElement td, ICoverageNode total,
-				Resources resources, ReportOutputFolder base) throws IOException;
+	void footer(HTMLElement td, ICoverageNode total, Resources resources,
+			ReportOutputFolder base) throws IOException;
 
 	/**
 	 * Renders a single item in this column.
@@ -70,7 +70,7 @@ public interface IColumnRenderer {
 	 *             in case of IO problems with the element output
 	 */
 	void item(HTMLElement td, ITableItem item, Resources resources,
-			  ReportOutputFolder base) throws IOException;
+			ReportOutputFolder base) throws IOException;
 
 	/**
 	 * Returns the comparator to sort this table column.

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/table/IColumnRenderer.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/table/IColumnRenderer.java
@@ -36,7 +36,7 @@ public interface IColumnRenderer {
 	 *            the summary of all coverage data items in the table
 	 * @return <code>true</code> if the column should be visible
 	 */
-	public boolean init(List<? extends ITableItem> items, ICoverageNode total);
+	boolean init(List<? extends ITableItem> items, ICoverageNode total);
 
 	/**
 	 * Renders the footer for this column.
@@ -52,8 +52,8 @@ public interface IColumnRenderer {
 	 * @throws IOException
 	 *             in case of IO problems with the element output
 	 */
-	public void footer(HTMLElement td, ICoverageNode total,
-			Resources resources, ReportOutputFolder base) throws IOException;
+	void footer(HTMLElement td, ICoverageNode total,
+				Resources resources, ReportOutputFolder base) throws IOException;
 
 	/**
 	 * Renders a single item in this column.
@@ -69,14 +69,14 @@ public interface IColumnRenderer {
 	 * @throws IOException
 	 *             in case of IO problems with the element output
 	 */
-	public void item(HTMLElement td, ITableItem item, Resources resources,
-			ReportOutputFolder base) throws IOException;
+	void item(HTMLElement td, ITableItem item, Resources resources,
+			  ReportOutputFolder base) throws IOException;
 
 	/**
 	 * Returns the comparator to sort this table column.
 	 * 
 	 * @return comparator for this column
 	 */
-	public Comparator<ITableItem> getComparator();
+	Comparator<ITableItem> getComparator();
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/table/ITableItem.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/table/ITableItem.java
@@ -24,6 +24,6 @@ public interface ITableItem extends ILinkable {
 	 * 
 	 * @return node data
 	 */
-	public ICoverageNode getNode();
+	ICoverageNode getNode();
 
 }


### PR DESCRIPTION
Modifier `public` is redundant for interface methods.