### PR TITLE
Configurable logging of exceptions

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
@@ -46,7 +46,7 @@ public class Agent implements IAgent {
 	 */
 	public static synchronized Agent getInstance(final AgentOptions options) {
 		if (singleton == null) {
-			final Agent agent = new Agent(options, IExceptionLogger.SYSTEM_ERR);
+			final Agent agent = new Agent(options, getLogger(options));
 			agent.startup();
 			Runtime.getRuntime().addShutdownHook(new Thread() {
 				@Override
@@ -67,11 +67,32 @@ public class Agent implements IAgent {
 	 * @throws IllegalStateException
 	 *             if no Agent has been started yet
 	 */
-	public static synchronized Agent getInstance() throws IllegalStateException {
+	public static synchronized Agent getInstance()
+			throws IllegalStateException {
 		if (singleton == null) {
 			throw new IllegalStateException("JaCoCo agent not started.");
 		}
 		return singleton;
+	}
+
+	/**
+	 * Returns the {@link IExceptionLogger} instance configured by the given
+	 * options.
+	 * 
+	 * @param options
+	 *            options to configure the agent
+	 * @return the resolved {@link IExceptionLogger}
+	 */
+	public static IExceptionLogger getLogger(final AgentOptions options) {
+		switch (options.getLog()) {
+		default:
+		case full:
+			return IExceptionLogger.SYSTEM_ERR;
+		case normal:
+			return IExceptionLogger.NORMAL;
+		case silent:
+			return IExceptionLogger.SILENT;
+		}
 	}
 
 	private final AgentOptions options;

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/IExceptionLogger.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/IExceptionLogger.java
@@ -27,6 +27,23 @@ public interface IExceptionLogger {
 	};
 
 	/**
+	 * Implementation which dumps the exception message to System.err.
+	 */
+	IExceptionLogger NORMAL = new IExceptionLogger() {
+		public void logExeption(final Exception ex) {
+			System.err.println(ex.getMessage());
+		}
+	};
+
+	/**
+	 * Implementation which is silent
+	 */
+	IExceptionLogger SILENT = new IExceptionLogger() {
+		public void logExeption(final Exception ex) {
+		}
+	};
+
+	/**
 	 * Logs the given exception.
 	 * 
 	 * @param ex

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
@@ -47,12 +47,13 @@ public final class PreMain {
 		final IRuntime runtime = createRuntime(inst);
 		runtime.startup(agent.getData());
 		inst.addTransformer(new CoverageTransformer(runtime, agentOptions,
-				IExceptionLogger.SYSTEM_ERR));
+				Agent.getLogger(agentOptions)));
 	}
 
 	private static IRuntime createRuntime(final Instrumentation inst)
 			throws Exception {
-		return ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError");
+		return ModifiedSystemClassRuntime.createFor(inst,
+				"java/lang/UnknownError");
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -188,10 +188,40 @@ public final class AgentOptions {
 	 */
 	public static final String JMX = "jmx";
 
+	/**
+	 * Specifies the amount of logging the agent should produce in case of an
+	 * error: <code>full</code>, <code>normal</code> or <code>silent</code>.
+	 */
+	public static final String LOG = "log";
+
+	/**
+	 * Possible values for {@link AgentOptions#LOG}.
+	 */
+	public static enum LogMode {
+
+		/**
+		 * Value for the {@link AgentOptions#LOG} parameter: Write the entire
+		 * stacktrace of an error to stderr.
+		 */
+		full,
+
+		/**
+		 * Value for the {@link AgentOptions#LOG} parameter: Write the message
+		 * of an error to stderr.
+		 */
+		normal,
+
+		/**
+		 * Value for the {@link AgentOptions#LOG} parameter: Do not log.
+		 */
+		silent
+
+	}
+
 	private static final Collection<String> VALID_OPTIONS = Arrays.asList(
 			DESTFILE, APPEND, INCLUDES, EXCLUDES, EXCLCLASSLOADER,
 			INCLBOOTSTRAPCLASSES, INCLNOLOCATIONCLASSES, SESSIONID, DUMPONEXIT,
-			OUTPUT, ADDRESS, PORT, CLASSDUMPDIR, JMX);
+			OUTPUT, ADDRESS, PORT, CLASSDUMPDIR, JMX, LOG);
 
 	private final Map<String, String> options;
 
@@ -219,8 +249,8 @@ public final class AgentOptions {
 				}
 				final String key = entry.substring(0, pos);
 				if (!VALID_OPTIONS.contains(key)) {
-					throw new IllegalArgumentException(format(
-							"Unknown agent option \"%s\".", key));
+					throw new IllegalArgumentException(
+							format("Unknown agent option \"%s\".", key));
 				}
 
 				final String value = entry.substring(pos + 1);
@@ -250,6 +280,7 @@ public final class AgentOptions {
 	private void validateAll() {
 		validatePort(getPort());
 		getOutput();
+		getLog();
 	}
 
 	private void validatePort(final int port) {
@@ -554,6 +585,36 @@ public final class AgentOptions {
 	 */
 	public void setJmx(final boolean jmx) {
 		setOption(JMX, jmx);
+	}
+
+	/**
+	 * Returns the log mode
+	 * 
+	 * @return current log mode
+	 */
+	public LogMode getLog() {
+		final String value = options.get(LOG);
+		return value == null ? LogMode.full : LogMode.valueOf(value);
+	}
+
+	/**
+	 * Sets the log mode
+	 * 
+	 * @param log
+	 *            Log mode
+	 */
+	public void setLog(final String log) {
+		setLog(LogMode.valueOf(log));
+	}
+
+	/**
+	 * Sets the log mode
+	 * 
+	 * @param log
+	 *            Log mode
+	 */
+	public void setLog(final LogMode log) {
+		setOption(LOG, log.name());
 	}
 
 	private void setOption(final String key, final int value) {

--- a/org.jacoco.doc/docroot/doc/agent.html
+++ b/org.jacoco.doc/docroot/doc/agent.html
@@ -205,6 +205,18 @@
       </td>
       <td><code>false</code></td>
     </tr>
+    <tr>
+      <td><code>log</code></td>
+      <td>Amount of logging to produce in case of an error. Valid options are:
+        <ul>
+          <li><code>full</code>: The full stacktrace is written to stderr.</li>
+          <li><code>normal</code>: The message of the stacktrace is written to
+              stderr.</li>
+          <li><code>silent</code>: Nothing is logged.</li>
+        </ul>
+      </td>
+      <td><code>full</code></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This pull request introduces a new option `log`, which can be used to limit or suppress exception logging. This fixes #32.

In some cases it may not be possible (or feasible) to prevent duplicate instrumentation. For example, in our case we use Arquillian to run tests inside our application server. However, part of the code also runs inside the test runner. Therefore, the agent needs to be loaded at both java processes, causing duplicate instrumentation. At the moment this produces an enormous amount of logging (several GBs per run), but the tests run fine and the instrumentation is correct.