### PR TITLE
Expand Expression in propertyName

### DIFF
--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -99,6 +99,11 @@
       <!-- annotations are needed only to build the plugin: -->
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
a minor improvment for `jacoco-maven-plugin` to support expand expression in `argLine`.

for maven project, developer may want use expression in `argLine` (the default `propertyName`), for example:

```
<properties>
     <argLine>-javaagent:${settings.localRepository}/co/paralleluniverse/quasar-core/0.7.5/quasar-core-0.7.5-jdk8.jar</argLine>
</properties>
```

there contains expression `${settings.localRepository}`.
as before, jacoco-maven-plugin simply append it to jacoco agent arguments, like this: 

```
argLine set to -javaagent:F:\\env\\repository\\org\\jacoco\\org.jacoco.agent\\0.8.3-SNAPSHOT\\org.jacoco.agent-0.8.3-SNAPSHOT-runtime.jar=destfile=F:\\Platform2\\platform-config\\target\\jacoco-it.exec -javaagent:${settings.localRepository}/co/paralleluniverse/quasar-core/0.7.5/quasar-core-0.7.5-jdk8.jar
```

after that, maven-surefire-plugin will immediate use this `argLine`, without expended expression. this will cause issue. another solution is use different `propertyName` for  `jacoco-maven-plugin` and `maven-surefire-plugin`, for example:

```
<properties>
     <argLine>-javaagent:${settings.localRepository}/co/paralleluniverse/quasar-core/0.7.5/quasar-core-0.7.5-jdk8.jar</argLine>
</properties>
<plugin>
                        <groupId>org.jacoco</groupId>
                        <artifactId>jacoco-maven-plugin</artifactId>
                        <version>0.8.2</version>
                        <configuration>
                            <propertyName>jacocoAgent</propertyName>
                        </configuration>
</plugin>
<plugin>
                        <groupId>org.apache.maven.plugins</groupId>
                        <artifactId>maven-surefire-plugin</artifactId>
                        <configuration>
                            <argLine>@{jacocoAgent} ${argLine}</argLine>
                        </configuration>
</plugin>
```

this is work well for maven, but IDE not support `@{...}` expression yet, when using IDE to run test, it failed.

seems the better solution is let `jacoco-maven-plugin` support expend expression.