### PR TITLE
Fix filtering in case of inlining top level function into class in same file

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineTest.java
@@ -12,7 +12,7 @@
 package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
-import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineTarget;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineTargetKt;
 
 /**
  * Test of <code>inline</code> functions.
@@ -20,7 +20,7 @@ import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineTarget;
 public class KotlinInlineTest extends ValidationTestBase {
 
 	public KotlinInlineTest() {
-		super(KotlinInlineTarget.class);
+		super(KotlinInlineTargetKt.class);
 	}
 
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineTarget.kt
@@ -17,11 +17,15 @@ import org.jacoco.core.test.validation.targets.Stubs.t
 /**
  * Test target for `inline` functions.
  */
-object KotlinInlineTarget {
+fun main(args: Array<String>) {
+    KotlinInlineTarget.main(args)
+}
 
-    inline fun inlined() {
-        nop() // assertNotCovered()
-    }
+inline fun inlined() {
+    nop() // assertNotCovered()
+}
+
+object KotlinInlineTarget {
 
     @JvmStatic
     fun main(args: Array<String>) {

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineTarget.kt
@@ -21,14 +21,20 @@ fun main(args: Array<String>) {
     KotlinInlineTarget.main(args)
 }
 
-inline fun inlined() {
+inline fun inlined_top_level() {
     nop() // assertNotCovered()
 }
 
 object KotlinInlineTarget {
 
+    inline fun inlined() {
+        nop() // assertNotCovered()
+    }
+
     @JvmStatic
     fun main(args: Array<String>) {
+
+        inlined_top_level() // assertFullyCovered()
 
         inlined() // assertFullyCovered()
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
@@ -92,37 +92,52 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 		filter.filter(m, context, output);
 	}
 
+	/**
+	 * <pre>
+	 *     inline fun inlined() {
+	 *       Stubs.nop()
+	 *     }
+	 *
+	 *     class Callsite {
+	 *       fun callsite {
+	 *         inlined()
+	 *       }
+	 *     }
+	 * </pre>
+	 */
 	@Test
 	public void should_filter_when_in_same_file() {
-		context.sourceFileName = "callsite.kt";
+		context.sourceFileName = "example.kt";
 		context.sourceDebugExtension = "" //
 				+ "SMAP\n" //
-				+ "callsite.kt\n" // OutputFileName=callsite.kt
+				+ "example.kt\n" // OutputFileName=example.kt
 				+ "Kotlin\n" // DefaultStratumId=Kotlin
 				+ "*S Kotlin\n" // StratumID=Kotlin
 				+ "*F\n" // FileSection
-				+ "+ 1 callsite.kt\n" // FileID=1,FileName=callsite.kt
-				+ "CallsiteKt\n" //
+				+ "+ 1 example.kt\n" // FileID=1,FileName=example.kt
+				+ "Callsite\n" //
+				+ "+ 2 example.kt\n" // FileID=2,FileName=example.kt
+				+ "ExampleKt\n" //
 				+ "*L\n" // LineSection
-				+ "1#1,33:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=33,OutputStartLine=1
-				+ "22#1,2:34\n" // InputStartLine=22,LineFileID=1,RepeatCount=2,OutputStartLine=34
+				+ "1#1,10:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=10,OutputStartLine=1
+				+ "2#2,2:11\n" // InputStartLine=2,LineFileID=2,RepeatCount=2,OutputStartLine=11
 				+ "*E\n"; // EndSection
 		context.classAnnotations
 				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
-		m.visitLineNumber(28, new Label());
+		m.visitLineNumber(7, new Label());
 		m.visitInsn(Opcodes.NOP);
 
-		m.visitLineNumber(34, new Label());
+		m.visitLineNumber(11, new Label());
 		shouldIgnorePrevious(m);
 		m.visitMethodInsn(Opcodes.INVOKESTATIC, "Stubs", "nop", "()V", false);
 		shouldIgnorePrevious(m);
-		m.visitLineNumber(35, new Label());
+		m.visitLineNumber(11, new Label());
 		shouldIgnorePrevious(m);
 		m.visitInsn(Opcodes.NOP);
 		shouldIgnorePrevious(m);
 
-		m.visitLineNumber(30, new Label());
+		m.visitLineNumber(8, new Label());
 		m.visitInsn(Opcodes.RETURN);
 
 		filter.filter(m, context, output);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
@@ -207,6 +207,30 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 	}
 
 	@Test
+	public void should_throw_exception_when_no_SourceFileId_for_SourceFile() {
+		context.sourceFileName = "example.kt";
+		context.classAnnotations
+				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
+		context.sourceDebugExtension = "" //
+				+ "SMAP\n" //
+				+ "example.kt\n" //
+				+ "Kotlin\n" //
+				+ "*S Kotlin\n" //
+				+ "*F\n" //
+				+ "+ 1 another.kt\n" //
+				+ "AnotherKt\n" //
+				+ "*L\n" //
+				+ "*E\n";
+
+		try {
+			filter.filter(m, context, output);
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP", e.getMessage());
+		}
+	}
+
+	@Test
 	public void should_throw_exception_when_unexpected_LineInfo() {
 		context.sourceFileName = "callsite.kt";
 		context.sourceDebugExtension = "" //
@@ -215,6 +239,8 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 				+ "Kotlin\n" //
 				+ "*S Kotlin\n" //
 				+ "*F\n" //
+				+ "+ 1 callsite.kt\n" //
+				+ "Callsite\n" //
 				+ "*L\n" //
 				+ "xxx";
 		context.classAnnotations

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
@@ -94,12 +94,17 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 	/**
 	 * <pre>
-	 *     inline fun inlined() {
+	 *     inline fun inlined_top_level() {
 	 *       Stubs.nop()
 	 *     }
 	 *
 	 *     class Callsite {
+	 *       fun inlined() {
+	 *           Stubs.nop()
+	 *       }
+	 *
 	 *       fun callsite {
+	 *         inlined_top_level()
 	 *         inlined()
 	 *       }
 	 *     }
@@ -119,25 +124,37 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 				+ "+ 2 example.kt\n" // FileID=2,FileName=example.kt
 				+ "ExampleKt\n" //
 				+ "*L\n" // LineSection
-				+ "1#1,10:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=10,OutputStartLine=1
-				+ "2#2,2:11\n" // InputStartLine=2,LineFileID=2,RepeatCount=2,OutputStartLine=11
+				+ "1#1,15:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=10,OutputStartLine=1
+				+ "7#1,2:18\n" // InputStartLine=7,LineFileID=1,RepeatCount=2,OutputStartLine=18
+				+ "2#2,2:16\n" // InputStartLine=2,LineFileID=2,RepeatCount=2,OutputStartLine=16
 				+ "*E\n"; // EndSection
 		context.classAnnotations
 				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
-		m.visitLineNumber(7, new Label());
-		m.visitInsn(Opcodes.NOP);
-
 		m.visitLineNumber(11, new Label());
+		m.visitInsn(Opcodes.NOP);
+		m.visitLineNumber(16, new Label());
 		shouldIgnorePrevious(m);
 		m.visitMethodInsn(Opcodes.INVOKESTATIC, "Stubs", "nop", "()V", false);
 		shouldIgnorePrevious(m);
-		m.visitLineNumber(11, new Label());
+		m.visitLineNumber(17, new Label());
 		shouldIgnorePrevious(m);
 		m.visitInsn(Opcodes.NOP);
 		shouldIgnorePrevious(m);
 
-		m.visitLineNumber(8, new Label());
+		m.visitLineNumber(12, new Label());
+		m.visitVarInsn(Opcodes.ALOAD, 0);
+		m.visitVarInsn(Opcodes.ASTORE, 1);
+		m.visitLineNumber(18, new Label());
+		shouldIgnorePrevious(m);
+		m.visitMethodInsn(Opcodes.INVOKESTATIC, "Stubs", "nop", "()V", false);
+		shouldIgnorePrevious(m);
+		m.visitLineNumber(19, new Label());
+		shouldIgnorePrevious(m);
+		m.visitInsn(Opcodes.NOP);
+		shouldIgnorePrevious(m);
+
+		m.visitLineNumber(13, new Label());
 		m.visitInsn(Opcodes.RETURN);
 
 		filter.filter(m, context, output);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
@@ -243,7 +243,7 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 			filter.filter(m, context, output);
 			fail("exception expected");
 		} catch (final IllegalStateException e) {
-			assertEquals("Unexpected SMAP", e.getMessage());
+			assertEquals("Unexpected SMAP FileSection", e.getMessage());
 		}
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
@@ -88,7 +88,7 @@ public final class KotlinInlineFilter implements IFilter {
 				}
 			}
 			if (sourceFileIds.isEmpty()) {
-				throw new IllegalStateException("Unexpected SMAP");
+				throw new IllegalStateException("Unexpected SMAP FileSection");
 			}
 			// LineSection
 			int min = Integer.MAX_VALUE;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
@@ -14,6 +14,7 @@ package org.jacoco.core.internal.analysis.filter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.BitSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,7 +71,7 @@ public final class KotlinInlineFilter implements IFilter {
 			expectLine(br, "*S Kotlin");
 			// FileSection
 			expectLine(br, "*F");
-			int sourceFileId = -1;
+			final BitSet sourceFileIds = new BitSet();
 			String line;
 			while (!"*L".equals(line = br.readLine())) {
 				// AbsoluteFileName
@@ -83,7 +84,7 @@ public final class KotlinInlineFilter implements IFilter {
 				}
 				final String fileName = m.group(2);
 				if (fileName.equals(sourceFileName)) {
-					sourceFileId = Integer.parseInt(m.group(1));
+					sourceFileIds.set(Integer.parseInt(m.group(1)));
 				}
 			}
 			// LineSection
@@ -98,7 +99,7 @@ public final class KotlinInlineFilter implements IFilter {
 				final int lineFileID = Integer
 						.parseInt(m.group(2).substring(1));
 				final int outputStartLine = Integer.parseInt(m.group(4));
-				if (sourceFileId == lineFileID
+				if (sourceFileIds.get(lineFileID)
 						&& inputStartLine == outputStartLine) {
 					continue;
 				}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
@@ -87,6 +87,9 @@ public final class KotlinInlineFilter implements IFilter {
 					sourceFileIds.set(Integer.parseInt(m.group(1)));
 				}
 			}
+			if (sourceFileIds.isEmpty()) {
+				throw new IllegalStateException("Unexpected SMAP");
+			}
 			// LineSection
 			int min = Integer.MAX_VALUE;
 			while (!"*E".equals(line = br.readLine())) {


### PR DESCRIPTION
For `inline` function declared at file level and used in class declared in the same file, Kotlin compiler produces SMAP that refers to the same source file by different `SourceFileId`s:

`example.kt`

```
inline fun inlined() {
}

class Callsite {
  fun callsite() {
    inlined()
  }
} // line 8
```

`javap -v -p Callsite.class`

```
...
      LineNumberTable:
        line 6: 0
        line 10: 1
        line 7: 2
...
SourceDebugExtension:
  SMAP
  example.kt
  Kotlin
  *S Kotlin
  *F
  + 1 example.kt
  Callsite
  + 2 example.kt
  ExampleKt
  *L
  1#1,9:1
  2#2:10
  *E
  *S KotlinDebug
  *F
  + 1 example.kt
  Callsite
  *L
  6#1:10
  *E
```

Filter that was implemented in #764 for #763 should be fixed to not filter out the whole class in this case.