### PR TITLE
Show message in HTML report when source file can't be found

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -30,6 +30,8 @@
   <li>Instructions inlined by Kotlin compiler are filtered out during generation
       of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/764">#764</a>).</li>
+  <li>HTML report shows message when source file can't be found
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/801">#801</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
@@ -47,6 +47,7 @@ public class ClassPageTest extends PageTestBase {
 		page.render();
 
 		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals("", support.findStr(doc, "doc/body/p[1]"));
 		assertEquals("el_method", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/span/@class"));
 		assertEquals("a()", support.findStr(doc,
@@ -55,6 +56,20 @@ public class ClassPageTest extends PageTestBase {
 				"/html/body/table[1]/tbody/tr[2]/td[1]/span"));
 		assertEquals("c()", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[3]/td[1]/span"));
+	}
+
+	@Test
+	public void should_generate_message_when_SourceFileName_present_but_no_SourceFilePage()
+			throws Exception {
+		node.setSourceFileName("Foo.java");
+
+		page = new ClassPage(node, null, null, rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals(
+				"Source file \"org/jacoco/example/Foo.java\" was not found during generation of report.",
+				support.findStr(doc, "/html/body/p[1]"));
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.internal.analysis.ClassCoverageImpl;
 import org.jacoco.core.internal.analysis.MethodCoverageImpl;
+import org.jacoco.report.internal.ReportOutputFolder;
+import org.jacoco.report.internal.html.ILinkable;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -59,6 +61,16 @@ public class ClassPageTest extends PageTestBase {
 	}
 
 	@Test
+	public void should_not_generate_message_when_SourceFileName_not_present()
+			throws Exception {
+		page = new ClassPage(node, null, null, rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals("", support.findStr(doc, "/html/body/p[1]"));
+	}
+
+	@Test
 	public void should_generate_message_when_SourceFileName_present_but_no_SourceFilePage()
 			throws Exception {
 		node.setSourceFileName("Foo.java");
@@ -70,6 +82,50 @@ public class ClassPageTest extends PageTestBase {
 		assertEquals(
 				"Source file \"org/jacoco/example/Foo.java\" was not found during generation of report.",
 				support.findStr(doc, "/html/body/p[1]"));
+	}
+
+	@Test
+	public void should_generate_message_with_default_package_when_SourceFileName_present_but_no_SourceFilePage()
+			throws Exception {
+		node = new ClassCoverageImpl("Foo", 123, false);
+		node.addMethod(new MethodCoverageImpl("a", "()V", null));
+		node.setSourceFileName("Foo.java");
+
+		page = new ClassPage(node, null, null, rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals(
+				"Source file \"Foo.java\" was not found during generation of report.",
+				support.findStr(doc, "/html/body/p[1]"));
+	}
+
+	@Test
+	public void should_not_generate_message_when_SourceFileName_and_SourceFilePage_present()
+			throws Exception {
+		node.setSourceFileName("Foo.java");
+
+		page = new ClassPage(node, null, new SourceLink(), rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals("", support.findStr(doc, "/html/body/p[1]"));
+	}
+
+	private class SourceLink implements ILinkable {
+
+		public String getLink(final ReportOutputFolder base) {
+			return "Source.java.html";
+		}
+
+		public String getLinkLabel() {
+			return "";
+		}
+
+		public String getLinkStyle() {
+			return null;
+		}
+
 	}
 
 	@Test

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IMethodCoverage;
 import org.jacoco.report.internal.ReportOutputFolder;
+import org.jacoco.report.internal.html.HTMLElement;
 import org.jacoco.report.internal.html.IHTMLReportContext;
 import org.jacoco.report.internal.html.ILinkable;
 
@@ -78,6 +79,22 @@ public class ClassPage extends TablePage<IClassCoverage> {
 		return context.getLanguageNames().getClassName(getNode().getName(),
 				getNode().getSignature(), getNode().getSuperName(),
 				getNode().getInterfaceNames());
+	}
+
+	@Override
+	protected void content(HTMLElement body) throws IOException {
+		if (getNode().getSourceFileName() != null && sourcePage == null) {
+			final String sourcePath;
+			if (getNode().getPackageName().length() != 0) {
+				sourcePath = getNode().getPackageName() + "/" + getNode().getSourceFileName();
+			} else {
+				sourcePath = getNode().getSourceFileName();
+			}
+			body.p().text("Source file \"" + sourcePath
+					+ "\" was not found during generation of report.");
+		}
+
+		super.content(body);
 	}
 
 }


### PR DESCRIPTION
One of common problems already described in [our FAQ](https://www.jacoco.org/jacoco/trunk/doc/faq.html) and still frequently faced by users - incorrect location of source files, which leads to absence of pages with sources in HTML report:

* https://stackoverflow.com/a/53833558/244993
* https://groups.google.com/d/msg/jacoco/wmwYxLKKn3Q/5AH5qSGBDgAJ
* https://github.com/jacoco/jacoco/issues/787#issuecomment-437578208
* https://github.com/jacoco/jacoco/issues/751#issuecomment-414480178

So I propose to add following message to a page with class methods

```
Source file `org/example/Example.java` was not found during generation of report.
```
