### PR TITLE
Show additional diagnostic information in HTML report

### DIFF
--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/DiagnosticInfoTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/DiagnosticInfoTest.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.report.internal.html.page;
+
+public class DiagnosticInfoTest {
+
+}

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IMethodCoverage;
 import org.jacoco.report.internal.ReportOutputFolder;
-import org.jacoco.report.internal.html.HTMLElement;
 import org.jacoco.report.internal.html.IHTMLReportContext;
 import org.jacoco.report.internal.html.ILinkable;
 
@@ -47,6 +46,8 @@ public class ClassPage extends TablePage<IClassCoverage> {
 			final IHTMLReportContext context) {
 		super(classNode, parent, folder, context);
 		this.sourcePage = sourcePage;
+		diagnosticInfo.checkClassIdMismatch(classNode);
+		diagnosticInfo.checkMissingSource(classNode, sourcePage);
 		context.getIndexUpdate().addClass(this, classNode.getId());
 	}
 
@@ -79,22 +80,6 @@ public class ClassPage extends TablePage<IClassCoverage> {
 		return context.getLanguageNames().getClassName(getNode().getName(),
 				getNode().getSignature(), getNode().getSuperName(),
 				getNode().getInterfaceNames());
-	}
-
-	@Override
-	protected void content(HTMLElement body) throws IOException {
-		if (getNode().getSourceFileName() != null && sourcePage == null) {
-			final String sourcePath;
-			if (getNode().getPackageName().length() != 0) {
-				sourcePath = getNode().getPackageName() + "/" + getNode().getSourceFileName();
-			} else {
-				sourcePath = getNode().getSourceFileName();
-			}
-			body.p().text("Source file \"" + sourcePath
-					+ "\" was not found during generation of report.");
-		}
-
-		super.content(body);
 	}
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/DiagnosticInfo.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/DiagnosticInfo.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *    
+ *******************************************************************************/
+package org.jacoco.report.internal.html.page;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICoverageNode;
+import org.jacoco.core.analysis.IPackageCoverage;
+import org.jacoco.report.internal.html.HTMLElement;
+import org.jacoco.report.internal.html.ILinkable;
+
+/**
+ * Diagnostic information to help users configure their reports correctly.
+ */
+class DiagnosticInfo {
+
+	private final List<String> infos = new ArrayList<String>();
+
+	private void addInfo(final String info, final Object... args) {
+		infos.add(String.format(info, args));
+	}
+
+	void checkMissingLineNumbers(final ICoverageNode coverage) {
+		if (coverage.getInstructionCounter().getTotalCount() > 0
+				&& coverage.getLineCounter().getTotalCount() == 0) {
+			addInfo("Class files must be compiled with debug information to show line coverage.");
+		}
+	}
+
+	void checkSourceReferences(final IPackageCoverage coverage) {
+		if (coverage.getInstructionCounter().getTotalCount() > 0
+				&& coverage.getSourceFiles().isEmpty()) {
+			addInfo("Class files must be compiled with debug information to link with source files.");
+		}
+	}
+
+	public void checkClassIdMismatch(final IClassCoverage coverage) {
+		if (coverage.isNoMatch()) {
+			addInfo("A different version of class \"%s\" was executed at runtime.",
+					coverage.getName());
+		}
+	}
+
+	void checkMissingSource(final IClassCoverage coverage,
+			final ILinkable sourcePage) {
+		final String fileName = coverage.getSourceFileName();
+		if (fileName == null) {
+			addInfo("Class files must be compiled with debug information to link with source files.\"");
+			return;
+		}
+		if (sourcePage == null) {
+			final String sourcePath;
+			if (coverage.getPackageName().length() != 0) {
+				sourcePath = coverage.getPackageName() + "/" + fileName;
+			} else {
+				sourcePath = fileName;
+			}
+			addInfo("Source file \"%s\" was not found during generation of report.",
+					sourcePath);
+		}
+	}
+
+	/**
+	 * Adds all identified issues after <code>check*</code> methods have been
+	 * called.
+	 */
+	void renderInfos(final HTMLElement parent) throws IOException {
+		for (final String info : infos) {
+			parent.p().text(info);
+		}
+	}
+
+}

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/NodePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/NodePage.java
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.jacoco.report.internal.html.page;
 
+import java.io.IOException;
+
 import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.report.internal.ReportOutputFolder;
+import org.jacoco.report.internal.html.HTMLElement;
 import org.jacoco.report.internal.html.IHTMLReportContext;
 import org.jacoco.report.internal.html.resources.Resources;
 import org.jacoco.report.internal.html.resources.Styles;
@@ -24,10 +27,15 @@ import org.jacoco.report.internal.html.table.ITableItem;
  * @param <NodeType>
  *            type of the node represented by this page
  */
-public abstract class NodePage<NodeType extends ICoverageNode> extends
-		ReportPage implements ITableItem {
+public abstract class NodePage<NodeType extends ICoverageNode>
+		extends ReportPage implements ITableItem {
 
 	private final NodeType node;
+
+	/**
+	 * Can be used in subclasses to perform checks check.
+	 */
+	protected final DiagnosticInfo diagnosticInfo;
 
 	/**
 	 * Creates a new node page.
@@ -45,6 +53,13 @@ public abstract class NodePage<NodeType extends ICoverageNode> extends
 			final ReportOutputFolder folder, final IHTMLReportContext context) {
 		super(parent, folder, context);
 		this.node = node;
+		this.diagnosticInfo = new DiagnosticInfo();
+		this.diagnosticInfo.checkMissingLineNumbers(node);
+	}
+
+	@Override
+	protected void content(final HTMLElement body) throws IOException {
+		diagnosticInfo.renderInfos(body);
 	}
 
 	// === ILinkable ===

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
@@ -49,9 +49,10 @@ public class PackagePage extends TablePage<IPackageCoverage> {
 			final ISourceFileLocator locator, final ReportOutputFolder folder,
 			final IHTMLReportContext context) {
 		super(node, parent, folder, context);
-		packageSourcePage = new PackageSourcePage(node, parent, locator,
-				folder, context, this);
+		packageSourcePage = new PackageSourcePage(node, parent, locator, folder,
+				context, this);
 		sourceCoverageExists = !node.getSourceFiles().isEmpty();
+		diagnosticInfo.checkSourceReferences(node);
 	}
 
 	@Override

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/SourceFilePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/SourceFilePage.java
@@ -59,6 +59,7 @@ public class SourceFilePage extends NodePage<ISourceNode> {
 
 	@Override
 	protected void content(final HTMLElement body) throws IOException {
+		super.content(body);
 		final SourceHighlighter hl = new SourceHighlighter(context.getLocale());
 		hl.render(body, getNode(), sourceReader);
 		sourceReader.close();

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/TablePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/TablePage.java
@@ -70,6 +70,7 @@ public abstract class TablePage<NodeType extends ICoverageNode>
 
 	@Override
 	protected void content(final HTMLElement body) throws IOException {
+		super.content(body);
 		context.getTable().render(body, items, getNode(),
 				context.getResources(), folder);
 		// free memory, otherwise we will keep the complete page tree:


### PR DESCRIPTION
In a follow-up to #801 more diagnostic information should be added to the HTML report:

* Only class with different class id found (`IClassCoverage.isNoMatch()`): ClassPage
* Class file without debug source file information (`IClassCoverage.getSourceFileName() == null`): ClassPage
* Class files without debug source file information (`IPackageCoverage.getSourceFiles().isEmpty()` for non empty packages): PackagePage
* Class files without debug line information (`ICoverageCounter.getLineCounter().getTotal() == 0`): All pages
