### PR TITLE
synthetic methods that represent Kotlin suspend functions should not be ignored

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinCoroutineTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinCoroutineTarget.kt
@@ -19,7 +19,8 @@ import org.jacoco.core.test.validation.targets.Stubs.nop
  */
 object KotlinCoroutineTarget {
 
-    suspend fun suspendingFunction() {
+    private suspend fun suspendingFunction() {
+        nop() // assertFullyCovered()
     }
 
     @JvmStatic

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SyntheticFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SyntheticFilterTest.java
@@ -82,4 +82,19 @@ public class SyntheticFilterTest extends FilterTestBase {
 		assertMethodIgnored(m);
 	}
 
+	@Test
+	public void should_not_filter_synthetic_methods_whose_last_argument_is_kotlin_coroutine_continuation() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
+				Opcodes.ACC_SYNTHETIC | Opcodes.ACC_STATIC, "example",
+				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
+				null);
+		context.classAnnotations
+				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		assertIgnored();
+	}
+
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;
@@ -25,6 +26,13 @@ import org.objectweb.asm.tree.TableSwitchInsnNode;
  * Filters branches that Kotlin compiler generates for coroutines.
  */
 public final class KotlinCoroutineFilter implements IFilter {
+
+	static boolean isLastArgumentContinuation(final MethodNode methodNode) {
+		final Type methodType = Type.getMethodType(methodNode.desc);
+		final int lastArgument = methodType.getArgumentTypes().length - 1;
+		return lastArgument >= 0 && "kotlin.coroutines.Continuation".equals(
+				methodType.getArgumentTypes()[lastArgument].getClassName());
+	}
 
 	public void filter(final MethodNode methodNode,
 			final IFilterContext context, final IFilterOutput output) {

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SyntheticFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SyntheticFilter.java
@@ -12,6 +12,7 @@
 package org.jacoco.core.internal.analysis.filter;
 
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.MethodNode;
 
 /**
@@ -29,10 +30,19 @@ public final class SyntheticFilter implements IFilter {
 			return;
 		}
 
-		if (KotlinDefaultArgumentsFilter
-				.isDefaultArgumentsMethodName(methodNode.name)
-				&& KotlinGeneratedFilter.isKotlinClass(context)) {
-			return;
+		if (KotlinGeneratedFilter.isKotlinClass(context)) {
+			if (KotlinDefaultArgumentsFilter
+					.isDefaultArgumentsMethodName(methodNode.name)) {
+				return;
+			}
+
+			final Type methodType = Type.getMethodType(methodNode.desc);
+			final int lastArgument = methodType.getArgumentTypes().length - 1;
+			if (lastArgument >= 0 && "kotlin.coroutines.Continuation"
+					.equals(methodType.getArgumentTypes()[lastArgument]
+							.getClassName())) {
+				return;
+			}
 		}
 
 		output.ignore(methodNode.instructions.getFirst(),

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SyntheticFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SyntheticFilter.java
@@ -12,7 +12,6 @@
 package org.jacoco.core.internal.analysis.filter;
 
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.MethodNode;
 
 /**
@@ -36,11 +35,7 @@ public final class SyntheticFilter implements IFilter {
 				return;
 			}
 
-			final Type methodType = Type.getMethodType(methodNode.desc);
-			final int lastArgument = methodType.getArgumentTypes().length - 1;
-			if (lastArgument >= 0 && "kotlin.coroutines.Continuation"
-					.equals(methodType.getArgumentTypes()[lastArgument]
-							.getClassName())) {
+			if (KotlinCoroutineFilter.isLastArgumentContinuation(methodNode)) {
 				return;
 			}
 		}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -42,6 +42,9 @@
 <ul>
   <li>Report code coverage correctly for Kotlin methods with default arguments
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/774">#774</a>).</li>
+  <li><code>synthetic</code> methods that represent Kotlin <code>suspend</code>
+      functions should not be ignored
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/804">#804</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>


### PR DESCRIPTION
Seems that Kotlin compiler generates `synthetic` methods for `private` and `open` suspending functions:

`Example.kt`

```
import kotlinx.coroutines.delay

private suspend fun suspendingFunction(x: Long) {
    delay(x) // line 4
}

open class Open {
    open suspend fun suspendingFunction(x: Long) {
        delay(x) // line 9
    }
}
```

`javap -v -p ExampleKt.class`

```
  static final java.lang.Object suspendingFunction(long, kotlin.coroutines.Continuation<? super kotlin.Unit>);
    descriptor: (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: ACC_STATIC, ACC_FINAL, ACC_SYNTHETIC
    Code:
      stack=3, locals=3, args_size=2
         0: lload_0
         1: aload_2
         2: invokestatic  #13                 // Method kotlinx/coroutines/DelayKt.delay:(JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
         5: areturn
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0       6     0     x   J
      LineNumberTable:
        line 4: 0
```

`javap -v -p Open.class`

```
  public java.lang.Object suspendingFunction(long, kotlin.coroutines.Continuation<? super kotlin.Unit>);
    descriptor: (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: ACC_PUBLIC
    Code:
      stack=4, locals=4, args_size=3
         0: aload_0
         1: lload_1
         2: aload_3
         3: invokestatic  #12                 // Method suspendingFunction$suspendImpl:(LOpen;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
         6: areturn

  static java.lang.Object suspendingFunction$suspendImpl(Open, long, kotlin.coroutines.Continuation);
    descriptor: (LOpen;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: ACC_STATIC, ACC_SYNTHETIC
    Code:
      stack=3, locals=4, args_size=3
         0: lload_1
         1: aload_3
         2: invokestatic  #17                 // Method kotlinx/coroutines/DelayKt.delay:(JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
         5: areturn
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0       6     0  this   LOpen;
            0       6     1     x   J
      LineNumberTable:
        line 9: 0
```
