### PR TITLE
Update filter for Kotlin suspending functions

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinCoroutineTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinCoroutineTarget.kt
@@ -19,7 +19,12 @@ import org.jacoco.core.test.validation.targets.Stubs.nop
  */
 object KotlinCoroutineTarget {
 
-    suspend fun suspendingFunction() {
+    suspend fun suspendingFunction() { // assertEmpty()
+        anotherSuspendingFunction() // assertFullyCovered()
+        nop() // assertFullyCovered()
+    } // assertFullyCovered()
+
+    suspend fun anotherSuspendingFunction() {
     }
 
     @JvmStatic

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
@@ -170,7 +170,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		m.visitVarInsn(Opcodes.ALOAD, continuationIndex);
 		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
 
-		m.visitLdcInsn(1 << 31);
+		m.visitLdcInsn(Integer.MIN_VALUE);
 		m.visitInsn(Opcodes.IAND);
 		m.visitJumpInsn(Opcodes.IFEQ, createStateInstance);
 
@@ -178,7 +178,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		m.visitInsn(Opcodes.DUP);
 		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
 
-		m.visitLdcInsn(1 << 31);
+		m.visitLdcInsn(Integer.MIN_VALUE);
 		m.visitInsn(Opcodes.ISUB);
 		m.visitFieldInsn(Opcodes.PUTFIELD, "ExampleKt$example$1", "label", "I");
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
@@ -44,6 +44,8 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitLabel(new Label());
+		final Range range1 = new Range();
+		range1.fromInclusive = m.instructions.getLast();
 		m.visitMethodInsn(Opcodes.INVOKESTATIC,
 				"kotlin/coroutines/intrinsics/IntrinsicsKt",
 				"getCOROUTINE_SUSPENDED", "()Ljava/lang/Object;", false);
@@ -56,8 +58,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		final Label state0 = new Label();
 		final Label state1 = new Label();
 		m.visitTableSwitchInsn(0, 1, dflt, state0, state1);
-		final Range range1 = new Range();
-		range1.fromInclusive = m.instructions.getLast();
 
 		m.visitLabel(state0);
 
@@ -98,6 +98,157 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		m.visitVarInsn(Opcodes.ALOAD, 0);
 		m.visitFieldInsn(Opcodes.GETFIELD, "Target", "I$0", "I");
 		m.visitVarInsn(Opcodes.ISTORE, 3);
+
+		{
+			m.visitVarInsn(Opcodes.ALOAD, 1);
+			m.visitInsn(Opcodes.DUP);
+			m.visitTypeInsn(Opcodes.INSTANCEOF, "kotlin/Result$Failure");
+			final Label label = new Label();
+			m.visitJumpInsn(Opcodes.IFEQ, label);
+			m.visitTypeInsn(Opcodes.CHECKCAST, "kotlin/Result$Failure");
+			m.visitFieldInsn(Opcodes.GETFIELD, "kotlin/Result$Failure",
+					"exception", "Ljava/lang/Throwable");
+			m.visitInsn(Opcodes.ATHROW);
+			m.visitInsn(Opcodes.POP);
+			m.visitLabel(label);
+		}
+		m.visitVarInsn(Opcodes.ALOAD, 1);
+		range2.toInclusive = m.instructions.getLast();
+		m.visitLabel(continuationLabelAfterLoadedResult);
+
+		// line after "suspendingFunction"
+		m.visitInsn(Opcodes.NOP);
+		m.visitInsn(Opcodes.ARETURN);
+
+		m.visitLabel(dflt);
+		final Range range0 = new Range();
+		range0.fromInclusive = m.instructions.getLast();
+		m.visitTypeInsn(Opcodes.NEW, "java/lang/IllegalStateException");
+		m.visitInsn(Opcodes.DUP);
+		m.visitLdcInsn("call to 'resume' before 'invoke' with coroutine");
+		m.visitMethodInsn(Opcodes.INVOKESPECIAL,
+				"java/lang/IllegalStateException", "<init>",
+				"(Ljava/lang/String;)V", false);
+		m.visitInsn(Opcodes.ATHROW);
+		range0.toInclusive = m.instructions.getLast();
+
+		filter.filter(m, context, output);
+
+		assertIgnored(range0, range1, range2);
+	}
+
+	/**
+	 * <pre>
+	 *     suspend fun example() {
+	 *         suspendingFunction()
+	 *         nop()
+	 *     }
+	 * </pre>
+	 */
+	@Test
+	public void should_filter_suspend_functions() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
+				Opcodes.ACC_STATIC, "example",
+				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
+				null);
+		context.classAnnotations
+				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
+
+		final int continuationArgumentIndex = 0;
+		final int continuationIndex = 2;
+
+		m.visitVarInsn(Opcodes.ALOAD, continuationArgumentIndex);
+		final Range range1 = new Range();
+		range1.fromInclusive = m.instructions.getLast();
+		m.visitTypeInsn(Opcodes.INSTANCEOF, "ExampleKt$example$1");
+		final Label createStateInstance = new Label();
+		m.visitJumpInsn(Opcodes.IFEQ, createStateInstance);
+
+		m.visitVarInsn(Opcodes.ALOAD, continuationArgumentIndex);
+		m.visitTypeInsn(Opcodes.CHECKCAST, "ExampleKt$example$1");
+		m.visitVarInsn(Opcodes.ASTORE, continuationIndex);
+
+		m.visitVarInsn(Opcodes.ALOAD, continuationIndex);
+		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
+
+		m.visitLdcInsn(1 << 31);
+		m.visitInsn(Opcodes.IAND);
+		m.visitJumpInsn(Opcodes.IFEQ, createStateInstance);
+
+		m.visitVarInsn(Opcodes.ALOAD, continuationIndex);
+		m.visitInsn(Opcodes.DUP);
+		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
+
+		m.visitLdcInsn(1 << 31);
+		m.visitInsn(Opcodes.ISUB);
+		m.visitFieldInsn(Opcodes.PUTFIELD, "ExampleKt$example$1", "label", "I");
+
+		final Label afterCoroutineStateCreated = new Label();
+		m.visitJumpInsn(Opcodes.GOTO, afterCoroutineStateCreated);
+
+		m.visitLabel(createStateInstance);
+
+		m.visitTypeInsn(Opcodes.NEW, "ExampleKt$example$1");
+		m.visitInsn(Opcodes.DUP);
+		m.visitVarInsn(Opcodes.ALOAD, 0);
+		m.visitMethodInsn(Opcodes.INVOKESPECIAL, "ExampleKt$example$1",
+				"<init>", "(Lkotlin/coroutines/Continuation;)V", false);
+
+		m.visitVarInsn(Opcodes.ASTORE, continuationIndex);
+
+		m.visitLabel(afterCoroutineStateCreated);
+
+		m.visitVarInsn(Opcodes.ALOAD, continuationIndex);
+		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "result",
+				"Ljava/lang/Object;");
+		m.visitVarInsn(Opcodes.ASTORE, 1);
+
+		m.visitMethodInsn(Opcodes.INVOKESTATIC,
+				"kotlin/coroutines/intrinsics/IntrinsicsKt",
+				"getCOROUTINE_SUSPENDED", "()Ljava/lang/Object;", false);
+
+		// line of "fun"
+		m.visitVarInsn(Opcodes.ASTORE, 3);
+
+		m.visitVarInsn(Opcodes.ALOAD, continuationIndex);
+		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
+		final Label dflt = new Label();
+		final Label state0 = new Label();
+		final Label state1 = new Label();
+		m.visitTableSwitchInsn(0, 1, dflt, state0, state1);
+
+		m.visitLabel(state0);
+
+		{
+			m.visitVarInsn(Opcodes.ALOAD, 1);
+			m.visitInsn(Opcodes.DUP);
+			m.visitTypeInsn(Opcodes.INSTANCEOF, "kotlin/Result$Failure");
+			Label label = new Label();
+			m.visitJumpInsn(Opcodes.IFEQ, label);
+			m.visitTypeInsn(Opcodes.CHECKCAST, "kotlin/Result$Failure");
+			m.visitFieldInsn(Opcodes.GETFIELD, "kotlin/Result$Failure",
+					"exception", "Ljava/lang/Throwable");
+			m.visitInsn(Opcodes.ATHROW);
+			m.visitInsn(Opcodes.POP);
+			range1.toInclusive = m.instructions.getLast();
+			m.visitLabel(label);
+		}
+
+		// line of "suspendingFunction"
+		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "", "suspendingFunction",
+				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", false);
+
+		m.visitInsn(Opcodes.DUP);
+		final Range range2 = new Range();
+		range2.fromInclusive = m.instructions.getLast();
+		m.visitVarInsn(Opcodes.ALOAD, 3);
+		final Label continuationLabelAfterLoadedResult = new Label();
+		m.visitJumpInsn(Opcodes.IF_ACMPNE, continuationLabelAfterLoadedResult);
+		// line of "fun"
+		m.visitVarInsn(Opcodes.ALOAD, 3);
+		m.visitInsn(Opcodes.ARETURN);
+
+		m.visitLabel(state1);
 
 		{
 			m.visitVarInsn(Opcodes.ALOAD, 1);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
@@ -24,10 +24,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 	private final IFilter filter = new KotlinCoroutineFilter();
 
-	private final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-			"invokeSuspend", "(Ljava/lang/Object;)Ljava/lang/Object;", null,
-			null);
-
 	/**
 	 * <pre>
 	 *     runBlocking {
@@ -39,7 +35,10 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 	 * </pre>
 	 */
 	@Test
-	public void should_filter() {
+	public void should_filter_suspending_lambdas() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"invokeSuspend", "(Ljava/lang/Object;)Ljava/lang/Object;", null,
+				null);
 		context.classAnnotations
 				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
@@ -146,7 +145,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 	 * </pre>
 	 */
 	@Test
-	public void should_filter_suspend_functions() {
+	public void should_filter_suspending_functions() {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
 				Opcodes.ACC_STATIC, "example",
 				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
@@ -190,7 +189,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 		m.visitTypeInsn(Opcodes.NEW, "ExampleKt$example$1");
 		m.visitInsn(Opcodes.DUP);
-		m.visitVarInsn(Opcodes.ALOAD, 0);
+		m.visitVarInsn(Opcodes.ALOAD, continuationArgumentIndex);
 		m.visitMethodInsn(Opcodes.INVOKESPECIAL, "ExampleKt$example$1",
 				"<init>", "(Lkotlin/coroutines/Continuation;)V", false);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
@@ -170,7 +170,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		m.visitVarInsn(Opcodes.ALOAD, continuationIndex);
 		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
 
-		m.visitLdcInsn(Integer.MIN_VALUE);
+		m.visitLdcInsn(Integer.valueOf(Integer.MIN_VALUE));
 		m.visitInsn(Opcodes.IAND);
 		m.visitJumpInsn(Opcodes.IFEQ, createStateInstance);
 
@@ -178,7 +178,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		m.visitInsn(Opcodes.DUP);
 		m.visitFieldInsn(Opcodes.GETFIELD, "ExampleKt$example$1", "label", "I");
 
-		m.visitLdcInsn(Integer.MIN_VALUE);
+		m.visitLdcInsn(Integer.valueOf(Integer.MIN_VALUE));
 		m.visitInsn(Opcodes.ISUB);
 		m.visitFieldInsn(Opcodes.PUTFIELD, "ExampleKt$example$1", "label", "I");
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
@@ -33,10 +33,6 @@ public final class KotlinCoroutineFilter implements IFilter {
 			return;
 		}
 
-		if (!"invokeSuspend".equals(methodNode.name)) {
-			return;
-		}
-
 		new Matcher().match(methodNode, output);
 
 	}
@@ -47,6 +43,61 @@ public final class KotlinCoroutineFilter implements IFilter {
 			cursor = methodNode.instructions.getFirst();
 			nextIsInvokeStatic("kotlin/coroutines/intrinsics/IntrinsicsKt",
 					"getCOROUTINE_SUSPENDED");
+
+			if (cursor == null) {
+				cursor = skipNonOpcodes(methodNode.instructions.getFirst());
+
+				nextIs(Opcodes.INSTANCEOF);
+
+				nextIs(Opcodes.IFEQ);
+				if (cursor == null) {
+					return;
+				}
+				final AbstractInsnNode createStateInstance = skipNonOpcodes(
+						((JumpInsnNode) cursor).label);
+
+				nextIs(Opcodes.ALOAD);
+				nextIs(Opcodes.CHECKCAST);
+				nextIs(Opcodes.ASTORE);
+
+				nextIs(Opcodes.ALOAD);
+				nextIs(Opcodes.GETFIELD);
+
+				nextIs(Opcodes.LDC);
+				nextIs(Opcodes.IAND);
+				nextIs(Opcodes.IFEQ);
+				if (cursor == null || skipNonOpcodes(
+						((JumpInsnNode) cursor).label) != createStateInstance) {
+					return;
+				}
+
+				nextIs(Opcodes.ALOAD);
+				nextIs(Opcodes.DUP);
+				nextIs(Opcodes.GETFIELD);
+
+				nextIs(Opcodes.LDC);
+				nextIs(Opcodes.ISUB);
+				nextIs(Opcodes.PUTFIELD);
+
+				nextIs(Opcodes.GOTO);
+				if (cursor == null) {
+					return;
+				}
+				final AbstractInsnNode afterCoroutineStateCreated = skipNonOpcodes(
+						((JumpInsnNode) cursor).label);
+
+				if (skipNonOpcodes(cursor.getNext()) != createStateInstance) {
+					return;
+				}
+
+				cursor = afterCoroutineStateCreated;
+				nextIs(Opcodes.GETFIELD);
+				nextIs(Opcodes.ASTORE);
+
+				nextIsInvokeStatic("kotlin/coroutines/intrinsics/IntrinsicsKt",
+						"getCOROUTINE_SUSPENDED");
+			}
+
 			nextIsVar(Opcodes.ASTORE, "COROUTINE_SUSPENDED");
 			nextIsVar(Opcodes.ALOAD, "this");
 			nextIs(Opcodes.GETFIELD);
@@ -70,7 +121,7 @@ public final class KotlinCoroutineFilter implements IFilter {
 			if (cursor == null) {
 				return;
 			}
-			ignore.add(s);
+			ignore.add(methodNode.instructions.getFirst());
 			ignore.add(cursor);
 
 			int suspensionPoint = 1;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
@@ -55,52 +55,7 @@ public final class KotlinCoroutineFilter implements IFilter {
 			if (cursor == null) {
 				cursor = skipNonOpcodes(methodNode.instructions.getFirst());
 
-				nextIs(Opcodes.INSTANCEOF);
-
-				nextIs(Opcodes.IFEQ);
-				if (cursor == null) {
-					return;
-				}
-				final AbstractInsnNode createStateInstance = skipNonOpcodes(
-						((JumpInsnNode) cursor).label);
-
-				nextIs(Opcodes.ALOAD);
-				nextIs(Opcodes.CHECKCAST);
-				nextIs(Opcodes.ASTORE);
-
-				nextIs(Opcodes.ALOAD);
-				nextIs(Opcodes.GETFIELD);
-
-				nextIs(Opcodes.LDC);
-				nextIs(Opcodes.IAND);
-				nextIs(Opcodes.IFEQ);
-				if (cursor == null || skipNonOpcodes(
-						((JumpInsnNode) cursor).label) != createStateInstance) {
-					return;
-				}
-
-				nextIs(Opcodes.ALOAD);
-				nextIs(Opcodes.DUP);
-				nextIs(Opcodes.GETFIELD);
-
-				nextIs(Opcodes.LDC);
-				nextIs(Opcodes.ISUB);
-				nextIs(Opcodes.PUTFIELD);
-
-				nextIs(Opcodes.GOTO);
-				if (cursor == null) {
-					return;
-				}
-				final AbstractInsnNode afterCoroutineStateCreated = skipNonOpcodes(
-						((JumpInsnNode) cursor).label);
-
-				if (skipNonOpcodes(cursor.getNext()) != createStateInstance) {
-					return;
-				}
-
-				cursor = afterCoroutineStateCreated;
-				nextIs(Opcodes.GETFIELD);
-				nextIs(Opcodes.ASTORE);
+				nextIsCreateStateInstance();
 
 				nextIsInvokeStatic("kotlin/coroutines/intrinsics/IntrinsicsKt",
 						"getCOROUTINE_SUSPENDED");
@@ -192,6 +147,55 @@ public final class KotlinCoroutineFilter implements IFilter {
 			for (int i = 0; i < ignore.size(); i += 2) {
 				output.ignore(ignore.get(i), ignore.get(i + 1));
 			}
+		}
+
+		private void nextIsCreateStateInstance() {
+			nextIs(Opcodes.INSTANCEOF);
+
+			nextIs(Opcodes.IFEQ);
+			if (cursor == null) {
+				return;
+			}
+			final AbstractInsnNode createStateInstance = skipNonOpcodes(
+					((JumpInsnNode) cursor).label);
+
+			nextIs(Opcodes.ALOAD);
+			nextIs(Opcodes.CHECKCAST);
+			nextIs(Opcodes.ASTORE);
+
+			nextIs(Opcodes.ALOAD);
+			nextIs(Opcodes.GETFIELD);
+
+			nextIs(Opcodes.LDC);
+			nextIs(Opcodes.IAND);
+			nextIs(Opcodes.IFEQ);
+			if (cursor == null || skipNonOpcodes(
+					((JumpInsnNode) cursor).label) != createStateInstance) {
+				return;
+			}
+
+			nextIs(Opcodes.ALOAD);
+			nextIs(Opcodes.DUP);
+			nextIs(Opcodes.GETFIELD);
+
+			nextIs(Opcodes.LDC);
+			nextIs(Opcodes.ISUB);
+			nextIs(Opcodes.PUTFIELD);
+
+			nextIs(Opcodes.GOTO);
+			if (cursor == null) {
+				return;
+			}
+			final AbstractInsnNode afterCoroutineStateCreated = skipNonOpcodes(
+					((JumpInsnNode) cursor).label);
+
+			if (skipNonOpcodes(cursor.getNext()) != createStateInstance) {
+				return;
+			}
+
+			cursor = afterCoroutineStateCreated;
+			nextIs(Opcodes.GETFIELD);
+			nextIs(Opcodes.ASTORE);
 		}
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -30,10 +30,11 @@
   <li>Instructions inlined by Kotlin compiler are filtered out during generation
       of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/764">#764</a>).</li>
-  <li>Branches added by the Kotlin compiler for coroutines are filtered out
-      during generation of report
+  <li>Branches added by the Kotlin compiler for suspending lambdas and functions
+      are filtered out during generation of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/802">#802</a>,
-      <a href="https://github.com/jacoco/jacoco/issues/803">#803</a>).</li>
+      <a href="https://github.com/jacoco/jacoco/issues/803">#803</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/809">#809</a>).</li>
   <li>HTML report shows message when source file can't be found
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/801">#801</a>).</li>
 </ul>


### PR DESCRIPTION
`Example.kt`

```
import kotlinx.coroutines.delay

fun nop() {
}

suspend fun example() { // line 6
  delay(0) // line 7
  nop()
}
```

`javap -v -p ExampleKt.class`

```
  public static final java.lang.Object example(kotlin.coroutines.Continuation<? super kotlin.Unit>);
    descriptor: (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=5, locals=4, args_size=1
         0: aload_0
         1: instanceof    #12                 // class ExampleKt$example$1
         4: ifeq          36
         7: aload_0
         8: checkcast     #12                 // class ExampleKt$example$1
        11: astore_2
        12: aload_2
        13: getfield      #16                 // Field ExampleKt$example$1.label:I
        16: ldc           #17                 // int -2147483648
        18: iand
        19: ifeq          36
        22: aload_2
        23: dup
        24: getfield      #16                 // Field ExampleKt$example$1.label:I
        27: ldc           #17                 // int -2147483648
        29: isub
        30: putfield      #16                 // Field ExampleKt$example$1.label:I
        33: goto          45
        36: new           #12                 // class ExampleKt$example$1
        39: dup
        40: aload_0
        41: invokespecial #21                 // Method ExampleKt$example$1."<init>":(Lkotlin/coroutines/Continuation;)V
        44: astore_2
        45: aload_2
        46: getfield      #25                 // Field ExampleKt$example$1.result:Ljava/lang/Object;
        49: astore_1
        50: invokestatic  #31                 // Method kotlin/coroutines/intrinsics/IntrinsicsKt.getCOROUTINE_SUSPENDED:()Ljava/lang/Object;
        53: astore_3
        54: aload_2
        55: getfield      #16                 // Field ExampleKt$example$1.label:I
        58: tableswitch   { // 0 to 1
                       0: 80
                       1: 113
                 default: 138
            }
        80: aload_1
        81: dup
        82: instanceof    #33                 // class kotlin/Result$Failure
        85: ifeq          95
        88: checkcast     #33                 // class kotlin/Result$Failure
        91: getfield      #37                 // Field kotlin/Result$Failure.exception:Ljava/lang/Throwable;
        94: athrow
        95: pop
        96: lconst_0
        97: aload_2
        98: aload_2
        99: iconst_1
       100: putfield      #16                 // Field ExampleKt$example$1.label:I
       103: invokestatic  #43                 // Method kotlinx/coroutines/DelayKt.delay:(JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
       106: dup
       107: aload_3
       108: if_acmpne     130
       111: aload_3
       112: areturn
       113: aload_1
       114: dup
       115: instanceof    #33                 // class kotlin/Result$Failure
       118: ifeq          128
       121: checkcast     #33                 // class kotlin/Result$Failure
       124: getfield      #37                 // Field kotlin/Result$Failure.exception:Ljava/lang/Throwable;
       127: athrow
       128: pop
       129: aload_1
       130: pop
       131: invokestatic  #45                 // Method nop:()V
       134: getstatic     #51                 // Field kotlin/Unit.INSTANCE:Lkotlin/Unit;
       137: areturn
       138: new           #53                 // class java/lang/IllegalStateException
       141: dup
       142: ldc           #55                 // String call to 'resume' before 'invoke' with coroutine
       144: invokespecial #58                 // Method java/lang/IllegalStateException."<init>":(Ljava/lang/String;)V
       147: athrow
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
           45      93     2 $continuation   Lkotlin/coroutines/Continuation;
      LineNumberTable:
        line 6: 53
        line 7: 96
        line 6: 111
        line 8: 130
        line 9: 134
```
