### PR TITLE
Do not print default zero values of attributes in XML report

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -52,6 +52,10 @@
 <ul>
   <li>JaCoCo now depends on ASM 7.0
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/760">#760</a>).</li>
+  <li>Default zero values are not printed in XML report for <code>mi</code>,
+      <code>ci</code>, <code>mb</code> and <code>cb</code> attributes of
+      <code>line</code> element
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/813">#813</a>).</li>
 </ul>
 
 <h2>Release 0.8.2 (2018/08/21)</h2>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/xml/ReportElementTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/xml/ReportElementTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.report.internal.xml;
+
+import org.jacoco.core.analysis.ICoverageNode;
+import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.internal.analysis.LineImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Unit test for {@link ReportElement}.
+ */
+public class ReportElementTest {
+
+	private ByteArrayOutputStream buffer;
+
+	private ReportElement root;
+
+	@Before
+	public void setup() throws Exception {
+		buffer = new ByteArrayOutputStream();
+		root = new ReportElement("sourcefile", buffer, "UTF-8");
+	}
+
+	@Test
+	public void should_not_write_zeros_for_line_attributes() throws Exception {
+		root.line(1, LineImpl.EMPTY.increment(CounterImpl.COUNTER_1_0,
+				CounterImpl.COUNTER_0_0));
+		root.line(2, LineImpl.EMPTY.increment(CounterImpl.COUNTER_0_1,
+				CounterImpl.COUNTER_0_0));
+		root.line(3, LineImpl.EMPTY.increment(CounterImpl.COUNTER_0_0,
+				CounterImpl.COUNTER_1_0));
+		root.line(4, LineImpl.EMPTY.increment(CounterImpl.COUNTER_0_0,
+				CounterImpl.COUNTER_0_1));
+		root.line(5, LineImpl.EMPTY);
+
+		assertTrue(actual().contains("<line nr=\"1\" mi=\"1\"/>"));
+		assertTrue(actual().contains("<line nr=\"2\" ci=\"1\"/>"));
+		assertTrue(actual().contains("<line nr=\"3\" mb=\"1\"/>"));
+		assertTrue(actual().contains("<line nr=\"4\" cb=\"1\"/>"));
+		assertTrue(actual().contains("<line nr=\"5\"/>"));
+	}
+
+	@Test
+	public void should_write_zeros_for_counter_attributes() throws Exception {
+		root.counter(ICoverageNode.CounterEntity.CLASS,
+				CounterImpl.COUNTER_0_0);
+
+		assertTrue(actual().contains(
+				"<counter type=\"CLASS\" missed=\"0\" covered=\"0\"/>"));
+	}
+
+	private String actual() throws IOException {
+		root.close();
+		return buffer.toString("UTF-8");
+	}
+
+}

--- a/org.jacoco.report/src/org/jacoco/report/internal/xml/ReportElement.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/xml/ReportElement.java
@@ -170,8 +170,19 @@ public class ReportElement extends XMLElement {
 	public void line(final int nr, final ILine line) throws IOException {
 		final ReportElement element = element("line");
 		element.attr("nr", nr);
-		counterAttributes(element, "mi", "ci", line.getInstructionCounter());
-		counterAttributes(element, "mb", "cb", line.getBranchCounter());
+		lineAttributes(element, "mi", "ci", line.getInstructionCounter());
+		lineAttributes(element, "mb", "cb", line.getBranchCounter());
+	}
+
+	private static void lineAttributes(final XMLElement element,
+			final String missedattr, final String coveredattr,
+			final ICounter counter) throws IOException {
+		if (counter.getMissedCount() != 0) {
+			element.attr(missedattr, counter.getMissedCount());
+		}
+		if (counter.getCoveredCount() != 0) {
+			element.attr(coveredattr, counter.getCoveredCount());
+		}
 	}
 
 	/**
@@ -190,14 +201,8 @@ public class ReportElement extends XMLElement {
 			final ICounter counter) throws IOException {
 		final ReportElement counterNode = element("counter");
 		counterNode.attr("type", counterEntity.name());
-		counterAttributes(counterNode, "missed", "covered", counter);
-	}
-
-	private static void counterAttributes(final XMLElement element,
-			final String missedattr, final String coveredattr,
-			final ICounter counter) throws IOException {
-		element.attr(missedattr, counter.getMissedCount());
-		element.attr(coveredattr, counter.getCoveredCount());
+		counterNode.attr("missed", counter.getMissedCount());
+		counterNode.attr("covered", counter.getCoveredCount());
 	}
 
 }


### PR DESCRIPTION
On example of our own XML report majority of lines do not have branches:

```
$ cat jacoco.xml | tr '>' '\n' | grep "<line" | wc -l
6403
$ cat jacoco.xml | tr '>' '\n' | grep "mb=\"0\" cb=\"0\"" | wc -l
5522
```

By not printing `mb="0" cb="0"` we can save 77308 bytes, which is about 7% out of 915390.

And by not printing zeros at all for [`IMPLIED` attributes `mi`, `ci`, `mb` and `cb`](https://github.com/jacoco/jacoco/blob/9c45dab3e9d9ed888481005095b30d3e5b55b338/org.jacoco.report/src/org/jacoco/report/xml/report.dtd#L68-L75) (as implemented in this PR) we can save 127498 bytes, which is about 14%.

----

Furthermore (not implemented in this PR) by [changing DTD to mark `missed` and `covered` as not `REQUIRED`](https://github.com/jacoco/jacoco/blob/9c45dab3e9d9ed888481005095b30d3e5b55b338/org.jacoco.report/src/org/jacoco/report/xml/report.dtd#L81-L84) and by not printing these too, we can save additional 93098 bytes, which is about 10%.
