### PR TITLE
Preserve empty class and sourcefile nodes in XML report

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
@@ -222,9 +222,9 @@ final class ReportSupport {
 						c.getName()));
 			}
 		}
-		if (bundle.getClassCounter().getTotalCount() > 0
-				&& bundle.getLineCounter().getTotalCount() == 0) {
-			log.warn("To enable source code annotation class files have to be compiled with debug information.");
+		if (!bundle.isEmpty() && bundle.getLineCounter().getTotalCount() == 0) {
+			log.warn(
+					"To enable source code annotation class files have to be compiled with debug information.");
 		}
 	}
 

--- a/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
@@ -593,8 +593,7 @@ public class ReportTask extends Task {
 	}
 
 	private void checkForMissingDebugInformation(final ICoverageNode node) {
-		if (node.getClassCounter().getTotalCount() > 0
-				&& node.getLineCounter().getTotalCount() == 0) {
+		if (!node.isEmpty() && node.getLineCounter().getTotalCount() == 0) {
 			log(format(
 					"To enable source code annotation class files for bundle '%s' have to be compiled with debug information.",
 					node.getName()), Project.MSG_WARN);

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
@@ -106,13 +106,10 @@ public class CoverageBuilderTest {
 	}
 
 	@Test
-	public void testIgnoreClassesWithoutCode() {
-		final MethodCoverageImpl method = new MethodCoverageImpl("doit", "()V",
-				null);
-		addClass(123L, false, "Sample", null, method);
+	public void should_not_ignore_empty_classes() {
+		addClass(123L, false, "Empty", null);
 
-		final Collection<IClassCoverage> classes = coverageBuilder.getClasses();
-		assertTrue(classes.isEmpty());
+		assertEquals(1, coverageBuilder.getClasses().size());
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
@@ -13,7 +13,6 @@ package org.jacoco.core.analysis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/ClassCoverageImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/ClassCoverageImplTest.java
@@ -93,7 +93,7 @@ public class ClassCoverageImplTest {
 		assertEquals(CounterImpl.COUNTER_0_0, node.getInstructionCounter());
 		assertEquals(CounterImpl.COUNTER_0_0, node.getBranchCounter());
 		assertEquals(CounterImpl.COUNTER_0_0, node.getMethodCounter());
-		assertEquals(CounterImpl.COUNTER_1_0, node.getClassCounter());
+		assertEquals(CounterImpl.COUNTER_0_0, node.getClassCounter());
 	}
 
 	@Test

--- a/org.jacoco.core/src/org/jacoco/core/analysis/CoverageBuilder.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/CoverageBuilder.java
@@ -98,23 +98,19 @@ public class CoverageBuilder implements ICoverageVisitor {
 	// === IStructureVisitor ===
 
 	public void visitCoverage(final IClassCoverage coverage) {
-		// Only consider classes that actually contain code:
-		if (coverage.getInstructionCounter().getTotalCount() > 0) {
-			final String name = coverage.getName();
-			final IClassCoverage dup = classes.put(name, coverage);
-			if (dup != null) {
-				if (dup.getId() != coverage.getId()) {
-					throw new IllegalStateException(
-							"Can't add different class with same name: "
-									+ name);
-				}
-			} else {
-				final String source = coverage.getSourceFileName();
-				if (source != null) {
-					final SourceFileCoverageImpl sourceFile = getSourceFile(
-							source, coverage.getPackageName());
-					sourceFile.increment(coverage);
-				}
+		final String name = coverage.getName();
+		final IClassCoverage dup = classes.put(name, coverage);
+		if (dup != null) {
+			if (dup.getId() != coverage.getId()) {
+				throw new IllegalStateException(
+						"Can't add different class with same name: " + name);
+			}
+		} else {
+			final String source = coverage.getSourceFileName();
+			if (source != null) {
+				final SourceFileCoverageImpl sourceFile = getSourceFile(source,
+						coverage.getPackageName());
+				sourceFile.increment(coverage);
 			}
 		}
 	}

--- a/org.jacoco.core/src/org/jacoco/core/analysis/CoverageNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/CoverageNodeImpl.java
@@ -143,6 +143,10 @@ public class CoverageNodeImpl implements ICoverageNode {
 		throw new AssertionError(entity);
 	}
 
+	public boolean isEmpty() {
+		return getInstructionCounter().getTotalCount() == 0;
+	}
+
 	public ICoverageNode getPlainCopy() {
 		final CoverageNodeImpl copy = new CoverageNodeImpl(elementType, name);
 		copy.instructionCounter = CounterImpl.getInstance(instructionCounter);

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
@@ -132,6 +132,13 @@ public interface ICoverageNode {
 	ICounter getCounter(CounterEntity entity);
 
 	/**
+	 * Checks whether this is an empty node.
+	 *
+	 * @return <code>true</code> if this node does not contain instructions
+	 */
+	boolean isEmpty();
+
+	/**
 	 * Creates a plain copy of this node. While {@link ICoverageNode}
 	 * implementations may contain heavy data structures, the copy returned by
 	 * this method is reduced to the counters only. This helps to save memory

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassAnalyzer.java
@@ -113,7 +113,7 @@ public class ClassAnalyzer extends ClassProbesVisitor
 				signature);
 		mcc.calculate(mc);
 
-		if (mc.getInstructionCounter().getTotalCount() > 0) {
+		if (!mc.isEmpty()) {
 			// Only consider methods that actually contain code
 			coverage.addMethod(mc);
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassCoverageImpl.java
@@ -47,7 +47,6 @@ public class ClassCoverageImpl extends SourceNodeImpl implements IClassCoverage 
 		this.id = id;
 		this.noMatch = noMatch;
 		this.methods = new ArrayList<IMethodCoverage>();
-		this.classCounter = CounterImpl.COUNTER_1_0;
 	}
 
 	/**
@@ -59,10 +58,11 @@ public class ClassCoverageImpl extends SourceNodeImpl implements IClassCoverage 
 	public void addMethod(final IMethodCoverage method) {
 		this.methods.add(method);
 		increment(method);
-		// As class is considered as covered when at least one method is
-		// covered:
+		// Class is considered as covered when at least one method is covered:
 		if (methodCounter.getCoveredCount() > 0) {
 			this.classCounter = CounterImpl.COUNTER_0_1;
+		} else {
+			this.classCounter = CounterImpl.COUNTER_1_0;
 		}
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -51,6 +51,8 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/818">#818</a>).</li>
   <li>HTML report shows message when analyzed class does not match executed
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/819">#819</a>).</li>
+  <li>Empty class and sourcefile nodes are preserved and available in XML report
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/817">#817</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
@@ -13,6 +13,8 @@ package org.jacoco.report;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +47,7 @@ public class ReportStructureTestDriver {
 
 		public Reader getSourceFile(String packageName, String fileName)
 				throws IOException {
-			return null;
+			return  new StringReader("");
 		}
 
 		public int getTabWidth() {
@@ -84,11 +86,20 @@ public class ReportStructureTestDriver {
 		sourceFileCoverageImpl.increment(classCoverage);
 		sourceFileCoverage = sourceFileCoverageImpl;
 
+		final ClassCoverageImpl emptyClass = new ClassCoverageImpl(
+				"empty/EmptyClass", 0, false);
+		emptyClass.setSourceFileName("Empty.java");
+		final SourceFileCoverageImpl emptySource = new SourceFileCoverageImpl(
+				"Empty.java", "empty");
+		final PackageCoverageImpl packageWithEmptyClass = new PackageCoverageImpl(
+				"empty", Collections.<IClassCoverage> singleton(emptyClass),
+				Collections.<ISourceFileCoverage> singleton(emptySource));
+
 		packageCoverage = new PackageCoverageImpl("org/jacoco/example",
 				Collections.singleton(classCoverage),
 				Collections.singleton(sourceFileCoverage));
 		bundleCoverage = new BundleCoverageImpl("bundle",
-				Collections.singleton(packageCoverage));
+				Arrays.asList(packageCoverage, packageWithEmptyClass));
 	}
 
 	public void sendNestedGroups(IReportVisitor reportVisitor)

--- a/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
@@ -86,20 +86,30 @@ public class ReportStructureTestDriver {
 		sourceFileCoverageImpl.increment(classCoverage);
 		sourceFileCoverage = sourceFileCoverageImpl;
 
-		final ClassCoverageImpl emptyClass = new ClassCoverageImpl(
-				"empty/EmptyClass", 0, false);
-		emptyClass.setSourceFileName("Empty.java");
-		final SourceFileCoverageImpl emptySource = new SourceFileCoverageImpl(
+		final ClassCoverageImpl emptyClassInNonEmptyPackage = new ClassCoverageImpl(
+				"org/jacoco/example/Empty", 0, false);
+		emptyClassInNonEmptyPackage.setSourceFileName("Empty.java");
+		final SourceFileCoverageImpl emptySourceInNonEmptyPackage = new SourceFileCoverageImpl(
+				"Empty.java", "org/jacoco/example");
+
+		final ClassCoverageImpl emptyClassInEmptyPackage = new ClassCoverageImpl(
+				"empty/Empty", 0, false);
+		emptyClassInEmptyPackage.setSourceFileName("Empty.java");
+		final SourceFileCoverageImpl emptySourceInEmptyPackage = new SourceFileCoverageImpl(
 				"Empty.java", "empty");
-		final PackageCoverageImpl packageWithEmptyClass = new PackageCoverageImpl(
-				"empty", Collections.<IClassCoverage> singleton(emptyClass),
-				Collections.<ISourceFileCoverage> singleton(emptySource));
+		final PackageCoverageImpl emptyPackage = new PackageCoverageImpl(
+				"empty",
+				Collections.<IClassCoverage> singletonList(
+						emptyClassInEmptyPackage),
+				Collections.<ISourceFileCoverage> singletonList(
+						emptySourceInEmptyPackage));
 
 		packageCoverage = new PackageCoverageImpl("org/jacoco/example",
-				Collections.singleton(classCoverage),
-				Collections.singleton(sourceFileCoverage));
+				Arrays.asList(classCoverage, emptyClassInNonEmptyPackage),
+				Arrays.asList(sourceFileCoverage,
+						emptySourceInNonEmptyPackage));
 		bundleCoverage = new BundleCoverageImpl("bundle",
-				Arrays.asList(packageCoverage, packageWithEmptyClass));
+				Arrays.asList(packageCoverage, emptyPackage));
 	}
 
 	public void sendNestedGroups(IReportVisitor reportVisitor)

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/CSVFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/CSVFormatterTest.java
@@ -64,6 +64,9 @@ public class CSVFormatterTest {
 		assertEquals(
 				"group/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				lines.get(1));
+		assertEquals("group/bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
+				lines.get(2));
+		assertEquals(3, lines.size());
 	}
 
 	@Test
@@ -75,8 +78,14 @@ public class CSVFormatterTest {
 				"report/group1/group/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				lines.get(1));
 		assertEquals(
-				"report/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
+				"report/group1/group/bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
 				lines.get(2));
+		assertEquals(
+				"report/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
+				lines.get(3));
+		assertEquals("report/bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
+				lines.get(4));
+		assertEquals(5, lines.size());
 	}
 
 	@Test
@@ -84,9 +93,11 @@ public class CSVFormatterTest {
 		driver.sendBundle(visitor);
 		final List<String> lines = getLines();
 		assertEquals(HEADER, lines.get(0));
-		assertEquals(
-				"bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
+		assertEquals("bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				lines.get(1));
+		assertEquals("bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
+				lines.get(2));
+		assertEquals(3, lines.size());
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/CSVFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/CSVFormatterTest.java
@@ -64,9 +64,7 @@ public class CSVFormatterTest {
 		assertEquals(
 				"group/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				lines.get(1));
-		assertEquals("group/bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
-				lines.get(2));
-		assertEquals(3, lines.size());
+		assertEquals(2, lines.size());
 	}
 
 	@Test
@@ -78,14 +76,9 @@ public class CSVFormatterTest {
 				"report/group1/group/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				lines.get(1));
 		assertEquals(
-				"report/group1/group/bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
-				lines.get(2));
-		assertEquals(
 				"report/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
-				lines.get(3));
-		assertEquals("report/bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
-				lines.get(4));
-		assertEquals(5, lines.size());
+				lines.get(2));
+		assertEquals(3, lines.size());
 	}
 
 	@Test
@@ -95,9 +88,7 @@ public class CSVFormatterTest {
 		assertEquals(HEADER, lines.get(0));
 		assertEquals("bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				lines.get(1));
-		assertEquals("bundle,empty,EmptyClass,0,0,0,0,0,0,0,0,0,0",
-				lines.get(2));
-		assertEquals(3, lines.size());
+		assertEquals(2, lines.size());
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/CSVGroupHandlerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/CSVGroupHandlerTest.java
@@ -12,6 +12,7 @@
 package org.jacoco.report.csv;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
@@ -51,6 +52,7 @@ public class CSVGroupHandlerTest {
 		assertEquals(
 				"bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				reader.readLine());
+		assertEquals("no more lines expected", null, reader.readLine());
 	}
 
 	@Test
@@ -61,6 +63,7 @@ public class CSVGroupHandlerTest {
 		assertEquals(
 				"group/bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				reader.readLine());
+		assertEquals("no more lines expected", null, reader.readLine());
 	}
 
 	private BufferedReader getResultReader() {

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/CSVGroupHandlerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/CSVGroupHandlerTest.java
@@ -12,7 +12,6 @@
 package org.jacoco.report.csv;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.io.BufferedReader;
 import java.io.StringReader;

--- a/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
@@ -70,10 +70,12 @@ public class HTMLFormatterTest {
 		output.assertFile("bundle/org.jacoco.example/index.source.html");
 		output.assertFile("bundle/org.jacoco.example/FooClass.html");
 		output.assertFile("bundle/org.jacoco.example/FooClass.java.html");
+		output.assertNoFile("bundle/org.jacoco.example/Empty.html");
+		output.assertNoFile("bundle/org.jacoco.example/Empty.java.html");
 
 		output.assertNoFile("bundle/empty/index.html");
 		output.assertNoFile("bundle/empty/index.source.html");
-		output.assertNoFile("bundle/empty/EmptyClass.html");
+		output.assertNoFile("bundle/empty/Empty.html");
 		output.assertNoFile("bundle/empty/Empty.java.html");
 	}
 
@@ -86,10 +88,12 @@ public class HTMLFormatterTest {
 		output.assertFile("org.jacoco.example/index.source.html");
 		output.assertFile("org.jacoco.example/FooClass.html");
 		output.assertFile("org.jacoco.example/FooClass.java.html");
+		output.assertNoFile("org.jacoco.example/Empty.html");
+		output.assertNoFile("org.jacoco.example/Empty.java.html");
 
 		output.assertNoFile("empty/index.html");
 		output.assertNoFile("empty/index.source.html");
-		output.assertNoFile("empty/EmptyClass.html");
+		output.assertNoFile("empty/Empty.html");
 		output.assertNoFile("empty/Empty.java.html");
 	}
 

--- a/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
@@ -65,16 +65,32 @@ public class HTMLFormatterTest {
 		driver.sendGroup(formatter.createVisitor(output));
 		output.assertFile("index.html");
 		output.assertFile("bundle/index.html");
+
 		output.assertFile("bundle/org.jacoco.example/index.html");
+		output.assertFile("bundle/org.jacoco.example/index.source.html");
 		output.assertFile("bundle/org.jacoco.example/FooClass.html");
+		output.assertFile("bundle/org.jacoco.example/FooClass.java.html");
+
+		output.assertFile("bundle/empty/index.html");
+		output.assertFile("bundle/empty/index.source.html");
+		output.assertFile("bundle/empty/EmptyClass.html");
+		output.assertFile("bundle/empty/Empty.java.html");
 	}
 
 	@Test
 	public void testStructureWithBundleOnly() throws IOException {
 		driver.sendBundle(formatter.createVisitor(output));
 		output.assertFile("index.html");
+
 		output.assertFile("org.jacoco.example/index.html");
+		output.assertFile("org.jacoco.example/index.source.html");
 		output.assertFile("org.jacoco.example/FooClass.html");
+		output.assertFile("org.jacoco.example/FooClass.java.html");
+
+		output.assertFile("empty/index.html");
+		output.assertFile("empty/index.source.html");
+		output.assertFile("empty/EmptyClass.html");
+		output.assertFile("empty/Empty.java.html");
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
@@ -71,10 +71,10 @@ public class HTMLFormatterTest {
 		output.assertFile("bundle/org.jacoco.example/FooClass.html");
 		output.assertFile("bundle/org.jacoco.example/FooClass.java.html");
 
-		output.assertFile("bundle/empty/index.html");
-		output.assertFile("bundle/empty/index.source.html");
-		output.assertFile("bundle/empty/EmptyClass.html");
-		output.assertFile("bundle/empty/Empty.java.html");
+		output.assertNoFile("bundle/empty/index.html");
+		output.assertNoFile("bundle/empty/index.source.html");
+		output.assertNoFile("bundle/empty/EmptyClass.html");
+		output.assertNoFile("bundle/empty/Empty.java.html");
 	}
 
 	@Test
@@ -87,10 +87,10 @@ public class HTMLFormatterTest {
 		output.assertFile("org.jacoco.example/FooClass.html");
 		output.assertFile("org.jacoco.example/FooClass.java.html");
 
-		output.assertFile("empty/index.html");
-		output.assertFile("empty/index.source.html");
-		output.assertFile("empty/EmptyClass.html");
-		output.assertFile("empty/Empty.java.html");
+		output.assertNoFile("empty/index.html");
+		output.assertNoFile("empty/index.source.html");
+		output.assertNoFile("empty/EmptyClass.html");
+		output.assertNoFile("empty/Empty.java.html");
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.report.internal.html.page;
+
+import org.jacoco.core.analysis.IBundleCoverage;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.IPackageCoverage;
+import org.jacoco.core.analysis.ISourceFileCoverage;
+import org.jacoco.core.internal.analysis.BundleCoverageImpl;
+import org.jacoco.core.internal.analysis.ClassCoverageImpl;
+import org.jacoco.core.internal.analysis.MethodCoverageImpl;
+import org.jacoco.core.internal.analysis.PackageCoverageImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link BundlePage}.
+ */
+public class BundlePageTest extends PageTestBase {
+
+	@Before
+	@Override
+	public void setup() throws Exception {
+		super.setup();
+	}
+
+	@Test
+	public void should_rended_non_empty_packages() throws Exception {
+		final ClassCoverageImpl classCoverage = new ClassCoverageImpl(
+				"example/Class", 0, false);
+		classCoverage.addMethod(new MethodCoverageImpl("m", "()V", null));
+		final IPackageCoverage nonEmptyPackage = new PackageCoverageImpl(
+				"example",
+				Collections.<IClassCoverage> singleton(classCoverage),
+				Collections.<ISourceFileCoverage> emptySet());
+
+		final IPackageCoverage emptyPackage = new PackageCoverageImpl("empty",
+				Collections.<IClassCoverage> emptySet(),
+				Collections.<ISourceFileCoverage> emptySet());
+
+		final IBundleCoverage node = new BundleCoverageImpl("bundle",
+				Arrays.asList(nonEmptyPackage, emptyPackage));
+
+		final BundlePage page = new BundlePage(node, null, null, rootFolder,
+				context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("index.html"));
+		assertEquals("el_package", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/a/@class"));
+		assertEquals("example", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/a"));
+		assertEquals("1",
+				support.findStr(doc, "count(/html/body/table[1]/tbody/tr)"));
+	}
+
+}

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -40,7 +40,7 @@ public class BundlePageTest extends PageTestBase {
 	}
 
 	@Test
-	public void should_rended_non_empty_packages() throws Exception {
+	public void should_render_non_empty_packages() throws Exception {
 		final ClassCoverageImpl classCoverage = new ClassCoverageImpl(
 				"example/Class", 0, false);
 		classCoverage.addMethod(new MethodCoverageImpl("m", "()V", null));

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -17,6 +17,7 @@ import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.jacoco.core.internal.analysis.BundleCoverageImpl;
 import org.jacoco.core.internal.analysis.ClassCoverageImpl;
+import org.jacoco.core.internal.analysis.CounterImpl;
 import org.jacoco.core.internal.analysis.MethodCoverageImpl;
 import org.jacoco.core.internal.analysis.PackageCoverageImpl;
 import org.junit.Before;
@@ -43,7 +44,11 @@ public class BundlePageTest extends PageTestBase {
 	public void should_render_non_empty_packages() throws Exception {
 		final ClassCoverageImpl classCoverage = new ClassCoverageImpl(
 				"example/Class", 0, false);
-		classCoverage.addMethod(new MethodCoverageImpl("m", "()V", null));
+		final MethodCoverageImpl methodCoverage = new MethodCoverageImpl("m",
+				"()V", null);
+		methodCoverage.increment(CounterImpl.COUNTER_1_0,
+				CounterImpl.COUNTER_0_0, 42);
+		classCoverage.addMethod(methodCoverage);
 		final IPackageCoverage nonEmptyPackage = new PackageCoverageImpl(
 				"example",
 				Collections.<IClassCoverage> singleton(classCoverage),

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
@@ -22,6 +22,7 @@ import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.jacoco.core.internal.analysis.ClassCoverageImpl;
+import org.jacoco.core.internal.analysis.CounterImpl;
 import org.jacoco.core.internal.analysis.MethodCoverageImpl;
 import org.jacoco.core.internal.analysis.PackageCoverageImpl;
 import org.jacoco.core.internal.analysis.SourceFileCoverageImpl;
@@ -61,7 +62,11 @@ public class PackagePageTest extends PageTestBase {
 	public void should_render_non_empty_classes() throws Exception {
 		final ClassCoverageImpl nonEmptyClass = new ClassCoverageImpl(
 				"example/NonEmptyClass", 0, false);
-		nonEmptyClass.addMethod(new MethodCoverageImpl("m", "()V", null));
+		final MethodCoverageImpl nonEmptyMethod = new MethodCoverageImpl("m",
+				"()V", null);
+		nonEmptyMethod.increment(CounterImpl.COUNTER_1_0,
+				CounterImpl.COUNTER_0_0, 42);
+		nonEmptyClass.addMethod(nonEmptyMethod);
 		final ClassCoverageImpl emptyClass = new ClassCoverageImpl(
 				"example/EmptyClass", 0, false);
 
@@ -83,10 +88,14 @@ public class PackagePageTest extends PageTestBase {
 	public void testContentsWithSource() throws Exception {
 		ClassCoverageImpl class1 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo1", 0x1000, false);
-		class1.addMethod(new MethodCoverageImpl("m", "()V", null));
+		MethodCoverageImpl method1 = new MethodCoverageImpl("m", "()V", null);
+		method1.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 42);
+		class1.addMethod(method1);
 		ClassCoverageImpl class2 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo2", 0x2000, false);
-		class2.addMethod(new MethodCoverageImpl("m", "()V", null));
+		MethodCoverageImpl method2 = new MethodCoverageImpl("m", "()V", null);
+		method2.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 42);
+		class2.addMethod(method2);
 		ISourceFileCoverage src1 = new SourceFileCoverageImpl("Src1.java",
 				"org/jacoco/example");
 		node = new PackageCoverageImpl("org/jacoco/example",
@@ -121,10 +130,14 @@ public class PackagePageTest extends PageTestBase {
 	public void testContentsNoSource() throws Exception {
 		ClassCoverageImpl class1 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo1", 0x1000, false);
-		class1.addMethod(new MethodCoverageImpl("m", "()V", null));
+		MethodCoverageImpl method1 = new MethodCoverageImpl("m", "()V", null);
+		method1.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 42);
+		class1.addMethod(method1);
 		ClassCoverageImpl class2 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo2", 0x2000, false);
-		class2.addMethod(new MethodCoverageImpl("m", "()V", null));
+		MethodCoverageImpl method2 = new MethodCoverageImpl("m", "()V", null);
+		method2.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 42);
+		class2.addMethod(method2);
 		node = new PackageCoverageImpl("org/jacoco/example",
 				Arrays.<IClassCoverage> asList(class1, class2),
 				Collections.<ISourceFileCoverage> emptyList());

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
@@ -58,7 +58,7 @@ public class PackagePageTest extends PageTestBase {
 	}
 
 	@Test
-	public void should_rended_non_empty_classes() throws Exception {
+	public void should_render_non_empty_classes() throws Exception {
 		final ClassCoverageImpl nonEmptyClass = new ClassCoverageImpl(
 				"example/NonEmptyClass", 0, false);
 		nonEmptyClass.addMethod(new MethodCoverageImpl("m", "()V", null));

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
@@ -81,14 +81,17 @@ public class PackagePageTest extends PageTestBase {
 
 	@Test
 	public void testContentsWithSource() throws Exception {
-		IClassCoverage class1 = new ClassCoverageImpl(
+		ClassCoverageImpl class1 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo1", 0x1000, false);
-		IClassCoverage class2 = new ClassCoverageImpl(
+		class1.addMethod(new MethodCoverageImpl("m", "()V", null));
+		ClassCoverageImpl class2 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo2", 0x2000, false);
+		class2.addMethod(new MethodCoverageImpl("m", "()V", null));
 		ISourceFileCoverage src1 = new SourceFileCoverageImpl("Src1.java",
 				"org/jacoco/example");
-		node = new PackageCoverageImpl("org/jacoco/example", Arrays.asList(
-				class1, class2), Arrays.asList(src1));
+		node = new PackageCoverageImpl("org/jacoco/example",
+				Arrays.<IClassCoverage> asList(class1, class2),
+				Arrays.asList(src1));
 
 		page = new PackagePage(node, null, sourceLocator, rootFolder, context);
 		page.render();
@@ -116,12 +119,15 @@ public class PackagePageTest extends PageTestBase {
 
 	@Test
 	public void testContentsNoSource() throws Exception {
-		IClassCoverage class1 = new ClassCoverageImpl(
+		ClassCoverageImpl class1 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo1", 0x1000, false);
-		IClassCoverage class2 = new ClassCoverageImpl(
+		class1.addMethod(new MethodCoverageImpl("m", "()V", null));
+		ClassCoverageImpl class2 = new ClassCoverageImpl(
 				"org/jacoco/example/Foo2", 0x2000, false);
-		node = new PackageCoverageImpl("org/jacoco/example", Arrays.asList(
-				class1, class2), Collections.<ISourceFileCoverage> emptyList());
+		class2.addMethod(new MethodCoverageImpl("m", "()V", null));
+		node = new PackageCoverageImpl("org/jacoco/example",
+				Arrays.<IClassCoverage> asList(class1, class2),
+				Collections.<ISourceFileCoverage> emptyList());
 
 		page = new PackagePage(node, null, sourceLocator, rootFolder, context);
 		page.render();

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
@@ -22,6 +22,7 @@ import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.jacoco.core.internal.analysis.ClassCoverageImpl;
+import org.jacoco.core.internal.analysis.MethodCoverageImpl;
 import org.jacoco.core.internal.analysis.PackageCoverageImpl;
 import org.jacoco.core.internal.analysis.SourceFileCoverageImpl;
 import org.jacoco.report.ISourceFileLocator;
@@ -54,6 +55,28 @@ public class PackagePageTest extends PageTestBase {
 				return null;
 			}
 		};
+	}
+
+	@Test
+	public void should_rended_non_empty_classes() throws Exception {
+		final ClassCoverageImpl nonEmptyClass = new ClassCoverageImpl(
+				"example/NonEmptyClass", 0, false);
+		nonEmptyClass.addMethod(new MethodCoverageImpl("m", "()V", null));
+		final ClassCoverageImpl emptyClass = new ClassCoverageImpl(
+				"example/EmptyClass", 0, false);
+
+		node = new PackageCoverageImpl("example",
+				Arrays.<IClassCoverage> asList(emptyClass, nonEmptyClass),
+				Collections.<ISourceFileCoverage> emptySet());
+
+		page = new PackagePage(node, null, sourceLocator, rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("index.html"));
+		assertEquals("NonEmptyClass", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/a"));
+		assertEquals("1",
+				support.findStr(doc, "count(/html/body/table[1]/tbody/tr)"));
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackageSourcePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackageSourcePageTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
+import org.jacoco.core.internal.analysis.CounterImpl;
 import org.jacoco.core.internal.analysis.PackageCoverageImpl;
 import org.jacoco.core.internal.analysis.SourceFileCoverageImpl;
 import org.jacoco.report.ISourceFileLocator;
@@ -106,6 +107,29 @@ public class PackageSourcePageTest extends PageTestBase {
 				"/html/body/table[1]/tbody/tr[2]/td[1]/span/@class"));
 		assertEquals("Src2.java", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[2]/td[1]/span"));
+	}
+
+	@Test
+	public void should_render_non_empty_sources() throws Exception {
+		final ISourceFileCoverage emptySource = new SourceFileCoverageImpl(
+				"Empty.java", "example");
+		final SourceFileCoverageImpl nonEmptySource = new SourceFileCoverageImpl(
+				"NonEmpty.java", "example");
+		nonEmptySource.increment(CounterImpl.COUNTER_1_0,
+				CounterImpl.COUNTER_0_0, 1);
+		node = new PackageCoverageImpl("example",
+				Collections.<IClassCoverage> emptyList(),
+				Arrays.asList(emptySource, nonEmptySource));
+
+		page = new PackageSourcePage(node, null, sourceLocator, rootFolder,
+				context, packagePageLink);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("index.source.html"));
+		assertEquals("NonEmpty.java", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/span"));
+		assertEquals("1",
+				support.findStr(doc, "count(/html/body/table[1]/tbody/tr)"));
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackageSourcePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackageSourcePageTest.java
@@ -49,12 +49,16 @@ public class PackageSourcePageTest extends PageTestBase {
 	@Override
 	public void setup() throws Exception {
 		super.setup();
-		ISourceFileCoverage src1 = new SourceFileCoverageImpl("Src1.java",
+		SourceFileCoverageImpl src1 = new SourceFileCoverageImpl("Src1.java",
 				"org/jacoco/example");
-		ISourceFileCoverage src2 = new SourceFileCoverageImpl("Src2.java",
+		src1.increment(CounterImpl.COUNTER_1_0,
+				CounterImpl.COUNTER_0_0, 1);
+		SourceFileCoverageImpl src2 = new SourceFileCoverageImpl("Src2.java",
 				"org/jacoco/example");
+		src2.increment(CounterImpl.COUNTER_1_0,
+				CounterImpl.COUNTER_0_0, 1);
 		node = new PackageCoverageImpl("org/jacoco/example",
-				Collections.<IClassCoverage> emptyList(), Arrays.asList(src1,
+				Collections.<IClassCoverage> emptyList(), Arrays.<ISourceFileCoverage>asList(src1,
 						src2));
 		sourceLocator = new ISourceFileLocator() {
 

--- a/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
@@ -138,7 +138,7 @@ public class XMLFormatterTest {
 		assertPathMatches("2", "count(/report/package)");
 		assertPathMatches("org/jacoco/example", "/report/package/@name");
 
-		assertPathMatches("2", "count(/report/package/class)");
+		assertPathMatches("3", "count(/report/package/class)");
 		assertPathMatches("org/jacoco/example/FooClass",
 				"/report/package/class/@name");
 
@@ -169,7 +169,8 @@ public class XMLFormatterTest {
 		assertPathMatches("0", "report/counter[@type='CLASS']/@missed");
 		assertPathMatches("1", "report/counter[@type='CLASS']/@covered");
 
-		assertPathMatches("2", "count(report/package/sourcefile)");
+		assertPathMatches("2",
+				"count(report/package[@name='org/jacoco/example']/sourcefile)");
 		assertPathMatches("3", "count(report/package/sourcefile/line)");
 		assertPathMatches("1",
 				"report/package/sourcefile[@name='FooClass.java']/line[1]/@nr");
@@ -188,7 +189,7 @@ public class XMLFormatterTest {
 		assertPathMatches("0", "count(/report/package[@name='empty']/counter)");
 
 		assertPathMatches("1", "count(/report/package[@name='empty']/class)");
-		assertPathMatches("empty/EmptyClass",
+		assertPathMatches("empty/Empty",
 				"/report/package[@name='empty']/class/@name");
 		assertPathMatches("0",
 				"count(report/package[@name='empty']/class/*)");

--- a/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
@@ -134,9 +134,15 @@ public class XMLFormatterTest {
 		visitor.visitInfo(infos, data);
 		driver.sendBundle(visitor);
 		assertPathMatches("bundle", "/report/@name");
+
+		assertPathMatches("2", "count(/report/package)");
 		assertPathMatches("org/jacoco/example", "/report/package/@name");
+
+		assertPathMatches("2", "count(/report/package/class)");
 		assertPathMatches("org/jacoco/example/FooClass",
 				"/report/package/class/@name");
+
+		assertPathMatches("1", "count(/report/package/class/method)");
 		assertPathMatches("fooMethod", "/report/package/class/method/@name");
 
 		assertPathMatches("1", "count(/report/counter[@type='INSTRUCTION'])");
@@ -163,6 +169,8 @@ public class XMLFormatterTest {
 		assertPathMatches("0", "report/counter[@type='CLASS']/@missed");
 		assertPathMatches("1", "report/counter[@type='CLASS']/@covered");
 
+		assertPathMatches("2", "count(report/package/sourcefile)");
+		assertPathMatches("3", "count(report/package/sourcefile/line)");
 		assertPathMatches("1",
 				"report/package/sourcefile[@name='FooClass.java']/line[1]/@nr");
 		assertPathMatches("3",
@@ -176,6 +184,21 @@ public class XMLFormatterTest {
 				"report/package/sourcefile[@name='FooClass.java']/line[3]/@nr");
 		assertPathMatches("4",
 				"report/package/sourcefile[@name='FooClass.java']/line[3]/@mi");
+
+		assertPathMatches("0", "count(/report/package[@name='empty']/counter)");
+
+		assertPathMatches("1", "count(/report/package[@name='empty']/class)");
+		assertPathMatches("empty/EmptyClass",
+				"/report/package[@name='empty']/class/@name");
+		assertPathMatches("0",
+				"count(report/package[@name='empty']/class/*)");
+
+		assertPathMatches("1",
+				"count(/report/package[@name='empty']/sourcefile)");
+		assertPathMatches("Empty.java",
+				"report/package[@name='empty']/sourcefile/@name");
+		assertPathMatches("0",
+				"count(report/package[@name='empty']/sourcefile/*)");
 	}
 
 	@Test

--- a/org.jacoco.report/src/org/jacoco/report/csv/CSVGroupHandler.java
+++ b/org.jacoco.report/src/org/jacoco/report/csv/CSVGroupHandler.java
@@ -43,7 +43,7 @@ class CSVGroupHandler implements IReportGroupVisitor {
 		for (final IPackageCoverage p : bundle.getPackages()) {
 			final String packageName = p.getName();
 			for (final IClassCoverage c : p.getClasses()) {
-				if (c.getClassCounter().getTotalCount() != 0) {
+				if (!c.isEmpty()) {
 					writer.writeRow(name, packageName, c);
 				}
 			}

--- a/org.jacoco.report/src/org/jacoco/report/csv/CSVGroupHandler.java
+++ b/org.jacoco.report/src/org/jacoco/report/csv/CSVGroupHandler.java
@@ -43,7 +43,9 @@ class CSVGroupHandler implements IReportGroupVisitor {
 		for (final IPackageCoverage p : bundle.getPackages()) {
 			final String packageName = p.getName();
 			for (final IClassCoverage c : p.getClasses()) {
-				writer.writeRow(name, packageName, c);
+				if (c.getClassCounter().getTotalCount() != 0) {
+					writer.writeRow(name, packageName, c);
+				}
 			}
 		}
 	}

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
@@ -62,7 +62,7 @@ public class BundlePage extends TablePage<ICoverageNode> {
 
 	private void renderPackages() throws IOException {
 		for (final IPackageCoverage p : bundle.getPackages()) {
-			if (p.getClassCounter().getTotalCount() == 0) {
+			if (p.isEmpty()) {
 				continue;
 			}
 			final String packagename = p.getName();

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
@@ -62,6 +62,9 @@ public class BundlePage extends TablePage<ICoverageNode> {
 
 	private void renderPackages() throws IOException {
 		for (final IPackageCoverage p : bundle.getPackages()) {
+			if (p.getClassCounter().getTotalCount() == 0) {
+				continue;
+			}
 			final String packagename = p.getName();
 			final String foldername = packagename.length() == 0 ? "default"
 					: packagename.replace('/', '.');

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
@@ -65,6 +65,9 @@ public class PackagePage extends TablePage<IPackageCoverage> {
 
 	private void renderClasses() throws IOException {
 		for (final IClassCoverage c : getNode().getClasses()) {
+			if (c.getClassCounter().getTotalCount() == 0) {
+				continue;
+			}
 			final ILinkable sourceFilePage = packageSourcePage
 					.getSourceFilePage(c.getSourceFileName());
 			final ClassPage page = new ClassPage(c, this, sourceFilePage,

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
@@ -65,7 +65,7 @@ public class PackagePage extends TablePage<IPackageCoverage> {
 
 	private void renderClasses() throws IOException {
 		for (final IClassCoverage c : getNode().getClasses()) {
-			if (c.getClassCounter().getTotalCount() == 0) {
+			if (c.isEmpty()) {
 				continue;
 			}
 			final ILinkable sourceFilePage = packageSourcePage

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackageSourcePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackageSourcePage.java
@@ -79,6 +79,9 @@ public class PackageSourcePage extends TablePage<IPackageCoverage> {
 	private final void renderSourceFilePages() throws IOException {
 		final String packagename = getNode().getName();
 		for (final ISourceFileCoverage s : getNode().getSourceFiles()) {
+			if (s.getInstructionCounter().getTotalCount() == 0) {
+				continue;
+			}
 			final String sourcename = s.getName();
 			final Reader reader = locator
 					.getSourceFile(packagename, sourcename);

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackageSourcePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackageSourcePage.java
@@ -79,7 +79,7 @@ public class PackageSourcePage extends TablePage<IPackageCoverage> {
 	private final void renderSourceFilePages() throws IOException {
 		final String packagename = getNode().getName();
 		for (final ISourceFileCoverage s : getNode().getSourceFiles()) {
-			if (s.getInstructionCounter().getTotalCount() == 0) {
+			if (s.isEmpty()) {
 				continue;
 			}
 			final String sourcename = s.getName();


### PR DESCRIPTION
Fixes #806

Our own XML report before this change is 915700 bytes, after is 920811 - increase is just 0.6%.