### PR TITLE
Show messages in HTML report when class has no debug information

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -37,6 +37,8 @@
       <a href="https://github.com/jacoco/jacoco/issues/809">#809</a>).</li>
   <li>HTML report shows message when source file can't be found
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/801">#801</a>).</li>
+  <li>HTML report shows message when class has no debug information
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/818">#818</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.internal.analysis.ClassCoverageImpl;
+import org.jacoco.core.internal.analysis.CounterImpl;
 import org.jacoco.core.internal.analysis.MethodCoverageImpl;
 import org.jacoco.report.internal.ReportOutputFolder;
 import org.jacoco.report.internal.html.ILinkable;
@@ -37,8 +38,10 @@ public class ClassPageTest extends PageTestBase {
 	@Override
 	public void setup() throws Exception {
 		super.setup();
+		final MethodCoverageImpl m = new MethodCoverageImpl("a", "()V", null);
+		m.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 42);
 		node = new ClassCoverageImpl("org/jacoco/example/Foo", 123, false);
-		node.addMethod(new MethodCoverageImpl("a", "()V", null));
+		node.addMethod(m);
 		node.addMethod(new MethodCoverageImpl("b", "()V", null));
 		node.addMethod(new MethodCoverageImpl("c", "()V", null));
 	}
@@ -89,8 +92,10 @@ public class ClassPageTest extends PageTestBase {
 	@Test
 	public void should_generate_message_with_default_package_when_SourceFileName_present_but_no_SourceFilePage()
 			throws Exception {
+		final MethodCoverageImpl m = new MethodCoverageImpl("a", "()V", null);
+		m.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 42);
 		node = new ClassCoverageImpl("Foo", 123, false);
-		node.addMethod(new MethodCoverageImpl("a", "()V", null));
+		node.addMethod(m);
 		node.setSourceFileName("Foo.java");
 
 		page = new ClassPage(node, null, null, rootFolder, context);

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
@@ -114,6 +114,20 @@ public class ClassPageTest extends PageTestBase {
 		assertEquals("", support.findStr(doc, "/html/body/p[1]"));
 	}
 
+	@Test
+	public void should_generate_message_when_no_lines() throws Exception {
+		node = new ClassCoverageImpl("Foo", 123, false);
+		node.addMethod(new MethodCoverageImpl("m", "()V", null));
+
+		page = new ClassPage(node, null, new SourceLink(), rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals(
+				"Class files must be compiled with debug information to show line coverage.",
+				support.findStr(doc, "/html/body/p[1]"));
+	}
+
 	private class SourceLink implements ILinkable {
 
 		public String getLink(final ReportOutputFolder base) {

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
@@ -61,13 +61,15 @@ public class ClassPageTest extends PageTestBase {
 	}
 
 	@Test
-	public void should_not_generate_message_when_SourceFileName_not_present()
+	public void should_generate_message_when_SourceFileName_not_present()
 			throws Exception {
 		page = new ClassPage(node, null, null, rootFolder, context);
 		page.render();
 
 		final Document doc = support.parse(output.getFile("Foo.html"));
-		assertEquals("", support.findStr(doc, "/html/body/p[1]"));
+		assertEquals(
+				"Class files must be compiled with debug information to link with source files.",
+				support.findStr(doc, "/html/body/p[1]"));
 	}
 
 	@Test

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
@@ -83,6 +83,11 @@ public class ClassPage extends TablePage<IClassCoverage> {
 
 	@Override
 	protected void content(HTMLElement body) throws IOException {
+		if (getNode().getLineCounter().getTotalCount() == 0) {
+			body.p().text(
+					"Class files must be compiled with debug information to show line coverage.");
+		}
+
 		final String sourceFileName = getNode().getSourceFileName();
 		if (sourceFileName == null) {
 			body.p().text(

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
@@ -83,12 +83,17 @@ public class ClassPage extends TablePage<IClassCoverage> {
 
 	@Override
 	protected void content(HTMLElement body) throws IOException {
-		if (getNode().getSourceFileName() != null && sourcePage == null) {
+		final String sourceFileName = getNode().getSourceFileName();
+		if (sourceFileName == null) {
+			body.p().text(
+					"Class files must be compiled with debug information to link with source files.");
+
+		} else if (sourcePage == null) {
 			final String sourcePath;
 			if (getNode().getPackageName().length() != 0) {
-				sourcePath = getNode().getPackageName() + "/" + getNode().getSourceFileName();
+				sourcePath = getNode().getPackageName() + "/" + sourceFileName;
 			} else {
-				sourcePath = getNode().getSourceFileName();
+				sourcePath = sourceFileName;
 			}
 			body.p().text("Source file \"" + sourcePath
 					+ "\" was not found during generation of report.");


### PR DESCRIPTION
In addition to #801 another common problem already described in our FAQ and still frequently faced by users - absence of debug information in class files.

This PR adds following messages to a page with class methods:

```
Class files must be compiled with debug information to link with source files.
```

```
Class files must be compiled with debug information to show line coverage.
```
