### PR TITLE
Show message in HTML report when analyzed class does not match executed

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -39,6 +39,8 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/801">#801</a>).</li>
   <li>HTML report shows message when class has no debug information
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/818">#818</a>).</li>
+  <li>HTML report shows message when analyzed class does not match executed
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/819">#819</a>).</li>
 </ul>
 
 <h3>Fixed Bugs</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ClassPageTest.java
@@ -133,6 +133,20 @@ public class ClassPageTest extends PageTestBase {
 				support.findStr(doc, "/html/body/p[1]"));
 	}
 
+	@Test
+	public void should_generate_message_when_class_id_mismatch()
+			throws Exception {
+		node = new ClassCoverageImpl("Foo", 123, true);
+		node.addMethod(new MethodCoverageImpl("m", "()V", null));
+
+		page = new ClassPage(node, null, new SourceLink(), rootFolder, context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("Foo.html"));
+		assertEquals("A different version of class was executed at runtime.",
+				support.findStr(doc, "/html/body/p[1]"));
+	}
+
 	private class SourceLink implements ILinkable {
 
 		public String getLink(final ReportOutputFolder base) {

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/ClassPage.java
@@ -83,6 +83,11 @@ public class ClassPage extends TablePage<IClassCoverage> {
 
 	@Override
 	protected void content(HTMLElement body) throws IOException {
+		if (getNode().isNoMatch()) {
+			body.p().text(
+					"A different version of class was executed at runtime.");
+		}
+
 		if (getNode().getLineCounter().getTotalCount() == 0) {
 			body.p().text(
 					"Class files must be compiled with debug information to show line coverage.");


### PR DESCRIPTION
In addition to #801 and #818 another common problem already described in our FAQ and still frequently faced by users - mismatch between executed and analyzed class file.

This PR adds following message to a page with class methods:

```
A different version of class was executed at runtime.
```
