### PR TITLE
Require at least Maven 3.0 for jacoco-maven-plugin

### DIFF
--- a/jacoco-maven-plugin.test/it/it-check-fails-halt/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-check-fails-halt/pom.xml
@@ -40,15 +40,13 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>CLASS</element>
                   <includes>
                     <include>Example</include>
                   </includes>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>METHOD</counter>
                       <value>MISSEDCOUNT</value>
                       <maximum>0</maximum>

--- a/jacoco-maven-plugin.test/it/it-check-fails-no-halt/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-check-fails-no-halt/pom.xml
@@ -41,12 +41,10 @@
             <configuration>
               <haltOnFailure>false</haltOnFailure>
              <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>METHOD</counter>
                       <value>MISSEDCOUNT</value>
                       <maximum>0</maximum>

--- a/jacoco-maven-plugin.test/it/it-check-passes/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-check-passes/pom.xml
@@ -40,18 +40,15 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>0.90</minimum>
                     </limit>
-                    <!-- implmentation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>CLASS</counter>
                       <value>MISSEDCOUNT</value>
                       <maximum>0</maximum>

--- a/jacoco-maven-plugin.test/it/it-dump/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-dump/pom.xml
@@ -50,12 +50,10 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>CLASS</counter>
                       <value>COVEREDCOUNT</value>
                       <minimum>1</minimum>

--- a/jacoco-maven-plugin.test/it/it-java9/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-java9/pom.xml
@@ -49,11 +49,9 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDCOUNT</value>
                       <minimum>8</minimum>

--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
   <description>The JaCoCo Maven Plugin provides the JaCoCo runtime agent to your tests and allows basic report creation.</description>
 
   <prerequisites>
-    <maven>2.2.1</maven>
+    <maven>3.0</maven>
   </prerequisites>
 
   <dependencyManagement>
@@ -54,7 +54,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
       <version>${project.prerequisites.maven}</version>
     </dependency>
     <dependency>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -64,12 +64,6 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 	 * </ul>
 	 * 
 	 * <p>
-	 * Note that you <b>must</b> use <tt>implementation</tt> hints for
-	 * <tt>rule</tt> and <tt>limit</tt> when using Maven 2, with Maven 3 you do
-	 * not need to specify the attributes.
-	 * </p>
-	 * 
-	 * <p>
 	 * This example requires an overall instruction coverage of 80% and no class
 	 * must be missed:
 	 * </p>
@@ -77,15 +71,15 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 	 * <pre>
 	 * {@code
 	 * <rules>
-	 *   <rule implementation="org.jacoco.maven.RuleConfiguration">
+	 *   <rule>
 	 *     <element>BUNDLE</element>
 	 *     <limits>
-	 *       <limit implementation="org.jacoco.report.check.Limit">
+	 *       <limit>
 	 *         <counter>INSTRUCTION</counter>
 	 *         <value>COVEREDRATIO</value>
 	 *         <minimum>0.80</minimum>
 	 *       </limit>
-	 *       <limit implementation="org.jacoco.report.check.Limit">
+	 *       <limit>
 	 *         <counter>CLASS</counter>
 	 *         <value>MISSEDCOUNT</value>
 	 *         <maximum>0</maximum>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
@@ -43,13 +43,10 @@ public class MergeMojo extends AbstractJacocoMojo {
 	/**
 	 * This mojo accepts any number of execution data file sets.
 	 * 
-	 * Note that you need an <tt>implementation</tt> hint on <tt>fileset</tt>
-	 * with Maven 2 (not needed with Maven 3):
-	 * 
 	 * <pre>
 	 * <code>
 	 * &lt;fileSets&gt;
-	 *   &lt;fileSet implementation="org.apache.maven.shared.model.fileset.FileSet"&gt;
+	 *   &lt;fileSet&gt;
 	 *     &lt;directory&gt;${project.build.directory}&lt;/directory&gt;
 	 *     &lt;includes&gt;
 	 *       &lt;include&gt;*.exec&lt;/include&gt;

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -22,6 +22,8 @@
 
 <h3>New Features</h3>
 <ul>
+  <li>jacoco-maven-plugin now requires at least Maven 3.0
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/821">#821</a>).</li>
   <li>JaCoCo now officially supports Java 11
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/760">#760</a>).</li>
   <li>Branch added by the Kotlin compiler for "unsafe" cast operator is filtered

--- a/org.jacoco.doc/docroot/doc/maven.html
+++ b/org.jacoco.doc/docroot/doc/maven.html
@@ -73,7 +73,7 @@
 </p>
 
 <ul>
-  <li>Maven 2.1.0 or higher and</li>
+  <li>Maven 3.0 or higher and</li>
   <li>Java 1.5 or higher (for both, the Maven runtime and the test executor).</li>
 </ul>
 

--- a/org.jacoco.examples/build/pom-it.xml
+++ b/org.jacoco.examples/build/pom-it.xml
@@ -74,12 +74,10 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>0.60</minimum>

--- a/org.jacoco.examples/build/pom-offline.xml
+++ b/org.jacoco.examples/build/pom-offline.xml
@@ -75,12 +75,10 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>0.60</minimum>

--- a/org.jacoco.examples/build/pom.xml
+++ b/org.jacoco.examples/build/pom.xml
@@ -62,12 +62,10 @@
             </goals>
             <configuration>
               <rules>
-                <!-- implementation is needed only for Maven 2 -->
-                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <rule>
                   <element>BUNDLE</element>
                   <limits>
-                    <!-- implementation is needed only for Maven 2 -->
-                    <limit implementation="org.jacoco.report.check.Limit">
+                    <limit>
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>0.60</minimum>


### PR DESCRIPTION
Fixes #194

Tests with Java 5 failed due to artifact doxia-site-renderer-1.7.4 compiled for Java 6 (from maven-reporting-impl:jar:3.0.0) - blocked by #314
