### PR TITLE
Fix MethodAnalyzerTest

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -325,22 +325,24 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	public void if_branch_merge_should_show_partial_branch_coverage_when_probe_for_first_branch_is_executed() {
 		createIfBranchMerge();
 		probes[0] = true;
+		probes[2] = true;
 		runMethodAnalzer();
 
 		assertLine(1001, 0, 2, 1, 1);
 		assertLine(1002, 1, 0, 0, 0);
-		assertLine(1003, 1, 0, 0, 0);
+		assertLine(1003, 0, 1, 0, 0);
 	}
 
 	@Test
 	public void if_branch_merge_should_show_partial_branch_coverage_when_probe_for_second_branch_is_executed() {
 		createIfBranchMerge();
 		probes[1] = true;
+		probes[2] = true;
 		runMethodAnalzer();
 
 		assertLine(1001, 0, 2, 1, 1);
 		assertLine(1002, 0, 1, 0, 0);
-		assertLine(1003, 1, 0, 0, 0);
+		assertLine(1003, 0, 1, 0, 0);
 	}
 
 	@Test


### PR DESCRIPTION
[`createIfBranchMerge` in `MethodAnalyzerTest`](https://github.com/jacoco/jacoco/blob/34afa221fa3102427b04ca44ef827c4ddff2cd0f/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java#L291-L305) creates following bytecode

```
    iload
    ifeq l1
    nop
l1: return
```

`probe[0]` is inserted for `ifeq` and indicates jump to `l1`
`probe[1]` is inserted before `l1`
`probe[2]` is inserted after `l1`

If dump is not taken in the middle of the method, then

[test `if_branch_merge_should_show_partial_branch_coverage_when_probe_for_second_branch_is_executed`](https://github.com/jacoco/jacoco/blob/34afa221fa3102427b04ca44ef827c4ddff2cd0f/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java#L335-L344) does not look realistic, because when `probe[1]` is `true` then `probe[2]` should also be `true`.

[test `if_branch_merge_should_show_partial_branch_coverage_when_probe_for_first_branch_is_executed`](https://github.com/jacoco/jacoco/blob/34afa221fa3102427b04ca44ef827c4ddff2cd0f/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java#L324-L333) also does not look realistic , because when `probe[0]` is `true` then `probe[2]` should also be `true`.
