### PR TITLE
Get rid of warnings about shading ASM "module-info.class"

### DIFF
--- a/org.jacoco.agent.rt/pom.xml
+++ b/org.jacoco.agent.rt/pom.xml
@@ -68,6 +68,14 @@
                   <shadedPattern>${jacoco.runtime.package.name}.asm</shadedPattern>
                 </relocation>
               </relocations>
+              <filters>
+                <filter>
+                  <artifact>org.ow2.asm:*</artifact>
+                  <excludes>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>

--- a/org.jacoco.ant/pom.xml
+++ b/org.jacoco.ant/pom.xml
@@ -67,6 +67,14 @@
                   <shadedPattern>org.jacoco.asm</shadedPattern>
                 </relocation>
               </relocations>
+              <filters>
+                <filter>
+                  <artifact>org.ow2.asm:*</artifact>
+                  <excludes>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>

--- a/org.jacoco.cli/pom.xml
+++ b/org.jacoco.cli/pom.xml
@@ -108,6 +108,12 @@
                     <exclude>**/Messages_*.properties</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>org.ow2.asm:*</artifact>
+                  <excludes>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
               </filters>
             </configuration>
           </execution>


### PR DESCRIPTION
Thanks to #820 we can benefit from https://issues.apache.org/jira/browse/MSHADE-303 and get rid of warnings

```
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
```
