### PR TITLE
Configure exec-maven-plugin to use selected JDK toolchain 

### DIFF
--- a/org.jacoco.cli/pom.xml
+++ b/org.jacoco.cli/pom.xml
@@ -49,11 +49,15 @@
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <configuration>
-              <mainClass>org.jacoco.cli.internal.XmlDocumentation</mainClass>
+              <toolchain>jdk</toolchain>
+              <executable>java</executable>
               <arguments>
+                <argument>-cp</argument>
+                <classpath/>
+                <argument>org.jacoco.cli.internal.XmlDocumentation</argument>
                 <argument>${project.build.directory}/generated-documentation/cli.xml</argument>
               </arguments>
             </configuration>
@@ -119,6 +123,6 @@
           </execution>
         </executions>
       </plugin>
-    </plugins>    
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Currently when Maven uses

```
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
```

execution of

```
mvn clean package -Djdk.version=10 -Dbytecode.version=10
```

fails

```
...
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ org.jacoco.cli ---
[INFO] Toolchain in maven-compiler-plugin: JDK[/Users/evgeny.mandrikov/.java-select/versions/10]
...
[INFO] --- exec-maven-plugin:1.5.0:java (default) @ org.jacoco.cli ---
[WARNING]
java.lang.UnsupportedClassVersionError: org/jacoco/cli/internal/XmlDocumentation has been compiled by a more recent version of the Java Runtime (class file version 54.0), this version of the Java Runtime only recognizes class file versions up to 52.0
    at java.lang.ClassLoader.defineClass1 (Native Method)
    at java.lang.ClassLoader.defineClass (ClassLoader.java:763)
    at java.security.SecureClassLoader.defineClass (SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass (URLClassLoader.java:467)
    at java.net.URLClassLoader.access$100 (URLClassLoader.java:73)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:368)
    at java.net.URLClassLoader$1.run (URLClassLoader.java:362)
    at java.security.AccessController.doPrivileged (Native Method)
    at java.net.URLClassLoader.findClass (URLClassLoader.java:361)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:424)
    at java.lang.ClassLoader.loadClass (ClassLoader.java:357)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:281)
    at java.lang.Thread.run (Thread.java:748)
...
[INFO] BUILD FAILURE
...
```
