### PR TITLE
Replace empty table in HTML report by messages

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -51,6 +51,9 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/818">#818</a>).</li>
   <li>HTML report shows message when analyzed class does not match executed
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/819">#819</a>).</li>
+  <li>HTML report shows message when no class files specified and when all
+      analyzed classes are abstract or generated code
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/833">#833</a>).</li>
   <li>Empty class and sourcefile nodes are preserved and available in XML report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/817">#817</a>).</li>
 </ul>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -51,8 +51,8 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/818">#818</a>).</li>
   <li>HTML report shows message when analyzed class does not match executed
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/819">#819</a>).</li>
-  <li>HTML report shows message when no class files specified and when all
-      analyzed classes are abstract or generated code
+  <li>HTML report shows message when no class files specified and when
+      none of the analyzed classes contain code relevant for code coverage
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/833">#833</a>).</li>
   <li>Empty class and sourcefile nodes are preserved and available in XML report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/817">#817</a>).</li>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -103,7 +103,8 @@ public class BundlePageTest extends PageTestBase {
 		page.render();
 
 		final Document doc = support.parse(output.getFile("index.html"));
-		assertEquals("No classes to display - all analyzed classes are abstract or generated code.",
+		assertEquals(
+				"None of the analyzed classes contain code relevant for code coverage.",
 				support.findStr(doc, "/html/body/p"));
 	}
 

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -74,4 +74,19 @@ public class BundlePageTest extends PageTestBase {
 				support.findStr(doc, "count(/html/body/table[1]/tbody/tr)"));
 	}
 
+	@Test
+	public void should_render_message_when_no_class_files_specified()
+			throws Exception {
+		final IBundleCoverage node = new BundleCoverageImpl("bundle",
+				Collections.<IPackageCoverage> emptySet());
+
+		final BundlePage page = new BundlePage(node, null, null, rootFolder,
+				context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("index.html"));
+		assertEquals("No class files specified.",
+				support.findStr(doc, "/html/body/p"));
+	}
+
 }

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -89,4 +89,22 @@ public class BundlePageTest extends PageTestBase {
 				support.findStr(doc, "/html/body/p"));
 	}
 
+	@Test
+	public void should_render_message_when_all_classes_empty()
+			throws Exception {
+		final ClassCoverageImpl emptyClass = new ClassCoverageImpl(
+				"example/Class", 0, false);
+		final IBundleCoverage node = new BundleCoverageImpl("bundle",
+				Collections.<IClassCoverage> singleton(emptyClass),
+				Collections.<ISourceFileCoverage> emptySet());
+
+		final BundlePage page = new BundlePage(node, null, null, rootFolder,
+				context);
+		page.render();
+
+		final Document doc = support.parse(output.getFile("index.html"));
+		assertEquals("No classes to display - all analyzed classes are abstract or generated code.",
+				support.findStr(doc, "/html/body/p"));
+	}
+
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
@@ -92,7 +92,7 @@ public class BundlePage extends TablePage<ICoverageNode> {
 			body.p().text("No class files specified.");
 		} else if (bundle.isEmpty()) {
 			body.p().text(
-					"No classes to display - all analyzed classes are abstract or generated code.");
+					"None of the analyzed classes contain code relevant for code coverage.");
 		} else {
 			super.content(body);
 		}

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/BundlePage.java
@@ -18,6 +18,7 @@ import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.report.ISourceFileLocator;
 import org.jacoco.report.internal.ReportOutputFolder;
+import org.jacoco.report.internal.html.HTMLElement;
 import org.jacoco.report.internal.html.IHTMLReportContext;
 
 /**
@@ -83,6 +84,18 @@ public class BundlePage extends TablePage<ICoverageNode> {
 	@Override
 	protected String getFileName() {
 		return "index.html";
+	}
+
+	@Override
+	protected void content(HTMLElement body) throws IOException {
+		if (bundle.getPackages().isEmpty()) {
+			body.p().text("No class files specified.");
+		} else if (bundle.isEmpty()) {
+			body.p().text(
+					"No classes to display - all analyzed classes are abstract or generated code.");
+		} else {
+			super.content(body);
+		}
 	}
 
 }


### PR DESCRIPTION
Using Ant Task and therefore Gradle Plugin, that is based on it, possible to generate report without classes.

For example in case of following `build.xml`

```
<project xmlns:jacoco="antlib:org.jacoco.ant" default="build">
  <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
    <classpath path="jacoco/lib/jacocoant.jar"/>
  </taskdef>

  <target name="build">
    <jacoco:report>
      <structure name="example"/>
      <html destdir="report"/>
    </jacoco:report>
  </target>
</project>
```

and `build.gradle`

```
apply plugin: 'base'
apply plugin: 'jacoco'

repositories {
  mavenCentral()
  mavenLocal()
}

task report(type:JacocoReport) {
  executionData.from(files(file('jacoco.exec')))
}
```

execution of

```
$ ant
Buildfile: /private/tmp/example/build.xml

build:
[jacoco:report] Writing bundle 'example' with 0 classes

BUILD SUCCESSFUL
Total time: 0 seconds

$ ant -silent
Buildfile: /private/tmp/example/build.xml

$ gradle-5.0 clean report

BUILD SUCCESSFUL in 1s
2 actionable tasks: 1 executed, 1 up-to-date
```

will produce

![empty](https://user-images.githubusercontent.com/138671/51421440-b3fd1080-1b9e-11e9-8403-6da4f4774125.png)

Note the absence of messages in the second and third cases.

Also unfortunately many users don't provide screenshots and the way they describe such report is ambiguous: "empty report" and "zero(s)" - in both cases some indeed refer to such report, some other refer to report with classes where covered counters are zero.

Could also be noted that produced `index.html` claims to be XHTML 1.0 Strict whereas this is not the case because of `<tbody/>`.

So I propose to replace empty table by messages for two cases thanks to #817 

```java
if (bundle.getPackages().isEmpty()) {
  ... // No class files specified.
} else if (bundle.isEmpty()) {
  ... // None of the analyzed classes contain code relevant for code coverage.
} else {
  ...
}
```
