### PR TITLE
Avoid additional members in instrumented classes

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/CoverageTransformer.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/CoverageTransformer.java
@@ -16,7 +16,7 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 
-import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.instr.NewInstrumenter;
 import org.jacoco.core.runtime.AgentOptions;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.WildcardMatcher;
@@ -33,7 +33,7 @@ public class CoverageTransformer implements ClassFileTransformer {
 		AGENT_PREFIX = toVMName(name.substring(0, name.lastIndexOf('.')));
 	}
 
-	private final Instrumenter instrumenter;
+	private final NewInstrumenter instrumenter;
 
 	private final IExceptionLogger logger;
 
@@ -59,7 +59,7 @@ public class CoverageTransformer implements ClassFileTransformer {
 	 */
 	public CoverageTransformer(final IRuntime runtime,
 			final AgentOptions options, final IExceptionLogger logger) {
-		this.instrumenter = new Instrumenter(runtime);
+		this.instrumenter = new NewInstrumenter(runtime);
 		this.logger = logger;
 		// Class names will be reported in VM notation:
 		includes = new WildcardMatcher(toVMName(options.getIncludes()));
@@ -90,7 +90,7 @@ public class CoverageTransformer implements ClassFileTransformer {
 
 		try {
 			classFileDumper.dump(classname, classfileBuffer);
-			return instrumenter.instrument(classfileBuffer, classname);
+			return instrumenter.instrument(loader, classfileBuffer, classname);
 		} catch (final Exception ex) {
 			final IllegalClassFormatException wrapper = new IllegalClassFormatException(
 					ex.getMessage());

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassInjector.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassInjector.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.ProtectionDomain;
+
+class ClassInjector {
+
+  private static final Method DEFINE_CLASS_METHOD;
+
+  private final ClassLoader classLoader;
+
+  static {
+    try {
+      DEFINE_CLASS_METHOD = ClassLoader.class.getDeclaredMethod("defineClass",
+        String.class,
+        byte[].class,
+        int.class,
+        int.class,
+        ProtectionDomain.class);
+      DEFINE_CLASS_METHOD.setAccessible(true);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public ClassInjector(ClassLoader classLoader) {
+    this.classLoader = classLoader;
+  }
+
+  public Class<?> inject(String name, byte[] binaryRepresentation) {
+    try {
+      synchronized (classLoader) {
+        return (Class<?>) DEFINE_CLASS_METHOD.invoke(
+          classLoader,
+          name,
+          binaryRepresentation,
+          0,
+          binaryRepresentation.length,
+          null
+        );
+      }
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    } catch (InvocationTargetException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/CompanionClass.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/CompanionClass.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+class CompanionClass {
+
+  private static final int FIELD_ACCESS = Opcodes.ACC_SYNTHETIC
+    | Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_TRANSIENT
+    | Opcodes.ACC_FINAL;
+
+  private final String className;
+  private final long classId;
+  private final int probeCount;
+
+  private final IExecutionDataAccessorGenerator accessorGenerator;
+
+  private final String companionClassName;
+
+  public CompanionClass(String className, long classId, int probeCount, IExecutionDataAccessorGenerator accessorGenerator) {
+    this.className = className;
+    this.classId = classId;
+    this.probeCount = probeCount;
+    this.accessorGenerator = accessorGenerator;
+
+    this.companionClassName = nameFor(className);
+  }
+
+  public void injectInto(ClassLoader classLoader) {
+    new ClassInjector(classLoader).inject(companionClassName.replace('/', '.'), generate());
+  }
+
+  private byte[] generate() {
+    final ClassWriter cv = new ClassWriter(0);
+    cv.visit(
+      Opcodes.V1_5, Opcodes.ACC_SYNTHETIC, companionClassName, null,
+      Type.getInternalName(Object.class),
+      new String[]{}
+    );
+
+    cv.visitField(FIELD_ACCESS, InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC, null, null);
+
+    GeneratorAdapter mv =  new GeneratorAdapter(
+      cv.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, new String[0]),
+      Opcodes.ACC_STATIC, "<clinit>", "()V");
+    final int size = accessorGenerator.generateDataAccessor(classId, className, probeCount, mv);
+    mv.visitFieldInsn(Opcodes.PUTSTATIC, companionClassName, InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC);
+    mv.returnValue();
+    mv.visitMaxs(size, 0);
+    mv.visitEnd();
+
+    cv.visitEnd();
+
+    return cv.toByteArray();
+  }
+
+  public static String nameFor(String className) {
+    return className + "$jacoco";
+  }
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/CompanionClassProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/CompanionClassProbeArrayStrategy.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+class CompanionClassProbeArrayStrategy implements IProbeArrayStrategy {
+  private final String className;
+
+  public CompanionClassProbeArrayStrategy(String className) {
+    this.className = className;
+  }
+
+  public int storeInstance(MethodVisitor mv, int variable) {
+    mv.visitFieldInsn(Opcodes.GETSTATIC, CompanionClass.nameFor(className), InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC);
+    mv.visitVarInsn(Opcodes.ASTORE, variable);
+    return 1;
+  }
+
+  public void addMembers(ClassVisitor cv, int probeCount) {
+    // nothing to do
+  }
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/NewInstrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/NewInstrumenter.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2015 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.data.CRC64;
+import org.jacoco.core.internal.flow.ClassProbesAdapter;
+import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import java.io.IOException;
+
+public class NewInstrumenter {
+
+  private final IExecutionDataAccessorGenerator accessorGenerator;
+  private final Instrumenter instrumenter;
+
+  public NewInstrumenter(IExecutionDataAccessorGenerator accessorGenerator) {
+    this.accessorGenerator = accessorGenerator;
+    this.instrumenter = new Instrumenter(accessorGenerator);
+  }
+
+  public byte[] instrument(final ClassLoader classLoader, final byte[] buffer, final String className) throws IOException {
+    if (classLoader == null) {
+      // Bootstrap ClassLoader - fallback to old instrumenter
+      return instrumenter.instrument(buffer, className);
+    }
+
+    try {
+      final ClassReader reader = new ClassReader(buffer);
+      final long classId = CRC64.checksum(reader.b);
+
+      final ProbeCounter counter = getProbeCounter(reader);
+      if (counter.getCount() == 0) {
+        return instrument(reader, new NoneProbeArrayStrategy());
+      }
+
+      new CompanionClass(className, classId, counter.getCount(), accessorGenerator).injectInto(classLoader);
+
+      return instrument(reader, new CompanionClassProbeArrayStrategy(className));
+
+    } catch (final RuntimeException e) {
+      throw instrumentError(className, e);
+    }
+  }
+
+  private IOException instrumentError(final String name, final RuntimeException cause) {
+    final IOException ex = new IOException(String.format("Error while instrumenting class %s.", name));
+    ex.initCause(cause);
+    return ex;
+  }
+
+  private byte[] instrument(final ClassReader reader, IProbeArrayStrategy strategy) {
+    final ClassWriter writer = new ClassWriter(reader, 0);
+    final ClassVisitor visitor = new ClassProbesAdapter(new ClassInstrumenter(strategy, writer), true);
+    reader.accept(visitor, ClassReader.EXPAND_FRAMES);
+    return writer.toByteArray();
+  }
+
+  private static ProbeCounter getProbeCounter(final ClassReader reader) {
+    final ProbeCounter counter = new ProbeCounter();
+    reader.accept(new ClassProbesAdapter(counter, false), 0);
+    return counter;
+  }
+
+}


### PR DESCRIPTION
Instead of remembering the probe array in a new member and delegating
the runtime access to a new method the runtime access is done via
companion class, which contains static field with probe array and which
is generated for every instrumented class and injected into their
ClassLoader, except classes from Bootstrap ClassLoader, for which
previous strategy is used.