### PR TITLE
This commit is for showing instruction coverage report on maven log

### DIFF
--- a/jacoco-maven-plugin.test/it/it-test-show-coverage/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-test-show-coverage/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+   All rights reserved. This program and the accompanying materials
+   are made available under the terms of the Eclipse Public License v1.0
+   which accompanies this distribution, and is available at
+   http://www.eclipse.org/legal/epl-v10.html
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-prepend-property-skip</artifactId>
+
+  <properties>
+    <argLine>-Dfoo</argLine>
+    <showCoverageOnLog>true</showCoverageOnLog>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-test-show-coverage/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-test-show-coverage/src/test/java/ExampleTest.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ExampleTest {
+  @Test
+  public void test() {
+  }
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -91,6 +91,18 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 	@Component
 	Renderer siteRenderer;
 
+	/**
+	 * Total coverage will be prefixed with this text
+	 */
+    @Parameter(property = "coverageText")
+	String coverageText;
+
+	/**
+	 * If true total coverage will be printed to maven log, default false
+	 */
+	@Parameter(property = "showCoverageOnLog")
+	boolean showCoverageOnLog;
+
 	public String getDescription(final Locale locale) {
 		return getName(locale) + " Coverage Report.";
 	}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
@@ -71,7 +71,7 @@ public class ReportMojo extends AbstractReportMojo {
 	void createReport(final IReportGroupVisitor visitor,
 			final ReportSupport support) throws IOException {
 		support.processProject(visitor, title, getProject(), getIncludes(),
-				getExcludes(), sourceEncoding);
+				getExcludes(), sourceEncoding, coverageText, showCoverageOnLog);
 	}
 
 	@Override


### PR DESCRIPTION
It introduces two properties
1. showCoverageOnLog (Boolean) which indecates whether jacoco will print coverage on maven log or not, default is false
2. coverageText (String) Text along side which total code coverage will be shown, default value is "Total Code Coverage"

If showCoverageOnLog is true then jacoco will also print below values for Instruction coverage
- Covered count
- Missed Count
- Missed Covered Ratio
- Total count

To utilize this feature, user has to define property `showCoverageOnLog` set to `true` in order to enable JaCoCo to print coverage information on maven log and `coverageText` set to some informative text to show total coverage.