### PR TITLE
Use condy for probes array in Java 11+ class files

### DIFF
--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/InstrumentTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/InstrumentTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
  * Unit tests for {@link Instrument}.
@@ -138,16 +138,16 @@ public class InstrumentTest extends CommandTestBase {
 		final ClassReader reader = InstrSupport
 				.classReaderFor(InputStreams.readFully(in));
 		in.close();
-		final Set<String> fields = new HashSet<String>();
+		final Set<String> methods = new HashSet<String>();
 		reader.accept(new ClassVisitor(InstrSupport.ASM_API_VERSION) {
 			@Override
-			public FieldVisitor visitField(int access, String name, String desc,
-					String signature, Object value) {
-				fields.add(name);
+			public MethodVisitor visitMethod(int access, String name,
+					String descriptor, String signature, String[] exceptions) {
+				methods.add(name);
 				return null;
 			}
 		}, 0);
-		assertTrue(fields.contains("$jacocoData"));
+		assertTrue(methods.contains("$jacocoInit"));
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/ClassFileVersionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/ClassFileVersionsTest.java
@@ -12,6 +12,7 @@
 package org.jacoco.core.instr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_SUPER;
 import static org.objectweb.asm.Opcodes.ALOAD;
@@ -150,8 +151,9 @@ public class ClassFileVersionsTest {
 							public void visitEnd() {
 								if (CondyProbeArrayStrategy.B_DESC
 										.equals(desc)) {
-									assertEquals(Boolean.FALSE,
-											Boolean.valueOf(frames));
+									assertFalse(
+											"CondyProbeArrayStrategy does not need frames",
+											frames);
 								} else {
 									assertEquals(Boolean.valueOf(expected),
 											Boolean.valueOf(frames));

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/ClassFileVersionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/ClassFileVersionsTest.java
@@ -37,6 +37,7 @@ import static org.objectweb.asm.Opcodes.V9;
 
 import java.io.IOException;
 
+import org.jacoco.core.internal.instr.CondyProbeArrayStrategy;
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.SystemPropertiesRuntime;
@@ -133,7 +134,7 @@ public class ClassFileVersionsTest {
 
 					@Override
 					public MethodVisitor visitMethod(int access, String name,
-							String desc, String signature,
+							final String desc, String signature,
 							String[] exceptions) {
 						return new MethodVisitor(InstrSupport.ASM_API_VERSION) {
 							boolean frames = false;
@@ -147,8 +148,14 @@ public class ClassFileVersionsTest {
 
 							@Override
 							public void visitEnd() {
-								assertEquals(Boolean.valueOf(expected),
-										Boolean.valueOf(frames));
+								if (CondyProbeArrayStrategy.B_DESC
+										.equals(desc)) {
+									assertEquals(Boolean.FALSE,
+											Boolean.valueOf(frames));
+								} else {
+									assertEquals(Boolean.valueOf(expected),
+											Boolean.valueOf(frames));
+								}
 							}
 						};
 					}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import org.junit.Test;
+import org.objectweb.asm.tree.ClassNode;
+
+import static org.junit.Assert.assertEquals;
+
+public class CondyProbeArrayStrategyTest {
+
+	private final CondyProbeArrayStrategy strategy = new CondyProbeArrayStrategy();
+
+	@Test
+	public void should_not_add_fields() {
+		final ClassNode c = new ClassNode();
+		strategy.addMembers(c, 1);
+
+		assertEquals(0, c.fields.size());
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
@@ -28,7 +28,7 @@ import org.objectweb.asm.tree.VarInsnNode;
 public class CondyProbeArrayStrategyTest {
 
 	private final CondyProbeArrayStrategy strategy = new CondyProbeArrayStrategy(
-			"ClassName", 1L, new OfflineInstrumentationAccessGenerator());
+			"ClassName", true, 1L, new OfflineInstrumentationAccessGenerator());
 
 	@Test
 	public void should_store_instance_using_condy_and_checkcast() {
@@ -49,7 +49,7 @@ public class CondyProbeArrayStrategyTest {
 		assertEquals("ClassName", bootstrapMethod.getOwner());
 		assertEquals("$jacocoInit", bootstrapMethod.getName());
 		assertEquals(
-				"(Ljava/lang/invoke/MethodHandle$Lookup;Ljava/lang/String;Ljava/lang/Class;)[Z",
+				"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)[Z",
 				bootstrapMethod.getDesc());
 		assertTrue(bootstrapMethod.isInterface());
 
@@ -86,7 +86,7 @@ public class CondyProbeArrayStrategyTest {
 				| Opcodes.ACC_STATIC, m.access);
 		assertEquals("$jacocoInit", m.name);
 		assertEquals(
-				"(Ljava/lang/invoke/MethodHandle$Lookup;Ljava/lang/String;Ljava/lang/Class;)[Z",
+				"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)[Z",
 				m.desc);
 
 		assertEquals(4, m.maxStack);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
@@ -12,7 +12,9 @@
 package org.jacoco.core.internal.instr;
 
 import org.junit.Test;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
 
 import static org.junit.Assert.assertEquals;
 
@@ -26,6 +28,25 @@ public class CondyProbeArrayStrategyTest {
 		strategy.addMembers(c, 1);
 
 		assertEquals(0, c.fields.size());
+	}
+
+	@Test
+	public void should_add_bootstrap_method() {
+		final ClassNode c = new ClassNode();
+		strategy.addMembers(c, 1);
+
+		assertEquals(1, c.methods.size());
+
+		final MethodNode m = c.methods.get(0);
+		assertEquals(Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PRIVATE
+				| Opcodes.ACC_STATIC, m.access);
+		assertEquals("$jacocoInit", m.name);
+		assertEquals(
+				"(Ljava/lang/invoke/MethodHandle$Lookup;Ljava/lang/String;Ljava/lang/Class;)[Z",
+				m.desc);
+
+		assertEquals(4, m.maxStack);
+		assertEquals(3, m.maxLocals);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
+import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.asm.ConstantDynamic;
 import org.objectweb.asm.Handle;
@@ -27,8 +28,13 @@ import org.objectweb.asm.tree.VarInsnNode;
 
 public class CondyProbeArrayStrategyTest {
 
-	private final CondyProbeArrayStrategy strategy = new CondyProbeArrayStrategy(
-			"ClassName", true, 1L, new OfflineInstrumentationAccessGenerator());
+	private CondyProbeArrayStrategy strategy;
+
+	@Before
+	public void setup() {
+		strategy = new CondyProbeArrayStrategy("ClassName", true, 1L,
+				new OfflineInstrumentationAccessGenerator());
+	}
 
 	@Test
 	public void should_store_instance_using_condy_and_checkcast() {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
@@ -14,13 +14,15 @@ package org.jacoco.core.internal.instr;
 import org.junit.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
+import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 import org.objectweb.asm.tree.MethodNode;
 
 import static org.junit.Assert.assertEquals;
 
 public class CondyProbeArrayStrategyTest {
 
-	private final CondyProbeArrayStrategy strategy = new CondyProbeArrayStrategy();
+	private final CondyProbeArrayStrategy strategy = new CondyProbeArrayStrategy(
+			"ClassName", 1L, new OfflineInstrumentationAccessGenerator());
 
 	@Test
 	public void should_not_add_fields() {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategyTest.java
@@ -40,8 +40,6 @@ public class CondyProbeArrayStrategyTest {
 		final ConstantDynamic constantDynamic = (ConstantDynamic) ((LdcInsnNode) m.instructions
 				.get(0)).cst;
 		assertEquals("$jacocoData", constantDynamic.getName());
-		// as a workaround for https://bugs.openjdk.java.net/browse/JDK-8216970
-		// constant should have type Object
 		assertEquals("Ljava/lang/Object;", constantDynamic.getDescriptor());
 
 		final Handle bootstrapMethod = constantDynamic.getBootstrapMethod();

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -228,13 +228,23 @@ public class ProbeArrayStrategyFactoryTest {
 	}
 
 	@Test
-	public void test_java11_interface_with_code() {
+	public void test_java11_interface_with_clinit_and_methods() {
 		final IProbeArrayStrategy strategy = test(Opcodes.V11,
 				Opcodes.ACC_INTERFACE, true, true, true);
 
 		assertEquals(CondyProbeArrayStrategy.class, strategy.getClass());
 		assertNoDataField();
 		assertCondyBootstrapMethod();
+	}
+
+	@Test
+	public void test_java11_interface_with_clinit() {
+		final IProbeArrayStrategy strategy = test(Opcodes.V11,
+				Opcodes.ACC_INTERFACE, true, false, true);
+
+		assertEquals(LocalProbeArrayStrategy.class, strategy.getClass());
+		assertNoDataField();
+		assertNoInitMethod();
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -224,6 +224,20 @@ public class ProbeArrayStrategyFactoryTest {
 		assertEquals(NoneProbeArrayStrategy.class, strategy.getClass());
 	}
 
+	@Test
+	public void should_not_add_field_into_java11_classes() {
+		test(Opcodes.V11, 0, true, true, true);
+
+		assertNoDataField();
+	}
+
+	@Test
+	public void should_not_add_field_into_java11_interfaces() {
+		test(Opcodes.V11, Opcodes.ACC_INTERFACE, true, true, true);
+
+		assertNoDataField();
+	}
+
 	private IProbeArrayStrategy test(int version, int access, boolean clinit,
 			boolean method, boolean abstractMethod) {
 		final ClassWriter writer = new ClassWriter(0);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -212,20 +212,13 @@ public class ProbeArrayStrategyFactoryTest {
 	}
 
 	@Test
-	public void testModule() {
-		final ClassWriter writer = new ClassWriter(0);
-		writer.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null,
-				null);
-		writer.visitModule("module", 0, null).visitEnd();
-		writer.visitEnd();
-
-		final IProbeArrayStrategy strategy = ProbeArrayStrategyFactory
-				.createFor(0, new ClassReader(writer.toByteArray()), generator);
+	public void test_java9_module() {
+		final IProbeArrayStrategy strategy = createForModule(Opcodes.V9);
 		assertEquals(NoneProbeArrayStrategy.class, strategy.getClass());
 	}
 
 	@Test
-	public void should_not_add_field_into_java11_classes() {
+	public void test_java11_class() {
 		final IProbeArrayStrategy strategy = test(Opcodes.V11, 0, true, true,
 				true);
 
@@ -235,13 +228,39 @@ public class ProbeArrayStrategyFactoryTest {
 	}
 
 	@Test
-	public void should_not_add_field_into_java11_interfaces() {
+	public void test_java11_interface_with_code() {
 		final IProbeArrayStrategy strategy = test(Opcodes.V11,
 				Opcodes.ACC_INTERFACE, true, true, true);
 
 		assertEquals(CondyProbeArrayStrategy.class, strategy.getClass());
 		assertNoDataField();
 		assertCondyBootstrapMethod();
+	}
+
+	@Test
+	public void test_java11_interface_without_code() {
+		final IProbeArrayStrategy strategy = test(Opcodes.V11,
+				Opcodes.ACC_INTERFACE, false, false, true);
+
+		assertEquals(NoneProbeArrayStrategy.class, strategy.getClass());
+		assertNoDataField();
+		assertNoInitMethod();
+	}
+
+	@Test
+	public void test_java11_module() {
+		final IProbeArrayStrategy strategy = createForModule(Opcodes.V11);
+		assertEquals(NoneProbeArrayStrategy.class, strategy.getClass());
+	}
+
+	private IProbeArrayStrategy createForModule(int version) {
+		final ClassWriter writer = new ClassWriter(0);
+		writer.visit(version, Opcodes.ACC_MODULE, "module-info", null, null,
+				null);
+		writer.visitModule("module", 0, null).visitEnd();
+		writer.visitEnd();
+		return ProbeArrayStrategyFactory.createFor(0,
+				new ClassReader(writer.toByteArray()), generator);
 	}
 
 	private IProbeArrayStrategy test(int version, int access, boolean clinit,

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -229,6 +229,7 @@ public class ProbeArrayStrategyFactoryTest {
 		test(Opcodes.V11, 0, true, true, true);
 
 		assertNoDataField();
+		assertCondyBootstrapMethod();
 	}
 
 	@Test
@@ -236,6 +237,7 @@ public class ProbeArrayStrategyFactoryTest {
 		test(Opcodes.V11, Opcodes.ACC_INTERFACE, true, true, true);
 
 		assertNoDataField();
+		assertCondyBootstrapMethod();
 	}
 
 	private IProbeArrayStrategy test(int version, int access, boolean clinit,
@@ -286,9 +288,9 @@ public class ProbeArrayStrategyFactoryTest {
 			this.desc = desc;
 		}
 
-		void assertInitMethod(boolean frames) {
+		void assertInitMethod(String expectedDesc, boolean frames) {
 			assertEquals(InstrSupport.INITMETHOD_NAME, name);
-			assertEquals(InstrSupport.INITMETHOD_DESC, desc);
+			assertEquals(expectedDesc, desc);
 			assertEquals(InstrSupport.INITMETHOD_ACC, access);
 			assertEquals(Boolean.valueOf(frames), Boolean.valueOf(frames));
 		}
@@ -387,12 +389,19 @@ public class ProbeArrayStrategyFactoryTest {
 
 	void assertInitMethod(boolean frames) {
 		assertEquals(cv.methods.size(), 1);
-		cv.methods.get(0).assertInitMethod(frames);
+		cv.methods.get(0).assertInitMethod(InstrSupport.INITMETHOD_DESC,
+				frames);
+	}
+
+	void assertCondyBootstrapMethod() {
+		assertEquals(cv.methods.size(), 1);
+		cv.methods.get(0).assertInitMethod(CondyProbeArrayStrategy.B_DESC,
+				false);
 	}
 
 	void assertInitAndClinitMethods() {
 		assertEquals(2, cv.methods.size());
-		cv.methods.get(0).assertInitMethod(true);
+		cv.methods.get(0).assertInitMethod(InstrSupport.INITMETHOD_DESC, true);
 		cv.methods.get(1).assertClinit();
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -226,16 +226,20 @@ public class ProbeArrayStrategyFactoryTest {
 
 	@Test
 	public void should_not_add_field_into_java11_classes() {
-		test(Opcodes.V11, 0, true, true, true);
+		final IProbeArrayStrategy strategy = test(Opcodes.V11, 0, true, true,
+				true);
 
+		assertEquals(CondyProbeArrayStrategy.class, strategy.getClass());
 		assertNoDataField();
 		assertCondyBootstrapMethod();
 	}
 
 	@Test
 	public void should_not_add_field_into_java11_interfaces() {
-		test(Opcodes.V11, Opcodes.ACC_INTERFACE, true, true, true);
+		final IProbeArrayStrategy strategy = test(Opcodes.V11,
+				Opcodes.ACC_INTERFACE, true, true, true);
 
+		assertEquals(CondyProbeArrayStrategy.class, strategy.getClass());
 		assertNoDataField();
 		assertCondyBootstrapMethod();
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
@@ -22,6 +22,11 @@ import org.objectweb.asm.MethodVisitor;
  */
 class CondyProbeArrayStrategy implements IProbeArrayStrategy {
 
+	/**
+	 * Descriptor of the bootstrap method.
+	 */
+	static final String B_DESC = "(Ljava/lang/invoke/MethodHandle$Lookup;Ljava/lang/String;Ljava/lang/Class;)[Z";
+
 	public int storeInstance(final MethodVisitor mv, final boolean clinit,
 			final int variable) {
 		return 0;

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
@@ -51,6 +51,8 @@ public class CondyProbeArrayStrategy implements IProbeArrayStrategy {
 			final int variable) {
 		final Handle bootstrapMethod = new Handle(Opcodes.H_INVOKESTATIC,
 				className, InstrSupport.INITMETHOD_NAME, B_DESC, isInterface);
+		// As a workaround for https://bugs.openjdk.java.net/browse/JDK-8216970
+		// constant should have type Object
 		mv.visitLdcInsn(new ConstantDynamic(InstrSupport.DATAFIELD_NAME,
 				"Ljava/lang/Object;", bootstrapMethod));
 		mv.visitTypeInsn(Opcodes.CHECKCAST, "[Z");

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ConstantDynamic;
+import org.objectweb.asm.MethodVisitor;
+
+/**
+ * This strategy for Java 11+ class files uses {@link ConstantDynamic} to hold
+ * the probe array and adds bootstrap method requesting the probe array from the
+ * runtime.
+ */
+class CondyProbeArrayStrategy implements IProbeArrayStrategy {
+
+	public int storeInstance(final MethodVisitor mv, final boolean clinit,
+			final int variable) {
+		return 0;
+	}
+
+	public void addMembers(final ClassVisitor cv, final int probeCount) {
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -50,7 +50,7 @@ public final class ProbeArrayStrategyFactory {
 			if (counter.getCount() == 0) {
 				return new NoneProbeArrayStrategy();
 			}
-			if (version >= Opcodes.V11) {
+			if (version >= Opcodes.V11 && counter.hasMethods()) {
 				return new CondyProbeArrayStrategy(className, true, classId,
 						accessorGenerator);
 			}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -45,14 +45,14 @@ public final class ProbeArrayStrategyFactory {
 		final String className = reader.getClassName();
 		final int version = InstrSupport.getVersionMajor(reader.b);
 
-		if (version >= Opcodes.V11) {
-			return new CondyProbeArrayStrategy(className, classId,
-					accessorGenerator);
-		}
 		if (isInterfaceOrModule(reader)) {
 			final ProbeCounter counter = getProbeCounter(reader);
 			if (counter.getCount() == 0) {
 				return new NoneProbeArrayStrategy();
+			}
+			if (version >= Opcodes.V11) {
+				return new CondyProbeArrayStrategy(className, classId,
+						accessorGenerator);
 			}
 			if (version >= Opcodes.V1_8 && counter.hasMethods()) {
 				return new InterfaceFieldProbeArrayStrategy(className, classId,
@@ -62,6 +62,10 @@ public final class ProbeArrayStrategyFactory {
 						counter.getCount(), accessorGenerator);
 			}
 		} else {
+			if (version >= Opcodes.V11) {
+				return new CondyProbeArrayStrategy(className, classId,
+						accessorGenerator);
+			}
 			return new ClassFieldProbeArrayStrategy(className, classId,
 					InstrSupport.needsFrames(version), accessorGenerator);
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -46,7 +46,8 @@ public final class ProbeArrayStrategyFactory {
 		final int version = InstrSupport.getVersionMajor(reader.b);
 
 		if (version >= Opcodes.V11) {
-			return new CondyProbeArrayStrategy();
+			return new CondyProbeArrayStrategy(className, classId,
+					accessorGenerator);
 		}
 		if (isInterfaceOrModule(reader)) {
 			final ProbeCounter counter = getProbeCounter(reader);

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -51,7 +51,7 @@ public final class ProbeArrayStrategyFactory {
 				return new NoneProbeArrayStrategy();
 			}
 			if (version >= Opcodes.V11) {
-				return new CondyProbeArrayStrategy(className, classId,
+				return new CondyProbeArrayStrategy(className, true, classId,
 						accessorGenerator);
 			}
 			if (version >= Opcodes.V1_8 && counter.hasMethods()) {
@@ -63,7 +63,7 @@ public final class ProbeArrayStrategyFactory {
 			}
 		} else {
 			if (version >= Opcodes.V11) {
-				return new CondyProbeArrayStrategy(className, classId,
+				return new CondyProbeArrayStrategy(className, false, classId,
 						accessorGenerator);
 			}
 			return new ClassFieldProbeArrayStrategy(className, classId,

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactory.java
@@ -45,6 +45,9 @@ public final class ProbeArrayStrategyFactory {
 		final String className = reader.getClassName();
 		final int version = InstrSupport.getVersionMajor(reader.b);
 
+		if (version >= Opcodes.V11) {
+			return new CondyProbeArrayStrategy();
+		}
 		if (isInterfaceOrModule(reader)) {
 			final ProbeCounter counter = getProbeCounter(reader);
 			if (counter.getCount() == 0) {

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,13 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>New Features</h3>
+<ul>
+  <li>Instrumentation does not add synthetic field to Java 11+ class files,
+      however still adds synthetic method
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/845">#845</a>).</li>
+</ul>
+
 <h2>Release 0.8.3 (2019/01/23)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
Users often forget to ignore **synthetic** fields when using reflection and continue asking questions even if this is already described in [our FAQ](https://github.com/jacoco/jacoco/blob/v0.8.3/org.jacoco.doc/docroot/doc/faq.html#L130-L141) - here is some recent ones:

* #834
* #816
* #799
* https://groups.google.com/d/msg/jacoco/3wT1WmrRPBA/A9MPMa6tHAAJ

We can get rid of this field in Java 11+ class files by using condy ([JEP 309](https://openjdk.java.net/jeps/309)).

Also I think that condy might be better in terms of performance than `ClassFieldProbeArrayStrategy` in following cases

* cold non JITed code and I suppose that this is quite common case when running unit tests
* when JIT fails to inline `$jacocoInit`
