### PR TITLE
Ability to use service loader (spi) to load a list of additional filters

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -141,7 +141,7 @@
     <asm.version>7.0</asm.version>
     <ant.version>1.7.1</ant.version>
     <args4j.version>2.0.28</args4j.version>
-    <junit.version>4.8.2</junit.version>
+    <junit.version>4.12</junit.version>
 
     <!-- ================== -->
     <!-- For SonarQube analysis -->

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
@@ -183,9 +183,9 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 		filter.filter(m, context, output);
 	}
 
-	@Test
+	@Test(expected = ServiceConfigurationError.class)
 	public void should_fail_on_unassignable_class() throws Exception {
-		// classes loaded by ServiceLoader which cannot be assigned to
+		// classes loaded by ServiceLoader which cannot be assigned to a
 		// service-class are just ignored instead of throwing an exception
 		// since java 9, so skip this test in that case
 		Assume.assumeTrue(isJavaVersionLessThan9());
@@ -196,14 +196,7 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 				"foo", "()V", null, null);
 		m.visitInsn(Opcodes.NOP);
 
-		// expected exceptions do not work with the assumptions, so test them
-		// the old way
-		try {
-			filter.filter(m, context, output);
-			Assert.fail("Filter should not be called successfully");
-		} catch (ServiceConfigurationError e) {
-			// ignore
-		}
+		filter.filter(m, context, output);
 	}
 
 	@Test(expected = ServiceConfigurationError.class)

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
@@ -1,0 +1,301 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sergey Zhemzhitsky - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ServiceConfigurationError;
+
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.MethodNode;
+
+public class ServiceLoaderFilterTest extends FilterTestBase {
+
+	private File metaInf;
+	private File services;
+	private File filters;
+
+	private boolean metaInfCreated;
+	private boolean servicesCreated;
+
+	private ServiceLoaderFilter filter;
+
+	@Before
+	public void setUp() throws Exception {
+		final File cpRoot = new File(getClass().getResource("/").toURI());
+
+		metaInf = new File(cpRoot, "META-INF");
+		metaInfCreated = metaInf.mkdir();
+
+		services = new File(metaInf, "services");
+		servicesCreated = services.mkdirs();
+
+		filters = new File(services, IFilter.class.getName());
+
+		ServiceLoaderFilter1.invoked = false;
+		ServiceLoaderFilter2.invoked = false;
+
+		filter = new ServiceLoaderFilter();
+	}
+
+	@After
+	public void tearDown() {
+		if (filters.exists()) {
+			Assert.assertTrue(filters.delete());
+		}
+		if (servicesCreated) {
+			Assert.assertTrue(services.delete());
+		}
+		if (metaInfCreated) {
+			Assert.assertTrue(metaInf.delete());
+		}
+		filter.reset();
+	}
+
+	@Test
+	public void should_load_filters_by_service_loader() throws Exception {
+		writeServiceLines(ServiceLoaderFilter1.class.getName(),
+				ServiceLoaderFilter2.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertTrue(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertTrue(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_not_fail_when_no_service_file_found() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_not_fail_on_empty_service_file() throws Exception {
+		writeServiceLines("\n");
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_handle_comments_at_start() throws Exception {
+		writeServiceLines("# " + ServiceLoaderFilter1.class.getName(),
+				"# " + ServiceLoaderFilter2.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_handle_comments_at_eol() throws Exception {
+		writeServiceLines(ServiceLoaderFilter1.class.getName() + " # comment",
+				ServiceLoaderFilter2.class.getName() + " # comment");
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertTrue(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertTrue(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test(expected = ServiceConfigurationError.class)
+	public void should_fail_on_invalid_first_char_in_name() throws Exception {
+		writeServiceLines("1" + ServiceLoaderFilter1.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = ServiceConfigurationError.class)
+	public void should_fail_on_invalid_char_in_name() throws Exception {
+		writeServiceLines(
+				ServiceLoaderFilter1.class.getName().replace('.', ','));
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = ServiceConfigurationError.class)
+	public void should_fail_on_class_not_found() throws Exception {
+		writeServiceLines(
+				ServiceLoaderFilter1.class.getName().replace('1', '0'));
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = ServiceConfigurationError.class)
+	public void should_fail_on_unassignable_class() throws Exception {
+		writeServiceLines(String.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = ServiceConfigurationError.class)
+	public void should_fail_on_no_default_constructor() throws Exception {
+		writeServiceLines(ServiceLoaderFilter4.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test
+	public void should_not_find_services_when_no_file_and_resetting()
+			throws Exception {
+		writeServiceLines(true, ServiceLoaderFilter1.class.getName(),
+				ServiceLoaderFilter2.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertTrue(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertTrue(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter2.invoked);
+
+		// reset services and theirs loader state
+		ServiceLoaderFilter1.invoked = false;
+		ServiceLoaderFilter2.invoked = false;
+
+		writeServiceLines(false, "\n");
+		filter.reset();
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	private void writeServiceLines(final boolean append, final String... lines)
+			throws Exception {
+		filters = new File(services, IFilter.class.getName());
+		final FileOutputStream os = new FileOutputStream(filters, append);
+		try {
+			for (final String line : lines) {
+				os.write(line.getBytes("UTF-8"));
+				os.write('\n');
+			}
+		} finally {
+			os.close();
+		}
+	}
+
+	private void writeServiceLines(final String... lines)
+			throws Exception {
+		writeServiceLines(true, lines);
+	}
+
+	public static class ServiceLoaderFilter1 implements IFilter {
+		private static boolean invoked;
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+	public static class ServiceLoaderFilter2 implements IFilter {
+		private static boolean invoked;
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+	public static class ServiceLoaderFilter3 implements IFilter {
+		@SuppressWarnings("unused")
+		private static boolean invoked;
+		private ServiceLoaderFilter3() {
+		}
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+	public static class ServiceLoaderFilter4 implements IFilter {
+		@SuppressWarnings("unused")
+		private static boolean invoked;
+		public ServiceLoaderFilter4(
+				@SuppressWarnings("unused") String ignored) {
+		}
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
@@ -187,7 +187,7 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 	public void should_fail_on_unassignable_class() throws Exception {
 		// since java 9 incompatible classes loaded by ServiceLoader
 		// are just ignored, so skip this test in that case
-		Assume.assumeTrue(getJavaMajorVersion() < 9);
+		Assume.assumeTrue(isJavaVersionLessThan9());
 
 		writeServiceLines(String.class.getName());
 
@@ -267,10 +267,13 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 		writeServiceLines(true, lines);
 	}
 
-	private int getJavaMajorVersion() {
-		final String javaVersion = System.getProperty("java.version");
-		return Integer.parseInt(
-				javaVersion.substring(0, javaVersion.indexOf('.')));
+	private static boolean isJavaVersionLessThan9() {
+		try {
+			Runtime.class.getMethod("version");
+			return false;
+		} catch (NoSuchMethodException e) {
+			return true;
+		}
 	}
 
 	public static class ServiceLoaderFilter1 implements IFilter {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
@@ -185,8 +185,9 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_fail_on_unassignable_class() throws Exception {
-		// since java 9 incompatible classes loaded by ServiceLoader
-		// are just ignored, so skip this test in that case
+		// classes loaded by ServiceLoader which cannot be assigned to
+		// service-class are just ignored instead of throwing an exception
+		// since java 9, so skip this test in that case
 		Assume.assumeTrue(isJavaVersionLessThan9());
 
 		writeServiceLines(String.class.getName());

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
@@ -44,7 +44,7 @@ public final class Filters implements IFilter {
 				new KotlinUnsafeCastOperatorFilter(),
 				new KotlinNotNullOperatorFilter(),
 				new KotlinDefaultArgumentsFilter(), new KotlinInlineFilter(),
-				new KotlinCoroutineFilter());
+				new KotlinCoroutineFilter(), new ServiceLoaderFilter());
 	}
 
 	private Filters(final IFilter... filters) {

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilter.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sergey Zhemzhitsky - initial API and implementation
+ *
+ *******************************************************************************/
+
+package org.jacoco.core.internal.analysis.filter;
+
+import java.util.ServiceLoader;
+
+import org.objectweb.asm.tree.MethodNode;
+
+/**
+ * Loads additional filters by means of {@link ServiceLoader}.
+ * For the additional filters to be found they should be accessible by the same
+ * {@code ClassLoader} that loads this class.
+ */
+public class ServiceLoaderFilter implements IFilter {
+
+	private final ServiceLoader<IFilter> filters =
+			ServiceLoader.load(IFilter.class, getClass().getClassLoader());
+
+	public void filter(final MethodNode methodNode,
+			final IFilterContext context, final IFilterOutput output) {
+		for (final IFilter filter : filters) {
+			filter.filter(methodNode, context, output);
+		}
+	}
+
+	// for test purposes only
+	void reset() {
+		filters.reload();
+	}
+
+}


### PR DESCRIPTION
This pull requests proposes to add an ability to load additional filters by means of java's SPI mechanism aka ServiceLoaders to easily extend a list of available filters by just dropping a jar into the plugin's classpath.

It could help to increase the amount of contributors to the jacoco's filters in case of (and even if) jacoco maintainers are not experts in the particular technology or library. Later on after the careful review the corresponding external filters can be included into the main distribution.

Candidates of externally available filters:
- [scala ones](https://groups.google.com/forum/#!topic/jacoco/npl9SUL8_WA)
- [aspectj ones ](https://github.com/jacoco/jacoco/pull/710)

Even jacoco itself can be considered to be a subject of using SPI mechanism to load its own filters (e.g. to improve its own modularity).

To include additional external filters into a build classpath it will be necessary to declare a jacoco dependency line the following:

**Maven**
```xml
<plugin>
  <groupId>org.jacoco</groupId>
  <artifactId>jacoco-maven-plugin</artifactId>
  <version>${project.version}</version>
  <dependencies>
    <dependency>
      <groupId>foo.bar.filters</groupId>
      <artifactId>external-filters</artifactId>
      <version>${external-filters.version}</version>
    </dependency>
  </dependencies>
</plugin>
```
**Gradle**
```groovy
dependencies {
  jacocoAnt [
    "org.jacoco:org.jacoco.core:${versions.jacoco}",
    "org.jacoco:org.jacoco.ant:${versions.jacoco}",
    "org.jacoco:org.jacoco.report:${versions.jacoco}",
    "foo.bar.filters:external-filters:${external-filters.version}"
  ]
}
```