### PR TITLE
Ability to use service loader (spi) to load a list of additional filters using java5-way

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
@@ -1,0 +1,259 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sergey Zhemzhitsky - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.MethodNode;
+
+public class ServiceLoaderFilterTest extends FilterTestBase {
+
+	private File metaInf;
+	private File services;
+	private File filters;
+
+	private boolean metaInfCreated;
+	private boolean servicesCreated;
+
+	final ServiceLoaderFilter filter = new ServiceLoaderFilter();
+
+	@Before
+	public void setUp() throws Exception {
+		final File cpRoot = new File(getClass().getResource("/").toURI());
+
+		metaInf = new File(cpRoot, "META-INF");
+		metaInfCreated = metaInf.mkdir();
+
+		services = new File(metaInf, "services");
+		servicesCreated = services.mkdirs();
+
+		filters = new File(services, IFilter.class.getName());
+
+		ServiceLoaderFilter1.invoked = false;
+		ServiceLoaderFilter2.invoked = false;
+	}
+
+	@After
+	public void tearDown() {
+		if (filters.exists()) {
+			Assert.assertTrue(filters.delete());
+		}
+		if (servicesCreated) {
+			Assert.assertTrue(services.delete());
+		}
+		if (metaInfCreated) {
+			Assert.assertTrue(metaInf.delete());
+		}
+	}
+
+	@Test
+	public void should_load_filters_by_service_loader() throws Exception {
+		writeServiceLines(ServiceLoaderFilter1.class.getName(),
+				ServiceLoaderFilter2.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertTrue(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertTrue(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_not_fail_when_no_service_file_found() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_not_fail_on_empty_service_file() throws Exception {
+		writeServiceLines("\n");
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_handle_comments_at_start() throws Exception {
+		writeServiceLines("# " + ServiceLoaderFilter1.class.getName(),
+				"# " + ServiceLoaderFilter2.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertFalse(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertFalse(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should not be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test
+	public void should_handle_comments_at_eol() throws Exception {
+		writeServiceLines(ServiceLoaderFilter1.class.getName() + " # comment",
+				ServiceLoaderFilter2.class.getName() + " # comment");
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+
+		Assert.assertTrue(ServiceLoaderFilter1.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter1.invoked);
+		Assert.assertTrue(ServiceLoaderFilter2.class.getCanonicalName() +
+				" should be invoked", ServiceLoaderFilter2.invoked);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void should_fail_on_invalid_first_char_in_name() throws Exception {
+		writeServiceLines("1" + ServiceLoaderFilter1.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void should_fail_on_invalid_char_in_name() throws Exception {
+		writeServiceLines(
+				ServiceLoaderFilter1.class.getName().replace('.', ','));
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void should_fail_on_class_not_found() throws Exception {
+		writeServiceLines(
+				ServiceLoaderFilter1.class.getName().replace('1', '0'));
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void should_fail_on_unassignable_class() throws Exception {
+		writeServiceLines(String.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void should_fail_on_no_default_constructor() throws Exception {
+		writeServiceLines(ServiceLoaderFilter4.class.getName());
+
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"foo", "()V", null, null);
+		m.visitInsn(Opcodes.NOP);
+
+		filter.filter(m, context, output);
+	}
+
+	private void writeServiceLines(String... lines) throws Exception {
+		filters = new File(services, IFilter.class.getName());
+		final FileOutputStream os = new FileOutputStream(filters, true);
+		try {
+			for (final String line : lines) {
+				os.write(line.getBytes("UTF-8"));
+				os.write('\n');
+			}
+		} finally {
+			os.close();
+		}
+	}
+
+	public static class ServiceLoaderFilter1 implements IFilter {
+		private static boolean invoked;
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+	public static class ServiceLoaderFilter2 implements IFilter {
+		private static boolean invoked;
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+	public static class ServiceLoaderFilter3 implements IFilter {
+		@SuppressWarnings("unused")
+		private static boolean invoked;
+		private ServiceLoaderFilter3() {
+		}
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+	public static class ServiceLoaderFilter4 implements IFilter {
+		@SuppressWarnings("unused")
+		private static boolean invoked;
+		public ServiceLoaderFilter4(
+				@SuppressWarnings("unused") String ignored) {
+		}
+		@Override
+		public void filter(final MethodNode methodNode,
+				final IFilterContext context, final IFilterOutput output) {
+			invoked = true;
+		}
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilterTest.java
@@ -215,7 +215,6 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 
 	public static class ServiceLoaderFilter1 implements IFilter {
 		private static boolean invoked;
-		@Override
 		public void filter(final MethodNode methodNode,
 				final IFilterContext context, final IFilterOutput output) {
 			invoked = true;
@@ -224,7 +223,6 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 
 	public static class ServiceLoaderFilter2 implements IFilter {
 		private static boolean invoked;
-		@Override
 		public void filter(final MethodNode methodNode,
 				final IFilterContext context, final IFilterOutput output) {
 			invoked = true;
@@ -236,7 +234,6 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 		private static boolean invoked;
 		private ServiceLoaderFilter3() {
 		}
-		@Override
 		public void filter(final MethodNode methodNode,
 				final IFilterContext context, final IFilterOutput output) {
 			invoked = true;
@@ -249,7 +246,6 @@ public class ServiceLoaderFilterTest extends FilterTestBase {
 		public ServiceLoaderFilter4(
 				@SuppressWarnings("unused") String ignored) {
 		}
-		@Override
 		public void filter(final MethodNode methodNode,
 				final IFilterContext context, final IFilterOutput output) {
 			invoked = true;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
@@ -44,7 +44,7 @@ public final class Filters implements IFilter {
 				new KotlinUnsafeCastOperatorFilter(),
 				new KotlinNotNullOperatorFilter(),
 				new KotlinDefaultArgumentsFilter(), new KotlinInlineFilter(),
-				new KotlinCoroutineFilter());
+				new KotlinCoroutineFilter(), new ServiceLoaderFilter());
 	}
 
 	private Filters(final IFilter... filters) {

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/ServiceLoaderFilter.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sergey Zhemzhitsky - initial API and implementation
+ *
+ *******************************************************************************/
+
+package org.jacoco.core.internal.analysis.filter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.objectweb.asm.tree.MethodNode;
+
+/**
+ * Loads additional filters the same way {@code java.util.ServiceLoader}
+ * from Java 6 does, staying compatible with Java 5 API.
+ * For the additional filters to be found they should be accessible by the same
+ * {@code ClassLoader} that loads this class.
+ */
+public class ServiceLoaderFilter implements IFilter {
+
+	private static final String RESOURCE_NAME =
+			"META-INF/services/" + IFilter.class.getName();
+	private static final char COMMENT_CHAR = '#';
+
+	private final ClassLoader loader = getClass().getClassLoader();
+
+	public void filter(final MethodNode methodNode,
+			final IFilterContext context, final IFilterOutput output) {
+		final Enumeration<URL> resources = findResources(loader);
+		while (resources.hasMoreElements()) {
+			final URL resource = resources.nextElement();
+			final Collection<String> serviceClasses = readURL(resource);
+			for (final String serviceClass : serviceClasses) {
+				IFilter filter = loadService(serviceClass, loader);
+				filter.filter(methodNode, context, output);
+			}
+		}
+	}
+
+	private static Enumeration<URL> findResources(final ClassLoader loader) {
+		try {
+			return loader.getResources(RESOURCE_NAME);
+		} catch (IOException e) {
+			throw new IllegalStateException(
+					"Unable to get a list of resources: " + RESOURCE_NAME, e);
+		}
+	}
+
+	private static Collection<String> readURL(final URL url) {
+		Set<String> lines = new LinkedHashSet<String>();
+
+		Exception failReason = null;
+		BufferedReader reader = null;
+		try {
+			reader = new BufferedReader(
+					new InputStreamReader(url.openStream(), "UTF-8"));
+			String line;
+			while ((line = reader.readLine()) != null) {
+				final String parsedLine = parseLine(url, line);
+				if (parsedLine != null) {
+					lines.add(parsedLine);
+				}
+			}
+		} catch (IOException e1) {
+			failReason = e1;
+		} finally {
+			if (reader != null) {
+				try {
+					reader.close();
+				} catch (IOException e2) {
+					if (failReason != null) {
+						failReason = e2;
+					}
+				}
+			}
+		}
+
+		if (failReason != null) {
+			throw new IllegalStateException(
+					"Unable to load a list of services from URL: " + url,
+					failReason);
+		}
+
+		return lines;
+	}
+
+	private static String parseLine(final URL url, final String line) {
+		String parsedLine = line.trim();
+		final int commentInd = parsedLine.indexOf(COMMENT_CHAR);
+		if (commentInd >= 0) {
+			parsedLine = parsedLine.substring(0, commentInd);
+		}
+		parsedLine = parsedLine.trim();
+		if (parsedLine.length() == 0) {
+			return null;
+		}
+
+		int codePoint = parsedLine.codePointAt(0);
+		if (!Character.isJavaIdentifierStart(codePoint)) {
+			throw new IllegalStateException("Illegal service-class name; "
+					+ "name must start from the valid java identifier: "
+					+ url + ", " + parsedLine);
+		}
+		for (int i = Character.charCount(codePoint),
+				length = parsedLine.length(); i < length;
+				i += Character.charCount(codePoint)) {
+			codePoint = parsedLine.codePointAt(i);
+			if (!Character.isJavaIdentifierPart(codePoint)
+					&& (codePoint != '.')) {
+				throw new IllegalStateException("Illegal service-class name; "
+						+ "name must consists of valid java identifier chars: "
+						+ url + ", " + parsedLine);
+			}
+		}
+
+		return parsedLine;
+	}
+
+	private static IFilter loadService(final String serviceClass,
+			final ClassLoader loader) {
+		try {
+			Class<?> filterClass = Class.forName(serviceClass, false, loader);
+			if (!IFilter.class.isAssignableFrom(filterClass)) {
+				throw new IllegalStateException(
+						"Filter class is not an instance of " +
+								IFilter.class.getName());
+			}
+			return (IFilter) filterClass.newInstance();
+		} catch (ClassNotFoundException e) {
+			throw new IllegalStateException(
+					"Filter class cannot be found: " + serviceClass, e);
+		} catch (IllegalAccessException e) {
+			throw new IllegalStateException(
+					"Filter class or its default constructor " +
+							"is not accessible: " + serviceClass, e);
+		} catch (InstantiationException e) {
+			throw new IllegalStateException(
+					"Filter class cannot be instantiated: " + serviceClass, e);
+		}
+	}
+
+}


### PR DESCRIPTION
This pull request proposes the same thing as #846 does, but using java5-way of loading additional filters just in case its (java5) support is still necessary.

--- 
#### Description below is copied from the #846
This pull requests proposes to add an ability to load additional filters by means of java's SPI mechanism aka ServiceLoaders to easily extend a list of available filters by just dropping a jar into the plugin's classpath.

It could help to increase the amount of contributors to the jacoco's filters in case of (and even if) jacoco maintainers are not experts in the particular technology or library. Later on after the careful review the corresponding external filters can be included into the main distribution.

Candidates of externally available filters:
- [scala ones](https://groups.google.com/forum/#!topic/jacoco/npl9SUL8_WA)
- [aspectj ones ](https://github.com/jacoco/jacoco/pull/710)

Even jacoco itself can be considered to be a subject of using SPI mechanism to load its own filters (e.g. to improve its own modularity).

To include additional external filters into a build classpath it will be necessary to declare a jacoco dependency line the following:

**Maven**
```xml
<plugin>
  <groupId>org.jacoco</groupId>
  <artifactId>jacoco-maven-plugin</artifactId>
  <version>${project.version}</version>
  <dependencies>
    <dependency>
      <groupId>foo.bar.filters</groupId>
      <artifactId>external-filters</artifactId>
      <version>${external-filters.version}</version>
    </dependency>
  </dependencies>
</plugin>
```
**Gradle**
```groovy
dependencies {
  jacocoAnt [
    "org.jacoco:org.jacoco.core:${versions.jacoco}",
    "org.jacoco:org.jacoco.ant:${versions.jacoco}",
    "org.jacoco:org.jacoco.report:${versions.jacoco}",
    "foo.bar.filters:external-filters:${external-filters.version}"
  ]
}
```