### PR TITLE
Update KotlinCoroutineFilter for Kotlin 1.3.30

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,14 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>New Features</h3>
+
+<ul>
+  <li>Branches added by the Kotlin compiler version 1.3.30 for suspending lambdas
+      and functions are filtered out during generation of report
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/849">#849</a>).</li>
+</ul>
+
 <h2>Release 0.8.3 (2019/01/23)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
During attempt to test resolution of [KT-28453](https://youtrack.jetbrains.com/issue/KT-28453) (#791) in Kotlin 1.3.30 EAP

```diff
--- a/org.jacoco.core.test.validation.kotlin/pom.xml
+++ b/org.jacoco.core.test.validation.kotlin/pom.xml
@@ -28,2 +28,2 @@
-    <kotlin.version>1.3.0</kotlin.version>
+    <kotlin.version>1.3.30-eap-11</kotlin.version>
   </properties>
@@ -47,3 +47,16 @@
   </dependencies>

+  <repositories>
+    <repository>
+      <id>kotlin-eap</id>
+      <url>https://dl.bintray.com/kotlin/kotlin-eap</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>kotlin-eap</id>
+      <url>https://dl.bintray.com/kotlin/kotlin-eap</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <build>
```

Thanks to our validation tests I discovered [KT-28015](https://youtrack.jetbrains.com/issue/KT-28015) (https://github.com/JetBrains/kotlin/commit/19d2262cf1bc04c2a164c54bd83d247548627e89):

```
$ mvn clean verify -Denforcer.skip
...
Failed tests:   execute_assertions_in_comments(org.jacoco.core.test.validation.kotlin.KotlinCoroutineTest): Instructions (KotlinCoroutineTarget.kt:22) expected:<[EMPTY]> but was:<[PARTLY_COVERED]>
```
