### PR TITLE
Remove `instrument(ClassReader)` and `analyzeClass(ClassReader)`

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/ExecuteInstrumentedCodeScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/ExecuteInstrumentedCodeScenario.java
@@ -18,7 +18,6 @@ import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.LoggerRuntime;
 import org.jacoco.core.runtime.RuntimeData;
 import org.jacoco.core.test.TargetLoader;
-import org.objectweb.asm.ClassReader;
 
 /**
  * This scenario runs a given scenario twice and reports the execution time:
@@ -37,11 +36,11 @@ public class ExecuteInstrumentedCodeScenario extends TimedScenario {
 	@Override
 	@SuppressWarnings("unchecked")
 	protected Callable<Void> getInstrumentedCallable() throws Exception {
-		ClassReader reader = new ClassReader(TargetLoader.getClassData(target));
 		IRuntime runtime = new LoggerRuntime();
 		runtime.startup(new RuntimeData());
 		final Instrumenter instr = new Instrumenter(runtime);
-		final byte[] instrumentedBuffer = instr.instrument(reader);
+		final byte[] original = TargetLoader.getClassDataAsBytes(target);
+		final byte[] instrumentedBuffer = instr.instrument(original, "");
 		final TargetLoader loader = new TargetLoader();
 
 		return (Callable<Void>) loader.add(target, instrumentedBuffer)

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/InstrumentationSizeSzenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/InstrumentationSizeSzenario.java
@@ -15,7 +15,6 @@ import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.IRuntime;
 import org.jacoco.core.runtime.LoggerRuntime;
 import org.jacoco.core.test.TargetLoader;
-import org.objectweb.asm.ClassReader;
 
 /**
  * Scenario to measure the overhead in terms of additional byte code size
@@ -31,11 +30,11 @@ public class InstrumentationSizeSzenario implements IPerfScenario {
 
 	public void run(IPerfOutput output) throws Exception {
 		final IRuntime runtime = new LoggerRuntime();
-		ClassReader reader = new ClassReader(TargetLoader.getClassData(target));
 		final Instrumenter instr = new Instrumenter(runtime);
-		instr.instrument(reader);
-		output.writeByteResult("instrumented class",
-				instr.instrument(reader).length, reader.b.length);
+		final byte[] original = TargetLoader.getClassDataAsBytes(target);
+		final byte[] instrumented = instr.instrument(original, "");
+		output.writeByteResult("instrumented class", instrumented.length,
+				original.length);
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -101,16 +101,6 @@ public class Analyzer {
 		return new ClassProbesAdapter(analyzer, false);
 	}
 
-	/**
-	 * Analyzes the class given as a ASM reader.
-	 * 
-	 * @param reader
-	 *            reader with class definitions
-	 */
-	public void analyzeClass(final ClassReader reader) {
-		analyzeClass(reader.b);
-	}
-
 	private void analyzeClass(final byte[] source) {
 		final long classId = CRC64.classId(source);
 		final ClassReader reader = InstrSupport.classReaderFor(source);

--- a/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
@@ -69,18 +69,6 @@ public class Instrumenter {
 		signatureRemover.setActive(flag);
 	}
 
-	/**
-	 * Creates a instrumented version of the given class if possible.
-	 * 
-	 * @param reader
-	 *            definition of the class as ASM reader
-	 * @return instrumented definition
-	 * 
-	 */
-	public byte[] instrument(final ClassReader reader) {
-		return instrument(reader.b);
-	}
-
 	private byte[] instrument(final byte[] source) {
 		final long classId = CRC64.classId(source);
 		final ClassReader reader = InstrSupport.classReaderFor(source);

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -21,11 +21,18 @@
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
 <h3>New Features</h3>
-
 <ul>
   <li>Branches added by the Kotlin compiler version 1.3.30 for suspending lambdas
       and functions are filtered out during generation of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/849">#849</a>).</li>
+</ul>
+
+<h3>API Changes</h3>
+<ul>
+    <li>Methods <code>Instrumenter.instrument(org.objectweb.asm.ClassReader)</code>
+        and <code>Analyzer.analyzeClass(org.objectweb.asm.ClassReader)</code>
+        were removed
+        (GitHub <a href="https://github.com/jacoco/jacoco/issues/850">#850</a>).</li>
 </ul>
 
 <h2>Release 0.8.3 (2019/01/23)</h2>


### PR DESCRIPTION
There are several problems with methods [`Instrumenter.instrument(ClassReader)`](https://github.com/jacoco/jacoco/blob/v0.8.3/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java#L72-L82) and [`Analyzer.analyzeClass(ClassReader)`](https://github.com/jacoco/jacoco/blob/v0.8.3/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java#L104-L112) :

* their implementations use
[field `org.objectweb.asm.ClassReader.b` which was marked as deprecated in ASM 7.1](https://gitlab.ow2.org/asm/asm/commit/5ed1a4abbbbd4ba416a5f3d99031535e89a2e88f)

* they don't work in case when field `ClassReader.b` contains more than just bytes of one class (see [`ClassReader(byte[] classFileBuffer, int classFileOffset, int classFileLength)`](https://gitlab.ow2.org/asm/asm/blob/ASM_7_1/asm/src/main/java/org/objectweb/asm/ClassReader.java#L165-177)) and seems that there is no easy way to fix this

So I think that we have only two options:
1. mark them as deprecated and remove later
2. remove them

@marchof WDYT?
