### PR TITLE
Method `needsFrames` should also consider high byte of version

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/InstrSupportTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/InstrSupportTest.java
@@ -128,6 +128,8 @@ public class InstrSupportTest {
 		assertTrue(InstrSupport.needsFrames(Opcodes.V11));
 		assertTrue(InstrSupport.needsFrames(Opcodes.V12));
 		assertTrue(InstrSupport.needsFrames(Opcodes.V12 + 1));
+
+		assertTrue(InstrSupport.needsFrames(0x0100));
 	}
 
 	@Test

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
@@ -215,7 +215,7 @@ public final class InstrSupport {
 	 */
 	public static boolean needsFrames(final int version) {
 		// consider major version only (due to 1.1 anomaly)
-		return (version & 0xff) >= Opcodes.V1_6;
+		return (version & 0xFFFF) >= Opcodes.V1_6;
 	}
 
 	/**


### PR DESCRIPTION
In follow-up to https://github.com/jacoco/jacoco/pull/851#issuecomment-470745829