### PR TITLE
InstrumentingLoader should use findLoadedClass

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoader.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoader.java
@@ -52,6 +52,10 @@ public final class InstrumentingLoader extends ClassLoader {
 	protected synchronized Class<?> loadClass(String name, boolean resolve)
 			throws ClassNotFoundException {
 		if (name.startsWith(scope)) {
+			Class<?> c = findLoadedClass(name);
+			if (c != null) {
+				return c;
+			}
 			final byte[] bytes;
 			try {
 				bytes = TargetLoader.getClassDataAsBytes(delegate, name);
@@ -64,8 +68,7 @@ public final class InstrumentingLoader extends ClassLoader {
 			} catch (IOException e) {
 				throw new ClassNotFoundException("Unable to instrument", e);
 			}
-			final Class<?> c = defineClass(name, instrumented, 0,
-					instrumented.length);
+			c = defineClass(name, instrumented, 0, instrumented.length);
 			if (resolve) {
 				resolveClass(c);
 			}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoaderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoaderTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+/**
+ * Unit test for {@link InstrumentingLoader}.
+ */
+public class InstrumentingLoaderTest {
+
+	@Test
+	public void should_use_findLoadedClass() throws Exception {
+		final InstrumentingLoader loader = new InstrumentingLoader(
+				InstrumentingLoaderTest.class);
+		final Class<?> c1 = loader
+				.loadClass(InstrumentingLoaderTest.class.getName());
+		final Class<?> c2 = loader
+				.loadClass(InstrumentingLoaderTest.class.getName());
+		assertSame(c1, c2);
+	}
+
+}


### PR DESCRIPTION
Because execution of `java.lang.ClassLoader.defineClass` multiple
times with same class name causes `java.lang.LinkageError` with
message "duplicate class definition".