### PR TITLE
Filter unreachable branches in Kotlin open functions with default arguments

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineTest.java
@@ -23,4 +23,9 @@ public class KotlinInlineTest extends ValidationTestBase {
 		super(KotlinInlineTargetKt.class);
 	}
 
+	@Override
+	public void all_missed_instructions_should_have_line_number() {
+		// missed instructions without line number in inline function
+	}
+
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget.kt
@@ -22,6 +22,11 @@ object KotlinDefaultArgumentsTarget {
     private fun branch(a: Boolean, b: String = if (a) "a" else "b") { // assertFullyCovered(0, 2)
     }
 
+    open class Open {
+        open fun f(a: String = "a") { // assertFullyCovered()
+        }
+    }
+
     @JvmStatic
     fun main(args: Array<String>) {
         f(a = "a")
@@ -31,6 +36,8 @@ object KotlinDefaultArgumentsTarget {
 
         branch(false)
         branch(true)
+
+        Open().f()
     }
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -124,6 +124,17 @@ public abstract class ValidationTestBase {
 	}
 
 	@Test
+	public void all_missed_instructions_should_have_line_number() {
+		CounterImpl c = CounterImpl.COUNTER_0_0;
+		for (Line line : source.getLines()) {
+			c = c.increment(line.getCoverage().getInstructionCounter());
+		}
+		assertEquals(
+				"sum of missed instructions of all lines should be equal to missed instructions of file",
+				source.getCoverage().getInstructionCounter().getMissedCount(), c.getMissedCount());
+	}
+
+	@Test
 	public void all_branches_should_have_line_number() {
 		CounterImpl c = CounterImpl.COUNTER_0_0;
 		for (Line line : source.getLines()) {

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -123,6 +123,17 @@ public abstract class ValidationTestBase {
 				source.getCoverage().getLastLine() <= source.getLines().size());
 	}
 
+	@Test
+	public void all_branches_should_have_line_number() {
+		CounterImpl c = CounterImpl.COUNTER_0_0;
+		for (Line line : source.getLines()) {
+			c = c.increment(line.getCoverage().getBranchCounter());
+		}
+		assertEquals(
+				"sum of branch counters of all lines should be equal to branch counter of file",
+				source.getCoverage().getBranchCounter(), c);
+	}
+
 	/*
 	 * Predefined assertion methods:
 	 */

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,13 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>New Features</h3>
+<ul>
+  <li>Branches added by the Kotlin compiler for <code>open</code> functions with
+      default arguments are filtered out during generation of report
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/887">#887</a>).</li>
+</ul>
+
 <h2>Release 0.8.4 (2019/05/08)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
For open functions with default arguments

```
open class Open {
    open fun f(a: String = "a") {
    }
}
```

Kotlin compiler generates check that default arguments are not used for super calls - https://github.com/JetBrains/kotlin/blob/v1.3.31/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionCodegen.java#L1341-L1359 , even if currently such calls not allowed - compiler rejects following

```
class Derived : Open() {
    override fun f(a: String) {
        super.f() // Error: Super-calls with default arguments are not allowed. Please specify all arguments of 'super.f' explicitly
    }
}
```

I suppose that check is introduced for future versions of language, where such calls might be allowed.

This PR adds handling of open functions to `KotlinDefaultArgumentsFilter`.

Fixes #882