### PR TITLE
Fix headers in javadocs

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java
@@ -23,7 +23,7 @@ import org.jacoco.core.analysis.ICounter;
  * case of a simple sequence of instructions (by convention branch 0). Instances
  * of this class are used in two steps:
  * 
- * <h3>Step 1: Building the CFG</h3>
+ * <h2>Step 1: Building the CFG</h2>
  * 
  * For each bytecode instruction of a method a {@link Instruction} instance is
  * created. In correspondence with the CFG these instances are linked with each
@@ -32,7 +32,7 @@ import org.jacoco.core.analysis.ICounter;
  * flow ({@link #addBranch(boolean, int)}) or indirectly propagated along the
  * CFG edges ({@link #addBranch(Instruction, int)}).
  * 
- * <h3>Step 2: Querying the Coverage Status</h3>
+ * <h2>Step 2: Querying the Coverage Status</h2>
  * 
  * After all instructions have been created and linked each instruction knows
  * its execution status and can be queried with:

--- a/org.jacoco.doc/javadoc/overview.html
+++ b/org.jacoco.doc/javadoc/overview.html
@@ -8,7 +8,7 @@
   regular JARs in your classpath.
 </p>
 
-<h2>Bundle org.jacoco.core</h2>
+<h1>Bundle org.jacoco.core</h1>
 
 <p>  
   The core bundle implements the code coverage technology itself. It provides
@@ -21,14 +21,14 @@
   <li>analyzing coverage data.</li> 
 </ul>
 
-<h2>Bundle org.jacoco.agent</h2>
+<h1>Bundle org.jacoco.agent</h1>
 
 <p>
   Provides the runtime Java agent (JAR file) as a resource.
 </p>
 
 
-<h2>Bundle org.jacoco.report</h2>
+<h1>Bundle org.jacoco.report</h1>
 
 <p>
   APIs and implementation to create coverage reports in several formats.


### PR DESCRIPTION
In JDK 13 EA b13 validation of headers in javadocs become stricter:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project org.jacoco.core: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - /Users/evgeny.mandrikov/projects/jacoco/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java:26: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
[ERROR]  * <h3>Step 1: Building the CFG</h3>
[ERROR]    ^
```

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project org.jacoco.doc: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - /Users/evgeny.mandrikov/projects/jacoco/org.jacoco.doc/javadoc/overview.html:11: error: heading used out of sequence: <H2>, compared to implicit preceding heading: <H0>
[ERROR] <h2>Bundle org.jacoco.core</h2>
[ERROR] ^
```

This change restores ability to build JaCoCo without `-Dmaven.javadoc.skip` using JDK 13 EA >= b13.

And here is how this impacts generated documentation:

![before](https://user-images.githubusercontent.com/138671/58881120-cb661180-86d9-11e9-9218-3b992c7fcfa3.png)

![after](https://user-images.githubusercontent.com/138671/58881135-d3be4c80-86d9-11e9-8a95-18b12557c3ae.png)
