### PR TITLE
ProbeInserter should update indexes of local variables in annotations

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
@@ -21,7 +21,6 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.TypePath;
 import org.objectweb.asm.TypeReference;
 
 /**

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
@@ -18,8 +18,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
 
 /**
  * Unit tests for {@link ProbeInserter}.
@@ -180,6 +183,28 @@ public class ProbeInserterTest {
 		// Local variables are shifted by one:
 		expectedVisitor.visitLocalVariable(null, null, null, null, null, 4);
 		expectedVisitor.visitLocalVariable(null, null, null, null, null, 5);
+	}
+
+	@Test
+	public void should_remap_LocalVariableAnnotation() {
+		ProbeInserter pi = new ProbeInserter(0, "m", "(I)V", actualVisitor,
+				arrayStrategy);
+
+		final Label start = new Label();
+		pi.visitLabel(start);
+		final Label end = new Label();
+		pi.visitLabel(end);
+
+		pi.visitLocalVariableAnnotation(TypeReference.LOCAL_VARIABLE, null,
+				new Label[] { start }, new Label[] { end }, new int[] { 2 },
+				"LNonNull;", false);
+
+		expectedVisitor.visitLabel(start);
+		expectedVisitor.visitLabel(end);
+		// Local variables are shifted by one:
+		expectedVisitor.visitLocalVariableAnnotation(
+				TypeReference.LOCAL_VARIABLE, null, new Label[] { start },
+				new Label[] { end }, new int[] { 3 }, "LNonNull;", false);
 	}
 
 	@Test

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
@@ -11,10 +11,12 @@
  *******************************************************************************/
 package org.jacoco.core.internal.instr;
 
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.TypePath;
 
 /**
  * Internal utility to add probes into the control flow of a method. The code
@@ -109,6 +111,18 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
 			final String signature, final Label start, final Label end,
 			final int index) {
 		mv.visitLocalVariable(name, desc, signature, start, end, map(index));
+	}
+
+	@Override
+	public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef,
+			final TypePath typePath, final Label[] start, final Label[] end,
+			final int[] index, final String descriptor, final boolean visible) {
+		int[] newIndex = new int[index.length];
+		for (int i = 0; i < newIndex.length; i++) {
+			newIndex[i] = map(index[i]);
+		}
+		return mv.visitLocalVariableAnnotation(typeRef, typePath, start, end,
+				newIndex, descriptor, visible);
 	}
 
 	@Override

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
@@ -117,7 +117,7 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
 	public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef,
 			final TypePath typePath, final Label[] start, final Label[] end,
 			final int[] index, final String descriptor, final boolean visible) {
-		int[] newIndex = new int[index.length];
+		final int[] newIndex = new int[index.length];
 		for (int i = 0; i < newIndex.length; i++) {
 			newIndex[i] = map(index[i]);
 		}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -32,6 +32,8 @@
   <li><code>synthetic</code> constructors that contain values of default arguments
       in Kotlin should not be ignored
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/888">#888</a>).</li>
+  <li>Instrumentation should update indexes of local variables in annotations
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/894">#894</a>).</li>
 </ul>
 
 <h2>Release 0.8.4 (2019/05/08)</h2>


### PR DESCRIPTION
Using

```
$ javac -version
javac 11.0.3
```

compilation (`javac -g Example.java`) of

```
@java.lang.annotation.Documented
@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS)
@java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
@interface NonNull {
}

class Example {
    Object legacy() {
        return null;
    }

    Object example() {
        @NonNull Object o = legacy();
        return o;
    }
}
```

results (`javap -v -p Example.class`) in

```
  java.lang.Object example();
    descriptor: ()Ljava/lang/Object;
    flags: (0x0000)
    Code:
      stack=1, locals=2, args_size=1
         0: aload_0
         1: invokevirtual #2                  // Method legacy:()Ljava/lang/Object;
         4: astore_1
         5: aload_1
         6: areturn
      LineNumberTable:
        line 13: 0
        line 14: 5
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0       7     0  this   LExample;
            5       2     1     o   Ljava/lang/Object;
      RuntimeInvisibleTypeAnnotations:
        0: #18(): LOCAL_VARIABLE, {start_pc=5, length=2, index=1}
          NonNull
```

after instrumentation (`java -jar jacoco-0.8.4/lib/jacococli.jar instrument Example.class --dest instrumented && javap -v -p instrumented/Example.class`)

```
  java.lang.Object example();
    descriptor: ()Ljava/lang/Object;
    flags: (0x0000)
    Code:
      stack=4, locals=3, args_size=1
         0: ldc           #32                 // Dynamic #0:$jacocoData:Ljava/lang/Object;
         2: checkcast     #34                 // class "[Z"
         5: astore_1
         6: aload_0
         7: invokevirtual #2                  // Method legacy:()Ljava/lang/Object;
        10: astore_2
        11: aload_2
        12: aload_1
        13: iconst_2
        14: iconst_1
        15: bastore
        16: areturn
      LineNumberTable:
        line 13: 6
        line 14: 11
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            6      11     0  this   LExample;
           11       6     2     o   Ljava/lang/Object;
      RuntimeInvisibleTypeAnnotations:
        0: #18(): LOCAL_VARIABLE, {start_pc=11, length=6, index=1}
          NonNull
```

where `index` in `RuntimeInvisibleTypeAnnotations` is still `1`, whereas should be `2`.

This was found during work on #893