### PR TITLE
KotlinDefaultArgumentsFilter should not assume that all parameters consume one slot

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget.kt
@@ -19,6 +19,9 @@ object KotlinDefaultArgumentsTarget {
     private fun f(a: String = "a", b: String = "b") { // assertFullyCovered(0, 0)
     }
 
+    private fun longParameter(x: Long = 0) { // assertFullyCovered()
+    }
+
     private fun branch(a: Boolean, b: String = if (a) "a" else "b") { // assertFullyCovered(0, 2)
     }
 
@@ -37,6 +40,9 @@ object KotlinDefaultArgumentsTarget {
         f(b = "b")
         /* next invocation doesn't use synthetic method: */
         f("a", "b")
+
+        longParameter()
+        longParameter(1)
 
         branch(false)
         branch(true)

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilter.java
@@ -129,12 +129,17 @@ public final class KotlinDefaultArgumentsFilter implements IFilter {
 			}
 		}
 
-		private static int maskVar(final String desc, final boolean constructor) {
+		private static int maskVar(final String desc,
+				final boolean constructor) {
+			int slot = 0;
+			if (constructor) {
+				// one slot for reference to current object
+				slot++;
+			}
 			final Type[] argumentTypes = Type.getMethodType(desc)
 					.getArgumentTypes();
-			int slot = 0;
-			for (int i = 0; i < argumentTypes.length
-					- (constructor ? 1 : 2); i++) {
+			final int penultimateArgument = argumentTypes.length - 2;
+			for (int i = 0; i < penultimateArgument; i++) {
 				slot += argumentTypes[i].getSize();
 			}
 			return slot;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilter.java
@@ -105,8 +105,7 @@ public final class KotlinDefaultArgumentsFilter implements IFilter {
 			}
 
 			final Set<AbstractInsnNode> ignore = new HashSet<AbstractInsnNode>();
-			final int maskVar = Type.getMethodType(methodNode.desc)
-					.getArgumentTypes().length - (constructor ? 1 : 2);
+			final int maskVar = maskVar(methodNode.desc, constructor);
 			while (true) {
 				if (cursor.getOpcode() != Opcodes.ILOAD) {
 					break;
@@ -128,6 +127,17 @@ public final class KotlinDefaultArgumentsFilter implements IFilter {
 			for (AbstractInsnNode i : ignore) {
 				output.ignore(i, i);
 			}
+		}
+
+		private static int maskVar(final String desc, final boolean constructor) {
+			final Type[] argumentTypes = Type.getMethodType(desc)
+					.getArgumentTypes();
+			int slot = 0;
+			for (int i = 0; i < argumentTypes.length
+					- (constructor ? 1 : 2); i++) {
+				slot += argumentTypes[i].getSize();
+			}
+			return slot;
 		}
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -36,6 +36,10 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/888">#888</a>).</li>
   <li>Instrumentation should update indexes of local variables in annotations
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/894">#894</a>).</li>
+  <li>Branches added by the Kotlin compiler for functions with default arguments
+      and containing arguments of type <code>long</code> or <code>double</code>
+      should be filtered out during generation of report
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/908">#908</a>).</li>
 </ul>
 
 <h2>Release 0.8.4 (2019/05/08)</h2>


### PR DESCRIPTION
Fixes #907