### PR TITLE
Check whether source reference actually is a file

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -44,6 +44,9 @@
   <li><code>synthetic</code> methods that contain bodies of anonymous functions
       in Scala should not be ignored
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/912">#912</a>).</li>
+  <li>To avoid failures with invalid class files report generation now checks
+      that source references are actually files
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/941">#941</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/DirectorySourceFileLocatorTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/DirectorySourceFileLocatorTest.java
@@ -45,13 +45,24 @@ public class DirectorySourceFileLocatorTest {
 	}
 
 	@Test
-	public void testGetSourceFileNegative() throws IOException {
+	public void getSourceFile_should_return_null_when_source_does_not_exist()
+			throws IOException {
 		assertNull(locator.getSourceFile("org/jacoco/example",
 				"DoesNotExist.java"));
 	}
 
 	@Test
-	public void testGetSourceFile() throws IOException {
+	public void getSourceFile_should_return_null_when_source_is_folder()
+			throws IOException {
+		final File file = new File(sourceFolder.getRoot(),
+				"org/jacoco/example");
+		file.mkdirs();
+		assertNull(locator.getSourceFile("org/jacoco", "example"));
+	}
+
+	@Test
+	public void getSourceFile_should_return_content_when_file_exists()
+			throws IOException {
 		createFile("org/jacoco/example/Test.java");
 		final Reader source = locator.getSourceFile("org/jacoco/example",
 				"Test.java");
@@ -61,8 +72,8 @@ public class DirectorySourceFileLocatorTest {
 	private void createFile(String path) throws IOException {
 		final File file = new File(sourceFolder.getRoot(), path);
 		file.getParentFile().mkdirs();
-		final Writer writer = new OutputStreamWriter(
-				new FileOutputStream(file), "UTF-8");
+		final Writer writer = new OutputStreamWriter(new FileOutputStream(file),
+				"UTF-8");
 		writer.write("Source");
 		writer.close();
 	}

--- a/org.jacoco.report/src/org/jacoco/report/DirectorySourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/DirectorySourceFileLocator.java
@@ -35,7 +35,6 @@ public class DirectorySourceFileLocator extends InputStreamSourceFileLocator {
 	 *            default encoding
 	 * @param tabWidth
 	 *            tab width in source files as number of blanks
-	 * 
 	 */
 	public DirectorySourceFileLocator(final File directory,
 			final String encoding, final int tabWidth) {
@@ -44,9 +43,10 @@ public class DirectorySourceFileLocator extends InputStreamSourceFileLocator {
 	}
 
 	@Override
-	protected InputStream getSourceStream(final String path) throws IOException {
+	protected InputStream getSourceStream(final String path)
+			throws IOException {
 		final File file = new File(directory, path);
-		if (file.exists()) {
+		if (file.isFile()) {
 			return new FileInputStream(file);
 		} else {
 			return null;


### PR DESCRIPTION
A corner case has been reported where the source reference points to an folder. Instead of ignoring such a reference (as we do for missing files) in this case the report generation process fails. This fix checks that the source reference actually points to a file.

The issue war reported on the mailing list: https://groups.google.com/forum/?fromgroups=#!topic/jacoco/cx9sTR3KMr4