### PR TITLE
Fix NPE in StringSwitchEcjFilter

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/StringSwitchEcjFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/StringSwitchEcjFilterTest.java
@@ -155,4 +155,22 @@ public class StringSwitchEcjFilterTest extends FilterTestBase {
 		assertIgnored(new Range(switchNode.getNext(), expectedToInclusive));
 	}
 
+	@Test
+	public void should_not_filter_empty_lookup_switch() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"name", "(Ljava/lang/String;)V", null, null);
+		m.visitVarInsn(Opcodes.ALOAD, 1);
+		m.visitVarInsn(Opcodes.ASTORE, 2);
+		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/String", "hashCode",
+				"()I", false);
+		final Label defaultCase = new Label();
+		m.visitLookupSwitchInsn(defaultCase, null, new Label[] {});
+		m.visitLabel(defaultCase);
+		m.visitInsn(Opcodes.RETURN);
+
+		filter.filter(m, context, output);
+
+		assertIgnored();
+	}
+
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/StringSwitchEcjFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/StringSwitchEcjFilter.java
@@ -70,6 +70,10 @@ public final class StringSwitchEcjFilter implements IFilter {
 			final Set<AbstractInsnNode> replacements = new HashSet<AbstractInsnNode>();
 			replacements.add(skipNonOpcodes(defaultLabel));
 
+			if (hashCodes == 0) {
+				return;
+			}
+
 			for (int i = 0; i < hashCodes; i++) {
 				while (true) {
 					nextIsVar(Opcodes.ALOAD, "s");

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -48,7 +48,8 @@
       that source references are actually files
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/941">#941</a>).</li>
   <li><code>NullPointerException</code> during filtering
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/942">#942</a>).</li>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/942">#942</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/944">#944</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>


### PR DESCRIPTION
Following bytecode

```
         0: aload_1
         1: astore_2
         2: invokevirtual #121                // Method java/lang/String.hashCode:()I
         5: lookupswitch  { // 0
                 default: 17
            }
        17:
```

will cause NPE in `StringSwitchEcjFilter`.