### PR TITLE
Update documentation about "excludes" option of offline instrumentation

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
@@ -55,7 +55,10 @@ public class InstrumentMojo extends AbstractJacocoMojo {
 
 	/**
 	 * A list of class files to exclude from instrumentation. May use wildcard
-	 * characters (* and ?). When not specified nothing will be excluded.
+	 * characters (* and ?). When not specified nothing will be excluded. Except
+	 * for performance optimization or technical corner cases this option is
+	 * normally not required. If you want to exclude classes from the report
+	 * please configure the <code>report</code> goal accordingly.
 	 */
 	@Parameter
 	private List<String> excludes;

--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -197,7 +197,7 @@
   in the report are explicitly provided. Coverage is determined from the
   provided execution data. If execution data is missing for a particular class,
   this class is shown as not covered because the report generator cannot
-  distinguish whether the class was excluded or not executed.
+  distinguish whether the class was excluded from instrumentation or not executed.
 </p>
 
 <p>


### PR DESCRIPTION
Case of offline instrumentation was forgotten in https://github.com/jacoco/jacoco/pull/932 while causes similar questions - https://stackoverflow.com/questions/58189496/jacoco-offline-instrumentation-in-goalinstrument-goal-analyzes-the-entire