### PR TITLE
ContentTypeDetector should recognize future versions of Java class files

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -125,6 +125,23 @@ public class AnalyzerTest {
 		return cw.toByteArray();
 	}
 
+	/**
+	 * @see #analyzeAll_should_throw_exception_for_unsupported_class_file_version()
+	 */
+	@Test
+	public void analyzeClass_should_throw_exception_for_unsupported_class_file_version() {
+		final byte[] bytes = createClass(Opcodes.V14 + 1);
+		try {
+			analyzer.analyzeClass(bytes, "UnsupportedVersion");
+			fail("exception expected");
+		} catch (IOException e) {
+			assertEquals("Error while analyzing UnsupportedVersion.",
+					e.getMessage());
+			assertEquals("Unsupported class file major version 59",
+					e.getCause().getMessage());
+		}
+	}
+
 	@Test
 	public void testAnalyzeClassFromStream() throws IOException {
 		analyzer.analyzeClass(TargetLoader.getClassData(AnalyzerTest.class),
@@ -193,6 +210,24 @@ public class AnalyzerTest {
 			fail("exception expected");
 		} catch (IOException e) {
 			assertEquals("Error while analyzing BrokenStream.", e.getMessage());
+		}
+	}
+
+	/**
+	 * @see #analyzeClass_should_throw_exception_for_unsupported_class_file_version()
+	 */
+	@Test
+	public void analyzeAll_should_throw_exception_for_unsupported_class_file_version() {
+		final byte[] bytes = createClass(Opcodes.V14 + 1);
+		try {
+			analyzer.analyzeAll(new ByteArrayInputStream(bytes),
+					"UnsupportedVersion");
+			fail("exception expected");
+		} catch (IOException e) {
+			assertEquals("Error while analyzing UnsupportedVersion.",
+					e.getMessage());
+			assertEquals("Unsupported class file major version 59",
+					e.getCause().getMessage());
 		}
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
@@ -117,6 +117,23 @@ public class InstrumenterTest {
 		return cw.toByteArray();
 	}
 
+	/**
+	 * @see #instrumentAll_should_throw_exception_for_unsupported_class_file_version()
+	 */
+	@Test
+	public void instrument_should_throw_exception_for_unsupported_class_file_version() {
+		final byte[] bytes = createClass(Opcodes.V14 + 1);
+		try {
+			instrumenter.instrument(bytes, "UnsupportedVersion");
+			fail("exception expected");
+		} catch (final IOException e) {
+			assertEquals("Error while instrumenting UnsupportedVersion.",
+					e.getMessage());
+			assertEquals("Unsupported class file major version 59",
+					e.getCause().getMessage());
+		}
+	}
+
 	@Test
 	public void testInstrumentClass() throws Exception {
 		byte[] bytes = instrumenter.instrument(
@@ -200,6 +217,24 @@ public class InstrumenterTest {
 		Object obj2 = new ObjectInputStream(new ByteArrayInputStream(
 				buffer.toByteArray())).readObject();
 		assertEquals("Hello42", obj2.toString());
+	}
+
+	/**
+	 * @see #instrument_should_throw_exception_for_unsupported_class_file_version()
+	 */
+	@Test
+	public void instrumentAll_should_throw_exception_for_unsupported_class_file_version() {
+		final byte[] bytes = createClass(Opcodes.V14 + 1);
+		try {
+			instrumenter.instrumentAll(new ByteArrayInputStream(bytes),
+					new ByteArrayOutputStream(), "UnsupportedVersion");
+			fail("exception expected");
+		} catch (final IOException e) {
+			assertEquals("Error while instrumenting UnsupportedVersion.",
+					e.getMessage());
+			assertEquals("Unsupported class file major version 59",
+					e.getCause().getMessage());
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
@@ -181,6 +181,21 @@ public class ContentTypeDetectorTest {
 	}
 
 	@Test
+	public void should_detect_java_42() throws IOException {
+		initData(0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x56);
+		assertEquals(ContentTypeDetector.CLASSFILE, detector.getType());
+		assertContent();
+	}
+
+	@Test
+	public void should_not_detect_MachO_fat_binary_with_44_architectures()
+			throws IOException {
+		initData(0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x2C);
+		assertEquals(ContentTypeDetector.UNKNOWN, detector.getType());
+		assertContent();
+	}
+
+	@Test
 	public void testMachObjectFile() throws IOException {
 		initData(0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02);
 		assertEquals(ContentTypeDetector.UNKNOWN, detector.getType());

--- a/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
@@ -16,8 +16,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.objectweb.asm.Opcodes;
-
 /**
  * Detector for content types of binary streams based on a magic headers.
  */

--- a/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
@@ -74,25 +74,8 @@ public class ContentTypeDetector {
 			return PACK200FILE;
 		case CLASSFILE:
 			// also verify version to distinguish from Mach Object files:
-			switch (readInt(in)) {
-			case Opcodes.V1_1:
-			case Opcodes.V1_2:
-			case Opcodes.V1_3:
-			case Opcodes.V1_4:
-			case Opcodes.V1_5:
-			case Opcodes.V1_6:
-			case Opcodes.V1_7:
-			case Opcodes.V1_8:
-			case Opcodes.V9:
-			case Opcodes.V10:
-			case Opcodes.V11:
-			case Opcodes.V11 | Opcodes.V_PREVIEW:
-			case Opcodes.V12:
-			case Opcodes.V12 | Opcodes.V_PREVIEW:
-			case Opcodes.V13:
-			case Opcodes.V13 | Opcodes.V_PREVIEW:
-			case (Opcodes.V13 + 1):
-			case (Opcodes.V13 + 1) | Opcodes.V_PREVIEW:
+			final int majorVersion = readInt(in) & 0xFFFF;
+			if (majorVersion >= 45) {
 				return CLASSFILE;
 			}
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java
@@ -73,7 +73,12 @@ public class ContentTypeDetector {
 		case PACK200FILE:
 			return PACK200FILE;
 		case CLASSFILE:
-			// also verify version to distinguish from Mach Object files:
+			// Mach-O fat/universal binaries have the same magic header as Java
+			// class files, number of architectures is stored in unsigned 4
+			// bytes in the same place and in the same big-endian order as major
+			// and minor version of class file. Hopefully on practice number of
+			// architectures in single executable is less than 45, which is
+			// major version of Java 1.1 class files:
 			final int majorVersion = readInt(in) & 0xFFFF;
 			if (majorVersion >= 45) {
 				return CLASSFILE;

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -70,8 +70,9 @@
         a coverage ratio limit is configured outside the range [0,1] to avoid
         common configuration mistakes
         (GitHub <a href="https://github.com/jacoco/jacoco/issues/783">#783</a>).</li>
-  <li>Report generation and offline instrumentation now throw an exception for
-      class files of unsupported version instead of skipping them silently
+  <li>Unsupported class file versions are now consistently reported as exceptions
+      by all methods of <code>Analyzer</code> and <code>Instrumenter</code> and
+      thus also during report generation and offline instrumentation
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/952">#952</a>).</li>
 </ul>
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -70,6 +70,9 @@
         a coverage ratio limit is configured outside the range [0,1] to avoid
         common configuration mistakes
         (GitHub <a href="https://github.com/jacoco/jacoco/issues/783">#783</a>).</li>
+  <li>Report generation and offline instrumentation now throw an exception for
+      class files of unsupported version instead of skipping them silently
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/952">#952</a>).</li>
 </ul>
 
 <h2>Release 0.8.4 (2019/05/08)</h2>


### PR DESCRIPTION
Each time new version of bytecode comes out, we have following inconsistency between processing of classes by agent and processing of files:

offline instrumentation and report generation skip class file

```
$ cat <<END > Example.java
class Example {
  public static void main(String[] args) {
  }
END

$ javac --release 14 Example.java -d classes

$ ls classes
Example.class

$ java -jar jacoco-0.8.3/lib/jacococli.jar instrument classes --dest instrumented
[INFO] 0 classes instrumented to /tmp/j/instrumented.

$  java -jar jacoco-0.8.3/lib/jacococli.jar report --classfiles classes
[WARN] No execution data files provided.
[INFO] Analyzing 0 classes.
```

which is IMO misleading and error-prone,
whereas on-the-fly instrumentation fails

```
$ java -javaagent:jacoco-0.8.3/lib/jacocoagent.jar -cp classes Example
java.lang.instrument.IllegalClassFormatException: Error while instrumenting Example.
        at org.jacoco.agent.rt.internal_1f1cc91.CoverageTransformer.transform(CoverageTransformer.java:93)
        at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:246)
        at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
        at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:151)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:823)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:721)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:644)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:416)
        at java.base/sun.launcher.LauncherHelper.loadMainClass(LauncherHelper.java:760)
        at java.base/sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:655)
Caused by: java.io.IOException: Error while instrumenting Example.
        at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrumentError(Instrumenter.java:170)
        at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrument(Instrumenter.java:120)
        at org.jacoco.agent.rt.internal_1f1cc91.CoverageTransformer.transform(CoverageTransformer.java:91)
        ... 16 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 58
        at org.jacoco.agent.rt.internal_1f1cc91.asm.ClassReader.<init>(ClassReader.java:184)
        at org.jacoco.agent.rt.internal_1f1cc91.asm.ClassReader.<init>(ClassReader.java:166)
        at org.jacoco.agent.rt.internal_1f1cc91.asm.ClassReader.<init>(ClassReader.java:152)
        at org.jacoco.agent.rt.internal_1f1cc91.core.internal.instr.InstrSupport.classReaderFor(InstrSupport.java:247)
        at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrument(Instrumenter.java:86)
        at org.jacoco.agent.rt.internal_1f1cc91.core.instr.Instrumenter.instrument(Instrumenter.java:118)
        ... 17 more
```

This happens because [`ContentTypeDetector` has strict version check](https://github.com/jacoco/jacoco/blob/v0.8.4/org.jacoco.core/src/org/jacoco/core/internal/ContentTypeDetector.java#L75)
and used by `Instrumenter.instrumentAll` and `Analyzer.analyzeAll`,
but not by `Instrumenter.instrument` and `Analyzer.analyzeClass`.

This check was introduced in https://github.com/jacoco/jacoco/commit/73ae850e0bbcceff227da4bc9e13f0ef425adf1a to distinguish class files from Mach-O fat/universal binaries, because both have `0xCAFEBABE` magic header.

To resolve above inconsistencies, simplify `ContentTypeDetector` and to avoid [constant need to update it when new bytecode version comes out](https://github.com/jacoco/jacoco/pull/897), I propose to relax check by just checking that unsigned 2 bytes number at position of major version is greater or equal to `45` (`0x2D`, Java 1.1).

For distinction from Mach-O this will be as good as current check: [header of fat binary contains unsigned 4 bytes for number of architectures](https://github.com/llvm/llvm-project/blob/llvmorg-8.0.1/llvm/include/llvm/BinaryFormat/MachO.h#L920-L923) at a same place and in a same big-endian order where class file contains unsigned 2 bytes for minor and 2 bytes for major version, so both theoretically can be `46` and both will pass current check, however unlikely to see on practice single executable with such number of architectures.