### PR TITLE
Format code base consistently

### DIFF
--- a/jacoco-maven-plugin.test/it/it-check-fails-halt/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-check-fails-halt/src/main/java/Example.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-check-fails-halt/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-check-fails-halt/src/test/java/ExampleTest.java
@@ -15,9 +15,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example();
-  }
+	@Test
+	public void test() {
+		new Example();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-check-fails-no-halt/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-check-fails-no-halt/src/main/java/Example.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-check-fails-no-halt/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-check-fails-no-halt/src/test/java/ExampleTest.java
@@ -15,9 +15,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example();
-  }
+	@Test
+	public void test() {
+		new Example();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-check-passes/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-check-passes/src/main/java/Example.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-check-passes/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-check-passes/src/test/java/ExampleTest.java
@@ -15,9 +15,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-customize-agent/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-customize-agent/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-customize-agent/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-customize-agent/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-dump/src/main/java/Server.java
+++ b/jacoco-maven-plugin.test/it/it-dump/src/main/java/Server.java
@@ -10,7 +10,6 @@
  *    Marc R. Hoffmann - initial API and implementation
  *    
  *******************************************************************************/
-
 import java.io.File;
 
 /**

--- a/jacoco-maven-plugin.test/it/it-includes-excludes/src/main/java/org/project/DatabaseUtil.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes/src/main/java/org/project/DatabaseUtil.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.project;
 
-
 public class DatabaseUtil {
-  public void doStuff() {
-    System.out.println("Do DatabaseUtil Stuff");
-  }
+	public void doStuff() {
+		System.out.println("Do DatabaseUtil Stuff");
+	}
 }

--- a/jacoco-maven-plugin.test/it/it-includes-excludes/src/main/java/org/project/FileUtil.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes/src/main/java/org/project/FileUtil.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.project;
 
-
 public class FileUtil {
-  public void doStuff() {
-    System.out.println("Do FileUtil Stuff");
-  }
+	public void doStuff() {
+		System.out.println("Do FileUtil Stuff");
+	}
 }

--- a/jacoco-maven-plugin.test/it/it-includes-excludes/src/main/java/org/project/TestUtil.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes/src/main/java/org/project/TestUtil.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.project;
 
-
 public class TestUtil {
-  public void doStuff() {
-    System.out.println("Do TestUtil Stuff");
-  }
+	public void doStuff() {
+		System.out.println("Do TestUtil Stuff");
+	}
 }

--- a/jacoco-maven-plugin.test/it/it-includes-excludes/src/test/java/org/project/TestDatabaseUtil.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes/src/test/java/org/project/TestDatabaseUtil.java
@@ -15,8 +15,8 @@ package org.project;
 import org.junit.Test;
 
 public class TestDatabaseUtil {
-  @Test
-  public void testDoStuff() {
-    new DatabaseUtil().doStuff();
-  }
+	@Test
+	public void testDoStuff() {
+		new DatabaseUtil().doStuff();
+	}
 }

--- a/jacoco-maven-plugin.test/it/it-java9-offline-instrumentation/src/main/java/org/example/Example.java
+++ b/jacoco-maven-plugin.test/it/it-java9-offline-instrumentation/src/main/java/org/example/Example.java
@@ -14,8 +14,8 @@ package org.example;
 
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-java9-offline-instrumentation/src/test/java/org/example/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-java9-offline-instrumentation/src/test/java/org/example/ExampleTest.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-java9/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-java9/src/main/java/Example.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello(String name) {
-    // http://openjdk.java.net/jeps/280
-    System.out.println("Hello, " + name);
-  }
+	public void sayHello(String name) {
+		// http://openjdk.java.net/jeps/280
+		System.out.println("Hello, " + name);
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-java9/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-java9/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello("test");
-  }
+	@Test
+	public void test() {
+		new Example().sayHello("test");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project1/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project1/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project1/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project1/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project2/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project2/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project2/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-merge-passes/it-merge-passes-project2/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-multi-module/child/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-multi-module/child/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-multi-module/child/src/main/java/somepackage/Example.java
+++ b/jacoco-maven-plugin.test/it/it-multi-module/child/src/main/java/somepackage/Example.java
@@ -14,8 +14,8 @@ package somepackage;
 
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-multi-module/child/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-multi-module/child/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-multi-module/skip-child/src/test/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-multi-module/skip-child/src/test/ExampleTest.java
@@ -14,8 +14,8 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-  }
+	@Test
+	public void test() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-multiple-executions/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-multiple-executions/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-multiple-executions/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-multiple-executions/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-offline-instrumentation/child-without-main-classes/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-offline-instrumentation/child-without-main-classes/src/test/java/ExampleTest.java
@@ -14,8 +14,8 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-  }
+	@Test
+	public void test() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-offline-instrumentation/child/src/main/java/DoNotInstrument.java
+++ b/jacoco-maven-plugin.test/it/it-offline-instrumentation/child/src/main/java/DoNotInstrument.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class DoNotInstrument {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-offline-instrumentation/child/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-offline-instrumentation/child/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-offline-instrumentation/child/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-offline-instrumentation/child/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-prepend-property-skip/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-prepend-property-skip/src/test/java/ExampleTest.java
@@ -16,9 +16,9 @@ import static org.junit.Assert.assertNotNull;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    assertNotNull(System.getProperty("foo"));
-  }
+	@Test
+	public void test() {
+		assertNotNull(System.getProperty("foo"));
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/main/java/package1/Example1.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/main/java/package1/Example1.java
@@ -14,7 +14,7 @@ package package1;
 
 public class Example1 {
 
-  public void a() {
-  }
+	public void a() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/test/java/package1/Example1Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child1/src/test/java/package1/Example1Test.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class Example1Test {
 
-  @Test
-  public void test() {
-    new Example1().a();
-  }
+	@Test
+	public void test() {
+		new Example1().a();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/main/java/package2/Example2.java
@@ -14,7 +14,7 @@ package package2;
 
 public class Example2 {
 
-  public void a() {
-  }
+	public void a() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-customization/child2/src/test/java/package2/Example2Test.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class Example2Test {
 
-  @Test
-  public void test() {
-    new Example2().a();
-  }
+	@Test
+	public void test() {
+		new Example2().a();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child1-test/src/test/java/package1/Example1bTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child1-test/src/test/java/package1/Example1bTest.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class Example1bTest {
 
-  @Test
-  public void test() {
-    new Example1b().b();
-  }
+	@Test
+	public void test() {
+		new Example1b().b();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child1/src/main/java/package1/Example1a.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child1/src/main/java/package1/Example1a.java
@@ -14,7 +14,7 @@ package package1;
 
 public class Example1a {
 
-  public void a() {
-  }
+	public void a() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child1/src/main/java/package1/Example1b.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child1/src/main/java/package1/Example1b.java
@@ -14,7 +14,7 @@ package package1;
 
 public class Example1b {
 
-  public void b() {
-  }
+	public void b() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child1/src/test/java/package1/Example1aTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child1/src/test/java/package1/Example1aTest.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class Example1aTest {
 
-  @Test
-  public void test() {
-    new Example1a().a();
-  }
+	@Test
+	public void test() {
+		new Example1a().a();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child2/src/main/java/package2/Example2.java
@@ -14,7 +14,7 @@ package package2;
 
 public class Example2 {
 
-  public void a() {
-  }
+	public void a() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child2/src/test/java/package2/Example2Test.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class Example2Test {
 
-  @Test
-  public void test() {
-    new Example2().a();
-  }
+	@Test
+	public void test() {
+		new Example2().a();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child2v2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child2v2/src/main/java/package2/Example2.java
@@ -14,7 +14,7 @@ package package2;
 
 public class Example2 {
 
-  public void a() {
-  }
+	public void a() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/child2v2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/child2v2/src/test/java/package2/Example2Test.java
@@ -16,9 +16,9 @@ import org.junit.Test;
 
 public class Example2Test {
 
-  @Test
-  public void test() {
-    new Example2().a();
-  }
+	@Test
+	public void test() {
+		new Example2().a();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-aggregate/report/src/test/java/packagereport/ReportTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate/report/src/test/java/packagereport/ReportTest.java
@@ -16,8 +16,8 @@ import org.junit.Test;
 
 public class ReportTest {
 
-  @Test
-  public void test() {
-  }
+	@Test
+	public void test() {
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-without-debug/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-report-without-debug/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-report-without-debug/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-without-debug/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-site-failsafe/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-site-failsafe/src/main/java/Example.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
-  public void sayHelloIT() {
-    System.out.println("Hello world");
-  }
+	public void sayHelloIT() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-site-failsafe/src/test/java/ExampleIT.java
+++ b/jacoco-maven-plugin.test/it/it-site-failsafe/src/test/java/ExampleIT.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleIT {
 
-  @Test
-  public void test() {
-    new Example().sayHelloIT();
-  }
+	@Test
+	public void test() {
+		new Example().sayHelloIT();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-site-failsafe/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-site-failsafe/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-site/src/main/java/Example.java
+++ b/jacoco-maven-plugin.test/it/it-site/src/main/java/Example.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 public class Example {
 
-  public void sayHello() {
-    System.out.println("Hello world");
-  }
+	public void sayHello() {
+		System.out.println("Hello world");
+	}
 
 }

--- a/jacoco-maven-plugin.test/it/it-site/src/test/java/ExampleTest.java
+++ b/jacoco-maven-plugin.test/it/it-site/src/test/java/ExampleTest.java
@@ -14,9 +14,9 @@ import org.junit.Test;
 
 public class ExampleTest {
 
-  @Test
-  public void test() {
-    new Example().sayHello();
-  }
+	@Test
+	public void test() {
+		new Example().sayHello();
+	}
 
 }

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -159,8 +159,8 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 		final String name = getEffectivePropertyName();
 		final Properties projectProperties = getProject().getProperties();
 		final String oldValue = projectProperties.getProperty(name);
-		final String newValue = createAgentOptions().prependVMArguments(
-				oldValue, getAgentJarFile());
+		final String newValue = createAgentOptions()
+				.prependVMArguments(oldValue, getAgentJarFile());
 		getLog().info(name + " set to " + newValue);
 		projectProperties.setProperty(name, newValue);
 	}
@@ -200,12 +200,12 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 			agentOptions.setExclClassloader(exclClassLoaders);
 		}
 		if (inclBootstrapClasses != null) {
-			agentOptions.setInclBootstrapClasses(inclBootstrapClasses
-					.booleanValue());
+			agentOptions.setInclBootstrapClasses(
+					inclBootstrapClasses.booleanValue());
 		}
 		if (inclNoLocationClasses != null) {
-			agentOptions.setInclNoLocationClasses(inclNoLocationClasses
-					.booleanValue());
+			agentOptions.setInclNoLocationClasses(
+					inclNoLocationClasses.booleanValue());
 		}
 		if (sessionId != null) {
 			agentOptions.setSessionId(sessionId);

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractJacocoMojo.java
@@ -35,8 +35,8 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 	@Parameter(property = "jacoco.skip", defaultValue = "false")
 	private boolean skip;
 
-	public final void execute() throws MojoExecutionException,
-			MojoFailureException {
+	public final void execute()
+			throws MojoExecutionException, MojoFailureException {
 		if (skip) {
 			getLog().info(
 					"Skipping JaCoCo execution because property jacoco.skip is set.");
@@ -57,8 +57,8 @@ public abstract class AbstractJacocoMojo extends AbstractMojo {
 	 *             occurs. Throwing this exception causes a "BUILD FAILURE"
 	 *             message to be displayed.
 	 */
-	protected abstract void executeMojo() throws MojoExecutionException,
-			MojoFailureException;
+	protected abstract void executeMojo()
+			throws MojoExecutionException, MojoFailureException;
 
 	/**
 	 * Skips Mojo.

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -181,16 +181,16 @@ public abstract class AbstractReportMojo extends AbstractMavenReport {
 			createReport(visitor, support);
 			visitor.visitEnd();
 		} catch (final IOException e) {
-			throw new MavenReportException("Error while creating report: "
-					+ e.getMessage(), e);
+			throw new MavenReportException(
+					"Error while creating report: " + e.getMessage(), e);
 		}
 	}
 
 	abstract void loadExecutionData(final ReportSupport support)
 			throws IOException;
 
-	abstract void addFormatters(final ReportSupport support, final Locale locale)
-			throws IOException;
+	abstract void addFormatters(final ReportSupport support,
+			final Locale locale) throws IOException;
 
 	abstract void createReport(final IReportGroupVisitor visitor,
 			final ReportSupport support) throws IOException;

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AgentMojo.java
@@ -38,7 +38,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  *
  * <p>
  * One of the ways to do this in case of maven-surefire-plugin - is to use
- * syntax for <a href="http://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation">late property evaluation</a>:
+ * syntax for <a href=
+ * "http://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation">late
+ * property evaluation</a>:
  * </p>
  * 
  * <pre>
@@ -52,13 +54,14 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * </pre>
  * 
  * <p>
- * You can define empty property to avoid JVM startup error <code>Could not find or load main class @{argLine}</code>
- * when using late property evaluation and jacoco-maven-plugin not executed.
+ * You can define empty property to avoid JVM startup error
+ * <code>Could not find or load main class @{argLine}</code> when using late
+ * property evaluation and jacoco-maven-plugin not executed.
  * </p>
  * 
  * <p>
- * Another way is to define "argLine" as a Maven property rather than
- * as part of the configuration of maven-surefire-plugin:
+ * Another way is to define "argLine" as a Maven property rather than as part of
+ * the configuration of maven-surefire-plugin:
  * </p>
  * 
  * <pre>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/DumpMojo.java
@@ -95,9 +95,8 @@ public class DumpMojo extends AbstractJacocoMojo {
 			@Override
 			protected void onConnecting(final InetAddress address,
 					final int port) {
-				getLog().info(
-						format("Connecting to %s:%s", address,
-								Integer.valueOf(port)));
+				getLog().info(format("Connecting to %s:%s", address,
+						Integer.valueOf(port)));
 			}
 
 			@Override
@@ -112,9 +111,8 @@ public class DumpMojo extends AbstractJacocoMojo {
 		try {
 			final ExecFileLoader loader = client.dump(address, port);
 			if (dump) {
-				getLog().info(
-						format("Dumping execution data to %s",
-								destFile.getAbsolutePath()));
+				getLog().info(format("Dumping execution data to %s",
+						destFile.getAbsolutePath()));
 				loader.save(destFile, append);
 			}
 		} catch (final IOException e) {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/FileFilter.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/FileFilter.java
@@ -40,7 +40,8 @@ public class FileFilter {
 	 * @param excludes
 	 *            list of excludes patterns
 	 */
-	public FileFilter(final List<String> includes, final List<String> excludes) {
+	public FileFilter(final List<String> includes,
+			final List<String> excludes) {
 		this.includes = includes;
 		this.excludes = excludes;
 	}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/InstrumentMojo.java
@@ -64,17 +64,18 @@ public class InstrumentMojo extends AbstractJacocoMojo {
 	private List<String> excludes;
 
 	@Override
-	public void executeMojo() throws MojoExecutionException,
-			MojoFailureException {
-		final File originalClassesDir = new File(getProject().getBuild()
-				.getDirectory(), "generated-classes/jacoco");
+	public void executeMojo()
+			throws MojoExecutionException, MojoFailureException {
+		final File originalClassesDir = new File(
+				getProject().getBuild().getDirectory(),
+				"generated-classes/jacoco");
 		originalClassesDir.mkdirs();
 		final File classesDir = new File(
 				getProject().getBuild().getOutputDirectory());
 		if (!classesDir.exists()) {
 			getLog().info(
-					"Skipping JaCoCo execution due to missing classes directory:" +
-					classesDir);
+					"Skipping JaCoCo execution due to missing classes directory:"
+							+ classesDir);
 			return;
 		}
 

--- a/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/MergeMojo.java
@@ -61,8 +61,8 @@ public class MergeMojo extends AbstractJacocoMojo {
 	private List<FileSet> fileSets;
 
 	@Override
-	protected void executeMojo() throws MojoExecutionException,
-			MojoFailureException {
+	protected void executeMojo()
+			throws MojoExecutionException, MojoFailureException {
 		if (!canMergeReports()) {
 			return;
 		}
@@ -96,13 +96,12 @@ public class MergeMojo extends AbstractJacocoMojo {
 					continue;
 				}
 				try {
-					getLog().info(
-							"Loading execution data file "
-									+ inputFile.getAbsolutePath());
+					getLog().info("Loading execution data file "
+							+ inputFile.getAbsolutePath());
 					loader.load(inputFile);
 				} catch (final IOException e) {
-					throw new MojoExecutionException("Unable to read "
-							+ inputFile.getAbsolutePath(), e);
+					throw new MojoExecutionException(
+							"Unable to read " + inputFile.getAbsolutePath(), e);
 				}
 			}
 		}
@@ -114,14 +113,14 @@ public class MergeMojo extends AbstractJacocoMojo {
 			getLog().info(MSG_SKIPPING);
 			return;
 		}
-		getLog().info(
-				"Writing merged execution data to "
-						+ destFile.getAbsolutePath());
+		getLog().info("Writing merged execution data to "
+				+ destFile.getAbsolutePath());
 		try {
 			loader.save(destFile, false);
 		} catch (final IOException e) {
-			throw new MojoExecutionException("Unable to write merged file "
-					+ destFile.getAbsolutePath(), e);
+			throw new MojoExecutionException(
+					"Unable to write merged file " + destFile.getAbsolutePath(),
+					e);
 		}
 	}
 

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -148,9 +148,8 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 
 	@Override
 	public void setReportOutputDirectory(final File reportOutputDirectory) {
-		if (reportOutputDirectory != null
-				&& !reportOutputDirectory.getAbsolutePath().endsWith(
-						"jacoco-aggregate")) {
+		if (reportOutputDirectory != null && !reportOutputDirectory
+				.getAbsolutePath().endsWith("jacoco-aggregate")) {
 			outputDirectory = new File(reportOutputDirectory,
 					"jacoco-aggregate");
 		} else {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportITMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportITMojo.java
@@ -87,9 +87,8 @@ public class ReportITMojo extends AbstractReportMojo {
 
 	@Override
 	public void setReportOutputDirectory(final File reportOutputDirectory) {
-		if (reportOutputDirectory != null
-				&& !reportOutputDirectory.getAbsolutePath().endsWith(
-						"jacoco-it")) {
+		if (reportOutputDirectory != null && !reportOutputDirectory
+				.getAbsolutePath().endsWith("jacoco-it")) {
 			outputDirectory = new File(reportOutputDirectory, "jacoco-it");
 		} else {
 			outputDirectory = reportOutputDirectory;

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportMojo.java
@@ -82,8 +82,8 @@ public class ReportMojo extends AbstractReportMojo {
 
 	@Override
 	public void setReportOutputDirectory(final File reportOutputDirectory) {
-		if (reportOutputDirectory != null
-				&& !reportOutputDirectory.getAbsolutePath().endsWith("jacoco")) {
+		if (reportOutputDirectory != null && !reportOutputDirectory
+				.getAbsolutePath().endsWith("jacoco")) {
 			outputDirectory = new File(reportOutputDirectory, "jacoco");
 		} else {
 			outputDirectory = reportOutputDirectory;

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
@@ -51,7 +51,8 @@ import org.jacoco.report.xml.XMLFormatter;
  * 
  * <ol>
  * <li>Create an instance</li>
- * <li>Load one or multiple exec files with <code>loadExecutionData()</code></li>
+ * <li>Load one or multiple exec files with
+ * <code>loadExecutionData()</code></li>
  * <li>Add one or multiple formatters with <code>addXXX()</code> methods</li>
  * <li>Create the root visitor with <code>initRootVisitor()</code></li>
  * <li>Process one or multiple projects with <code>processProject()</code></li>
@@ -110,8 +111,8 @@ final class ReportSupport {
 		if (footer != null) {
 			htmlFormatter.setFooterText(footer);
 		}
-		formatters.add(htmlFormatter.createVisitor(new FileMultiReportOutput(
-				targetdir)));
+		formatters.add(htmlFormatter
+				.createVisitor(new FileMultiReportOutput(targetdir)));
 	}
 
 	public void addAllFormatters(final File targetdir, final String encoding,
@@ -131,8 +132,8 @@ final class ReportSupport {
 
 	public IReportVisitor initRootVisitor() throws IOException {
 		final IReportVisitor visitor = new MultiReportVisitor(formatters);
-		visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader
-				.getExecutionDataStore().getContents());
+		visitor.visitInfo(loader.getSessionInfoStore().getInfos(),
+				loader.getExecutionDataStore().getContents());
 		return visitor;
 	}
 
@@ -190,8 +191,8 @@ final class ReportSupport {
 			final List<String> includes, final List<String> excludes,
 			final ISourceFileLocator locator) throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
-		final File classesDir = new File(project.getBuild()
-				.getOutputDirectory());
+		final File classesDir = new File(
+				project.getBuild().getOutputDirectory());
 
 		if (classesDir.isDirectory()) {
 			final Analyzer analyzer = new Analyzer(
@@ -276,7 +277,8 @@ final class ReportSupport {
 		}
 	}
 
-	private static List<File> getCompileSourceRoots(final MavenProject project) {
+	private static List<File> getCompileSourceRoots(
+			final MavenProject project) {
 		final List<File> result = new ArrayList<File>();
 		for (final Object path : project.getCompileSourceRoots()) {
 			result.add(resolvePath(project, (String) path));

--- a/jacoco-maven-plugin/src/org/jacoco/maven/RestoreMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/RestoreMojo.java
@@ -30,12 +30,13 @@ import org.codehaus.plexus.util.FileUtils;
 public class RestoreMojo extends AbstractJacocoMojo {
 
 	@Override
-	protected void executeMojo() throws MojoExecutionException,
-			MojoFailureException {
-		final File originalClassesDir = new File(getProject().getBuild()
-				.getDirectory(), "generated-classes/jacoco");
-		final File classesDir = new File(getProject().getBuild()
-				.getOutputDirectory());
+	protected void executeMojo()
+			throws MojoExecutionException, MojoFailureException {
+		final File originalClassesDir = new File(
+				getProject().getBuild().getDirectory(),
+				"generated-classes/jacoco");
+		final File classesDir = new File(
+				getProject().getBuild().getOutputDirectory());
 		try {
 			FileUtils.copyDirectoryStructure(originalClassesDir, classesDir);
 		} catch (final IOException e) {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/RuleConfiguration.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/RuleConfiguration.java
@@ -38,8 +38,8 @@ public class RuleConfiguration {
 
 	/**
 	 * @param element
-	 *            element type this rule applies to
-	 * TODO: use ElementType directly once Maven 3 is required.
+	 *            element type this rule applies to TODO: use ElementType
+	 *            directly once Maven 3 is required.
 	 */
 	public void setElement(final String element) {
 		rule.setElement(ElementType.valueOf(element));

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -104,31 +104,33 @@ public class CoverageTransformerTest {
 	@Test
 	public void testFilterClassLoaderNegative1() {
 		options.setInclBootstrapClasses(false);
-		options.setExclClassloader("org.jacoco.agent.rt.internal.CoverageTransformerTest$*");
+		options.setExclClassloader(
+				"org.jacoco.agent.rt.internal.CoverageTransformerTest$*");
 		CoverageTransformer t = createTransformer();
 		ClassLoader myClassLoader = new ClassLoader(null) {
 		};
-		assertFalse(t
-				.filter(myClassLoader, "org/example/Foo", protectionDomain));
+		assertFalse(
+				t.filter(myClassLoader, "org/example/Foo", protectionDomain));
 	}
 
 	@Test
 	public void testFilterClassLoaderNegative2() {
 		options.setInclBootstrapClasses(true);
-		options.setExclClassloader("org.jacoco.agent.rt.internal.CoverageTransformerTest$*");
+		options.setExclClassloader(
+				"org.jacoco.agent.rt.internal.CoverageTransformerTest$*");
 		CoverageTransformer t = createTransformer();
 		ClassLoader myClassLoader = new ClassLoader(null) {
 		};
-		assertFalse(t
-				.filter(myClassLoader, "org/example/Foo", protectionDomain));
+		assertFalse(
+				t.filter(myClassLoader, "org/example/Foo", protectionDomain));
 	}
 
 	@Test
 	public void testFilterIncludedClassPositive() {
 		options.setIncludes("org.jacoco.core.*:org.jacoco.agent.rt.*");
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo",
-				protectionDomain));
+		assertTrue(
+				t.filter(classLoader, "org/jacoco/core/Foo", protectionDomain));
 	}
 
 	@Test
@@ -159,8 +161,8 @@ public class CoverageTransformerTest {
 	public void testFilterExcludedClassNegative() {
 		options.setExcludes("*Test");
 		CoverageTransformer t = createTransformer();
-		assertTrue(t.filter(classLoader, "org/jacoco/core/Foo",
-				protectionDomain));
+		assertTrue(
+				t.filter(classLoader, "org/jacoco/core/Foo", protectionDomain));
 	}
 
 	@Test

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/ExceptionRecorder.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/ExceptionRecorder.java
@@ -15,8 +15,6 @@ package org.jacoco.agent.rt.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import org.jacoco.agent.rt.internal.IExceptionLogger;
-
 /**
  * {@link IExceptionLogger} implementation for testing purposes.
  */

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/FileOutputTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/FileOutputTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.jacoco.agent.rt.internal.output.FileOutput;
 import org.jacoco.core.runtime.AgentOptions;
 import org.jacoco.core.runtime.RuntimeData;
 import org.junit.Rule;

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpServerOutputTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpServerOutputTest.java
@@ -85,7 +85,8 @@ public class TcpServerOutputTest {
 
 	@Test
 	public void testWriteExecutionData() throws Exception {
-		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42).getProbes()[0] = true;
+		data.getExecutionData(Long.valueOf(0x12345678), "Foo", 42)
+				.getProbes()[0] = true;
 		data.setSessionId("stubid");
 
 		final Socket socket = serverSocket.connect();

--- a/org.jacoco.agent.rt/src/com/vladium/emma/rt/RT.java
+++ b/org.jacoco.agent.rt/src/com/vladium/emma/rt/RT.java
@@ -45,12 +45,12 @@ public final class RT {
 	 *             in case of problems with the file output
 	 */
 	@SuppressWarnings("unused")
-	public static void dumpCoverageData(final File outFile,
-			final boolean merge, final boolean stopDataCollection)
-			throws IOException {
+	public static void dumpCoverageData(final File outFile, final boolean merge,
+			final boolean stopDataCollection) throws IOException {
 		final OutputStream out = new FileOutputStream(outFile, merge);
 		try {
-			out.write(org.jacoco.agent.rt.RT.getAgent().getExecutionData(false));
+			out.write(
+					org.jacoco.agent.rt.RT.getAgent().getExecutionData(false));
 		} finally {
 			out.close();
 		}

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/ClassFileDumper.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/ClassFileDumper.java
@@ -66,8 +66,8 @@ class ClassFileDumper {
 			}
 			outputdir.mkdirs();
 			final Long id = Long.valueOf(CRC64.classId(contents));
-			final File file = new File(outputdir, String.format(
-					"%s.%016x.class", localname, id));
+			final File file = new File(outputdir,
+					String.format("%s.%016x.class", localname, id));
 			final OutputStream out = new FileOutputStream(file);
 			out.write(contents);
 			out.close();

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/CoverageTransformer.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/CoverageTransformer.java
@@ -118,7 +118,8 @@ public class CoverageTransformer implements ClassFileTransformer {
 				return false;
 			}
 		} else {
-			if (!inclNoLocationClasses && !hasSourceLocation(protectionDomain)) {
+			if (!inclNoLocationClasses
+					&& !hasSourceLocation(protectionDomain)) {
 				return false;
 			}
 			if (exclClassloader.matches(loader.getClass().getName())) {
@@ -128,9 +129,9 @@ public class CoverageTransformer implements ClassFileTransformer {
 
 		return !classname.startsWith(AGENT_PREFIX) &&
 
-		includes.matches(classname) &&
+				includes.matches(classname) &&
 
-		!excludes.matches(classname);
+				!excludes.matches(classname);
 	}
 
 	/**

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
@@ -62,7 +62,8 @@ public final class PreMain {
 			return new InjectedClassRuntime(Object.class, "$JaCoCo");
 		}
 
-		return ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError");
+		return ModifiedSystemClassRuntime.createFor(inst,
+				"java/lang/UnknownError");
 	}
 
 	/**

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/FileOutput.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/FileOutput.java
@@ -37,8 +37,8 @@ public class FileOutput implements IAgentOutput {
 
 	private boolean append;
 
-	public final void startup(final AgentOptions options, final RuntimeData data)
-			throws IOException {
+	public final void startup(final AgentOptions options,
+			final RuntimeData data) throws IOException {
 		this.data = data;
 		this.destFile = new File(options.getDestfile()).getAbsoluteFile();
 		this.append = options.getAppend();

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/NoneOutput.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/NoneOutput.java
@@ -20,7 +20,8 @@ import org.jacoco.core.runtime.RuntimeData;
  */
 public class NoneOutput implements IAgentOutput {
 
-	public final void startup(final AgentOptions options, final RuntimeData data) {
+	public final void startup(final AgentOptions options,
+			final RuntimeData data) {
 		// Nothing to do
 	}
 

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/TcpClientOutput.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/TcpClientOutput.java
@@ -20,8 +20,8 @@ import org.jacoco.core.runtime.AgentOptions;
 import org.jacoco.core.runtime.RuntimeData;
 
 /**
- * Output that connects to a TCP port. This controller uses the following
- * agent options:
+ * Output that connects to a TCP port. This controller uses the following agent
+ * options:
  * <ul>
  * <li>address</li>
  * <li>port</li>

--- a/org.jacoco.agent/src/org/jacoco/agent/AgentJar.java
+++ b/org.jacoco.agent/src/org/jacoco/agent/AgentJar.java
@@ -123,8 +123,8 @@ public final class AgentJar {
 		}
 	}
 
-	private static final String ERRORMSG = String.format(
-			"The resource %s has not been found. Please see "
+	private static final String ERRORMSG = String
+			.format("The resource %s has not been found. Please see "
 					+ "/org.jacoco.agent/README.TXT for details.", RESOURCE);
 
 }

--- a/org.jacoco.ant.test/src/org/jacoco/ant/AgentTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AgentTaskTest.java
@@ -14,11 +14,11 @@ package org.jacoco.ant;
 
 import java.io.File;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class AgentTaskTest {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/AntFilesLocatorTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AntFilesLocatorTest.java
@@ -63,8 +63,8 @@ public class AntFilesLocatorTest {
 	private Resource createFile(String path) throws IOException {
 		final File file = new File(folder.getRoot(), path);
 		file.getParentFile().mkdirs();
-		final Writer writer = new OutputStreamWriter(
-				new FileOutputStream(file), "UTF-8");
+		final Writer writer = new OutputStreamWriter(new FileOutputStream(file),
+				"UTF-8");
 		writer.write("Source");
 		writer.close();
 		return new FileResource(folder.getRoot(), path);

--- a/org.jacoco.ant.test/src/org/jacoco/ant/AntResourcesLocatorTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AntResourcesLocatorTest.java
@@ -121,11 +121,12 @@ public class AntResourcesLocatorTest {
 		assertContent("BBB", source);
 	}
 
-	private Resource createFile(String path, String content) throws IOException {
+	private Resource createFile(String path, String content)
+			throws IOException {
 		final File file = new File(folder.getRoot(), path);
 		file.getParentFile().mkdirs();
-		final Writer writer = new OutputStreamWriter(
-				new FileOutputStream(file), "UTF-8");
+		final Writer writer = new OutputStreamWriter(new FileOutputStream(file),
+				"UTF-8");
 		writer.write(content);
 		writer.close();
 		return new FileResource(folder.getRoot(), path);

--- a/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.java
@@ -14,11 +14,11 @@ package org.jacoco.ant;
 
 import java.io.File;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class CoverageTaskTest {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskTest.java
@@ -14,11 +14,11 @@ package org.jacoco.ant;
 
 import java.io.File;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class DumpTaskTest {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskWithServerTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskWithServerTest.java
@@ -14,11 +14,11 @@ package org.jacoco.ant;
 
 import java.io.File;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class DumpTaskWithServerTest {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.java
@@ -15,12 +15,12 @@ package org.jacoco.ant;
 import java.io.File;
 import java.io.IOException;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.jacoco.agent.AgentJar;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class InstrumentTaskTest {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/MergeTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/MergeTaskTest.java
@@ -14,11 +14,11 @@ package org.jacoco.ant;
 
 import java.io.File;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class MergeTaskTest {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.java
@@ -14,11 +14,11 @@ package org.jacoco.ant;
 
 import java.io.File;
 
-import junit.framework.TestSuite;
-
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
 import org.junit.runner.RunWith;
+
+import junit.framework.TestSuite;
 
 @RunWith(AntUnitSuiteRunner.class)
 public class ReportTaskTest {

--- a/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
@@ -231,8 +231,8 @@ public class AbstractCoverageTask extends Task {
 	private File getAgentFile() {
 		try {
 			File agentFile = null;
-			final String agentFileLocation = getProject().getProperty(
-					"_jacoco.agentFile");
+			final String agentFileLocation = getProject()
+					.getProperty("_jacoco.agentFile");
 			if (agentFileLocation != null) {
 				agentFile = new File(agentFileLocation);
 			} else {

--- a/org.jacoco.ant/src/org/jacoco/ant/AntFilesLocator.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/AntFilesLocator.java
@@ -28,8 +28,7 @@ class AntFilesLocator extends InputStreamSourceFileLocator {
 
 	private final Map<String, Resource> resources;
 
-	public AntFilesLocator(final String encoding,
-			final int tabWidth) {
+	public AntFilesLocator(final String encoding, final int tabWidth) {
 		super(encoding, tabWidth);
 		this.resources = new HashMap<String, Resource>();
 	}
@@ -45,7 +44,8 @@ class AntFilesLocator extends InputStreamSourceFileLocator {
 	}
 
 	@Override
-	protected InputStream getSourceStream(final String path) throws IOException {
+	protected InputStream getSourceStream(final String path)
+			throws IOException {
 		final Resource file = resources.get(path);
 		if (file == null) {
 			return null;

--- a/org.jacoco.ant/src/org/jacoco/ant/CoverageTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/CoverageTask.java
@@ -34,7 +34,8 @@ import org.apache.tools.ant.UnknownElement;
  * <li>Task must be using a forked VM (so vm args can be passed)</li>
  * </ul>
  */
-public class CoverageTask extends AbstractCoverageTask implements TaskContainer {
+public class CoverageTask extends AbstractCoverageTask
+		implements TaskContainer {
 
 	private final Collection<TaskEnhancer> taskEnhancers = new ArrayList<TaskEnhancer>();
 	private Task childTask;
@@ -66,9 +67,10 @@ public class CoverageTask extends AbstractCoverageTask implements TaskContainer 
 
 		final TaskEnhancer enhancer = findEnhancerForTask(subTaskTypeName);
 		if (enhancer == null) {
-			throw new BuildException(format(
-					"%s is not a valid child of the coverage task",
-					subTaskTypeName), getLocation());
+			throw new BuildException(
+					format("%s is not a valid child of the coverage task",
+							subTaskTypeName),
+					getLocation());
 		}
 
 		if (isEnabled()) {
@@ -162,8 +164,8 @@ public class CoverageTask extends AbstractCoverageTask implements TaskContainer 
 			runtimeConfigurableWrapper.setAttribute("value",
 					getLaunchingArgument());
 
-			task.getRuntimeConfigurableWrapper().addChild(
-					runtimeConfigurableWrapper);
+			task.getRuntimeConfigurableWrapper()
+					.addChild(runtimeConfigurableWrapper);
 
 			((UnknownElement) task).addChild(el);
 		}

--- a/org.jacoco.ant/src/org/jacoco/ant/InstrumentTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/InstrumentTask.java
@@ -110,8 +110,9 @@ public class InstrumentTask extends Task {
 			}
 		} catch (final Exception e) {
 			file.delete();
-			throw new BuildException(format("Error while instrumenting %s",
-					resource), e, getLocation());
+			throw new BuildException(
+					format("Error while instrumenting %s", resource), e,
+					getLocation());
 		}
 	}
 }

--- a/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
@@ -345,8 +345,8 @@ public class ReportTask extends Task {
 	/**
 	 * Formatter element for coverage checks.
 	 */
-	public class CheckFormatterElement extends FormatterElement implements
-			IViolationsOutput {
+	public class CheckFormatterElement extends FormatterElement
+			implements IViolationsOutput {
 
 		private final List<Rule> rules = new ArrayList<Rule>();
 		private boolean violations = false;
@@ -398,8 +398,8 @@ public class ReportTask extends Task {
 			violations = true;
 			if (violationsPropery != null) {
 				final String old = getProject().getProperty(violationsPropery);
-				final String value = old == null ? message : String.format(
-						"%s\n%s", old, message);
+				final String value = old == null ? message
+						: String.format("%s\n%s", old, message);
 				getProject().setProperty(violationsPropery, value);
 			}
 		}
@@ -506,7 +506,8 @@ public class ReportTask extends Task {
 
 	private void loadExecutionData() {
 		final ExecFileLoader loader = new ExecFileLoader();
-		for (final Iterator<?> i = executiondataElement.iterator(); i.hasNext();) {
+		for (final Iterator<?> i = executiondataElement.iterator(); i
+				.hasNext();) {
 			final Resource resource = (Resource) i.next();
 			log(format("Loading execution data file %s", resource));
 			InputStream in = null;
@@ -514,9 +515,10 @@ public class ReportTask extends Task {
 				in = resource.getInputStream();
 				loader.load(in);
 			} catch (final IOException e) {
-				throw new BuildException(format(
-						"Unable to read execution data file %s", resource), e,
-						getLocation());
+				throw new BuildException(
+						format("Unable to read execution data file %s",
+								resource),
+						e, getLocation());
 			} finally {
 				FileUtils.close(in);
 			}

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyAutoCloneClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyAutoCloneClassTest.java
@@ -20,12 +20,12 @@ import org.junit.Test;
  * Test of class with {@link groovy.transform.AutoClone} annotation.
  */
 public class GroovyAutoCloneClassTest extends ValidationTestBase {
-    public GroovyAutoCloneClassTest() {
-        super(GroovyAutoCloneClassTarget.class);
-    }
+	public GroovyAutoCloneClassTest() {
+		super(GroovyAutoCloneClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyAutoExternalizeClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyAutoExternalizeClassTest.java
@@ -21,12 +21,12 @@ import org.junit.Test;
  * Test of class with {@link groovy.transform.AutoExternalize} annotation.
  */
 public class GroovyAutoExternalizeClassTest extends ValidationTestBase {
-    public GroovyAutoExternalizeClassTest() {
-        super(GroovyAutoExternalizeClassTarget.class);
-    }
+	public GroovyAutoExternalizeClassTest() {
+		super(GroovyAutoExternalizeClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyBindableClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyBindableClassTest.java
@@ -21,12 +21,12 @@ import org.junit.Test;
  * Test of class with {@link groovy.beans.Bindable} annotation.
  */
 public class GroovyBindableClassTest extends ValidationTestBase {
-    public GroovyBindableClassTest() {
-        super(GroovyBindableClassTarget.class);
-    }
+	public GroovyBindableClassTest() {
+		super(GroovyBindableClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyCanonicalClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyCanonicalClassTest.java
@@ -20,12 +20,12 @@ import org.junit.Test;
  * Test of class with {@link groovy.transform.Canonical} annotation.
  */
 public class GroovyCanonicalClassTest extends ValidationTestBase {
-    public GroovyCanonicalClassTest() {
-        super(GroovyCanonicalClassTarget.class);
-    }
+	public GroovyCanonicalClassTest() {
+		super(GroovyCanonicalClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyDelegateClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyDelegateClassTest.java
@@ -20,12 +20,12 @@ import org.junit.Test;
  * Test of class with field annotated by {@link groovy.lang.Delegate}.
  */
 public class GroovyDelegateClassTest extends ValidationTestBase {
-    public GroovyDelegateClassTest() {
-        super(GroovyDelegateClassTarget.class);
-    }
+	public GroovyDelegateClassTest() {
+		super(GroovyDelegateClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(4);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(4);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyImmutableClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyImmutableClassTest.java
@@ -20,12 +20,12 @@ import org.junit.Test;
  * Test of class with {@link groovy.transform.Immutable} annotation.
  */
 public class GroovyImmutableClassTest extends ValidationTestBase {
-    public GroovyImmutableClassTest() {
-        super(GroovyImmutableClassTarget.class);
-    }
+	public GroovyImmutableClassTest() {
+		super(GroovyImmutableClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyIndexPropertyClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyIndexPropertyClassTest.java
@@ -18,15 +18,16 @@ import org.jacoco.core.test.validation.groovy.targets.GroovyIndexPropertyClassTa
 import org.junit.Test;
 
 /**
- * Test of class with fields annotated by {@link groovy.transform.IndexedProperty} annotation.
+ * Test of class with fields annotated by
+ * {@link groovy.transform.IndexedProperty} annotation.
  */
 public class GroovyIndexPropertyClassTest extends ValidationTestBase {
-    public GroovyIndexPropertyClassTest() {
-        super(GroovyIndexPropertyClassTarget.class);
-    }
+	public GroovyIndexPropertyClassTest() {
+		super(GroovyIndexPropertyClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovySortableClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovySortableClassTest.java
@@ -21,13 +21,13 @@ import org.junit.Test;
  * Test of class with {@link groovy.transform.Sortable} annotation.
  */
 public class GroovySortableClassTest extends ValidationTestBase {
-    public GroovySortableClassTest() {
-        super(GroovySortableClassTarget.class);
-    }
+	public GroovySortableClassTest() {
+		super(GroovySortableClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        // main method and static initializer
-        assertMethodCount(2);
-    }
+	@Test
+	public void test_method_count() {
+		// main method and static initializer
+		assertMethodCount(2);
+	}
 }

--- a/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyVetoableClassTest.java
+++ b/org.jacoco.core.test.validation.groovy/src/org/jacoco/core/test/validation/groovy/GroovyVetoableClassTest.java
@@ -21,12 +21,12 @@ import org.junit.Test;
  * Test of class with {@link groovy.beans.Vetoable} annotation.
  */
 public class GroovyVetoableClassTest extends ValidationTestBase {
-    public GroovyVetoableClassTest() {
-        super(GroovyVetoableClassTarget.class);
-    }
+	public GroovyVetoableClassTest() {
+		super(GroovyVetoableClassTarget.class);
+	}
 
-    @Test
-    public void test_method_count() {
-        assertMethodCount(1);
-    }
+	@Test
+	public void test_method_count() {
+		assertMethodCount(1);
+	}
 }

--- a/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaAnonymousFunctionTest.java
+++ b/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaAnonymousFunctionTest.java
@@ -20,8 +20,8 @@ import org.jacoco.core.test.validation.scala.targets.ScalaAnonymousFunctionTarge
  */
 public class ScalaAnonymousFunctionTest extends ValidationTestBase {
 
-    public ScalaAnonymousFunctionTest() {
-        super(ScalaAnonymousFunctionTarget.class);
-    }
+	public ScalaAnonymousFunctionTest() {
+		super(ScalaAnonymousFunctionTarget.class);
+	}
 
 }

--- a/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaSingletonObjectTest.java
+++ b/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaSingletonObjectTest.java
@@ -20,8 +20,8 @@ import org.jacoco.core.test.validation.scala.targets.ScalaSingletonObjectTarget;
  */
 public class ScalaSingletonObjectTest extends ValidationTestBase {
 
-    public ScalaSingletonObjectTest() {
-        super(ScalaSingletonObjectTarget.class);
-    }
+	public ScalaSingletonObjectTest() {
+		super(ScalaSingletonObjectTarget.class);
+	}
 
 }

--- a/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaSynchronizedTest.java
+++ b/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaSynchronizedTest.java
@@ -20,8 +20,8 @@ import org.jacoco.core.test.validation.scala.targets.ScalaSynchronizedTarget;
  */
 public class ScalaSynchronizedTest extends ValidationTestBase {
 
-    public ScalaSynchronizedTest() {
-        super(ScalaSynchronizedTarget.class);
-    }
+	public ScalaSynchronizedTest() {
+		super(ScalaSynchronizedTarget.class);
+	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -183,8 +183,7 @@ public class AnalyzerTest {
 	}
 
 	/**
-	 * Triggers exception in
-	 * {@link Analyzer#analyzeClass(InputStream, String)}.
+	 * Triggers exception in {@link Analyzer#analyzeClass(InputStream, String)}.
 	 */
 	@Test
 	public void testAnalyzeClass_BrokenStream() throws IOException {
@@ -208,8 +207,8 @@ public class AnalyzerTest {
 	public void testAnalyzeAll_Zip() throws IOException {
 		final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		final ZipOutputStream zip = new ZipOutputStream(buffer);
-		zip.putNextEntry(new ZipEntry(
-				"org/jacoco/core/analysis/AnalyzerTest.class"));
+		zip.putNextEntry(
+				new ZipEntry("org/jacoco/core/analysis/AnalyzerTest.class"));
 		zip.write(TargetLoader.getClassDataAsBytes(AnalyzerTest.class));
 		zip.finish();
 		final int count = analyzer.analyzeAll(
@@ -262,20 +261,21 @@ public class AnalyzerTest {
 	public void testAnalyzeAll_Pack200() throws IOException {
 		final ByteArrayOutputStream zipbuffer = new ByteArrayOutputStream();
 		final ZipOutputStream zip = new ZipOutputStream(zipbuffer);
-		zip.putNextEntry(new ZipEntry(
-				"org/jacoco/core/analysis/AnalyzerTest.class"));
+		zip.putNextEntry(
+				new ZipEntry("org/jacoco/core/analysis/AnalyzerTest.class"));
 		zip.write(TargetLoader.getClassDataAsBytes(AnalyzerTest.class));
 		zip.finish();
 
 		final ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
 		GZIPOutputStream gzipOutput = new GZIPOutputStream(pack200buffer);
-		Pack200.newPacker().pack(
-				new JarInputStream(new ByteArrayInputStream(
-						zipbuffer.toByteArray())), gzipOutput);
+		Pack200.newPacker()
+				.pack(new JarInputStream(
+						new ByteArrayInputStream(zipbuffer.toByteArray())),
+						gzipOutput);
 		gzipOutput.finish();
 
-		final int count = analyzer.analyzeAll(new ByteArrayInputStream(
-				pack200buffer.toByteArray()), "Test");
+		final int count = analyzer.analyzeAll(
+				new ByteArrayInputStream(pack200buffer.toByteArray()), "Test");
 		assertEquals(1, count);
 		assertClasses("org/jacoco/core/analysis/AnalyzerTest");
 	}
@@ -299,8 +299,8 @@ public class AnalyzerTest {
 
 	@Test
 	public void testAnalyzeAll_Empty() throws IOException {
-		final int count = analyzer.analyzeAll(new ByteArrayInputStream(
-				new byte[0]), "Test");
+		final int count = analyzer
+				.analyzeAll(new ByteArrayInputStream(new byte[0]), "Test");
 		assertEquals(0, count);
 		assertEquals(Collections.emptyMap(), classes);
 	}
@@ -346,12 +346,12 @@ public class AnalyzerTest {
 
 	/**
 	 * With JDK 5 triggers exception in
-	 * {@link Analyzer#nextEntry(ZipInputStream, String)},
-	 * i.e. message will contain only "broken.zip".
+	 * {@link Analyzer#nextEntry(ZipInputStream, String)}, i.e. message will
+	 * contain only "broken.zip".
 	 *
 	 * With JDK > 5 triggers exception in
-	 * {@link Analyzer#analyzeAll(java.io.InputStream, String)},
-	 * i.e. message will contain only "broken.zip@brokenentry.txt".
+	 * {@link Analyzer#analyzeAll(java.io.InputStream, String)}, i.e. message
+	 * will contain only "broken.zip@brokenentry.txt".
 	 */
 	@Test
 	public void testAnalyzeAll_BrokenZipEntry() throws IOException {
@@ -378,8 +378,8 @@ public class AnalyzerTest {
 	public void testAnalyzeAll_BrokenClassFileInZip() throws IOException {
 		final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		final ZipOutputStream zip = new ZipOutputStream(buffer);
-		zip.putNextEntry(new ZipEntry(
-				"org/jacoco/core/analysis/AnalyzerTest.class"));
+		zip.putNextEntry(
+				new ZipEntry("org/jacoco/core/analysis/AnalyzerTest.class"));
 		final byte[] brokenclass = TargetLoader
 				.getClassDataAsBytes(AnalyzerTest.class);
 		brokenclass[10] = 0x23;

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CounterComparatorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CounterComparatorTest.java
@@ -111,12 +111,14 @@ public class CounterComparatorTest {
 
 	private void assertCmpLess(Comparator<ICounter> cmp, int missed1,
 			int covered1, int missed2, int covered2) {
-		assertTrue(cmp.compare(ctr(missed1, covered1), ctr(missed2, covered2)) < 0);
+		assertTrue(cmp.compare(ctr(missed1, covered1),
+				ctr(missed2, covered2)) < 0);
 	}
 
 	private void assertCmpGreater(Comparator<ICounter> cmp, int missed1,
 			int covered1, int missed2, int covered2) {
-		assertTrue(cmp.compare(ctr(missed1, covered1), ctr(missed2, covered2)) > 0);
+		assertTrue(cmp.compare(ctr(missed1, covered1),
+				ctr(missed2, covered2)) > 0);
 	}
 
 	private CounterImpl ctr(int missed, int covered) {

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
@@ -142,13 +142,13 @@ public class CoverageBuilderTest {
 
 	@Test
 	public void testCreateSourceFile() {
-		final MethodCoverageImpl method1 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method1 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method1.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
 		addClass(123L, false, "Sample", "Sample.java", method1);
 
-		final MethodCoverageImpl method2 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method2 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method2.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 6);
 		addClass(234L, false, "Second", "Sample.java", method2);
 
@@ -163,13 +163,13 @@ public class CoverageBuilderTest {
 
 	@Test
 	public void testCreateSourceFileDuplicateClassNameIdentical() {
-		final MethodCoverageImpl method1 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method1 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method1.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
 		addClass(123L, false, "Sample", "Sample.java", method1);
 
-		final MethodCoverageImpl method2 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method2 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method2.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
 		addClass(123L, false, "Sample", "Sample.java", method2);
 
@@ -184,18 +184,18 @@ public class CoverageBuilderTest {
 
 	@Test
 	public void testGetBundle() {
-		final MethodCoverageImpl method1 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method1 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method1.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
 		addClass(1, false, "org/jacoco/examples/Sample1", null, method1);
 
-		final MethodCoverageImpl method2 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method2 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method2.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 6);
 		addClass(2, false, "org/jacoco/examples/Sample2", null, method2);
 
-		final MethodCoverageImpl method3 = new MethodCoverageImpl("doit",
-				"()V", null);
+		final MethodCoverageImpl method3 = new MethodCoverageImpl("doit", "()V",
+				null);
 		method3.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 1);
 		addClass(3, false, "Sample3", null, method3);
 
@@ -212,8 +212,7 @@ public class CoverageBuilderTest {
 		IPackageCoverage p1 = packagesByName.get("org/jacoco/examples");
 		assertNotNull(p1);
 		assertEquals(
-				new HashSet<String>(Arrays.asList(
-						"org/jacoco/examples/Sample1",
+				new HashSet<String>(Arrays.asList("org/jacoco/examples/Sample1",
 						"org/jacoco/examples/Sample2")),
 				getNames(p1.getClasses()));
 
@@ -237,9 +236,10 @@ public class CoverageBuilderTest {
 		m.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
 		addClass(3, false, "Sample3", null, m);
 
-		final Set<String> actual = getNames(coverageBuilder.getNoMatchClasses());
-		final Set<String> expected = new HashSet<String>(Arrays.asList(
-				"Sample1", "Sample2"));
+		final Set<String> actual = getNames(
+				coverageBuilder.getNoMatchClasses());
+		final Set<String> expected = new HashSet<String>(
+				Arrays.asList("Sample1", "Sample2"));
 
 		assertEquals(expected, actual);
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageNodeImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageNodeImplTest.java
@@ -53,7 +53,8 @@ public class CoverageNodeImplTest {
 	public void testIncrement() {
 		CoverageNodeImpl parent = new CoverageNodeImpl(ElementType.GROUP,
 				"sample");
-		ICoverageNode child = new CoverageNodeImpl(ElementType.GROUP, "sample") {
+		ICoverageNode child = new CoverageNodeImpl(ElementType.GROUP,
+				"sample") {
 			{
 				instructionCounter = CounterImpl.getInstance(1, 41);
 				branchCounter = CounterImpl.getInstance(10, 15);
@@ -68,8 +69,10 @@ public class CoverageNodeImplTest {
 				parent.getCounter(INSTRUCTION));
 		assertEquals(CounterImpl.getInstance(1, 41),
 				parent.getInstructionCounter());
-		assertEquals(CounterImpl.getInstance(10, 15), parent.getCounter(BRANCH));
-		assertEquals(CounterImpl.getInstance(10, 15), parent.getBranchCounter());
+		assertEquals(CounterImpl.getInstance(10, 15),
+				parent.getCounter(BRANCH));
+		assertEquals(CounterImpl.getInstance(10, 15),
+				parent.getBranchCounter());
 		assertEquals(CounterImpl.getInstance(5, 3), parent.getCounter(LINE));
 		assertEquals(CounterImpl.getInstance(5, 3), parent.getLineCounter());
 		assertEquals(CounterImpl.getInstance(4, 2),
@@ -86,12 +89,14 @@ public class CoverageNodeImplTest {
 	public void testIncrementCollection() {
 		CoverageNodeImpl parent = new CoverageNodeImpl(ElementType.GROUP,
 				"sample");
-		ICoverageNode child1 = new CoverageNodeImpl(ElementType.GROUP, "sample") {
+		ICoverageNode child1 = new CoverageNodeImpl(ElementType.GROUP,
+				"sample") {
 			{
 				branchCounter = CounterImpl.getInstance(5, 2);
 			}
 		};
-		ICoverageNode child2 = new CoverageNodeImpl(ElementType.GROUP, "sample") {
+		ICoverageNode child2 = new CoverageNodeImpl(ElementType.GROUP,
+				"sample") {
 			{
 				branchCounter = CounterImpl.getInstance(3, 3);
 			}
@@ -121,7 +126,8 @@ public class CoverageNodeImplTest {
 		assertEquals(CounterImpl.getInstance(4, 4),
 				copy.getInstructionCounter());
 		assertEquals(CounterImpl.getInstance(5, 5), copy.getLineCounter());
-		assertEquals(CounterImpl.getInstance(6, 6), copy.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(6, 6),
+				copy.getComplexityCounter());
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/NodeComparatorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/NodeComparatorTest.java
@@ -35,9 +35,9 @@ public class NodeComparatorTest {
 		ICoverageNode d3 = new MockNode(30);
 		ICoverageNode d4 = new MockNode(60);
 		ICoverageNode d5 = new MockNode(99);
-		final List<ICoverageNode> result = CounterComparator.TOTALITEMS.on(
-				CounterEntity.INSTRUCTION).sort(
-				Arrays.asList(d3, d5, d1, d4, d2));
+		final List<ICoverageNode> result = CounterComparator.TOTALITEMS
+				.on(CounterEntity.INSTRUCTION)
+				.sort(Arrays.asList(d3, d5, d1, d4, d2));
 		assertEquals(Arrays.asList(d1, d2, d3, d4, d5), result);
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -152,8 +152,8 @@ public class ExecutionDataReaderWriterTest {
 	@Test(expected = IOException.class)
 	public void testMissingHeader() throws IOException {
 		buffer.reset();
-		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
-				createData(8)));
+		writer.visitClassExecution(
+				new ExecutionData(Long.MIN_VALUE, "Sample", createData(8)));
 		createReaderWithVisitors().read();
 	}
 
@@ -165,8 +165,8 @@ public class ExecutionDataReaderWriterTest {
 
 	@Test(expected = EOFException.class)
 	public void testTruncatedFile() throws IOException {
-		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
-				createData(8)));
+		writer.visitClassExecution(
+				new ExecutionData(Long.MIN_VALUE, "Sample", createData(8)));
 		final byte[] content = buffer.toByteArray();
 		buffer.reset();
 		buffer.write(content, 0, content.length - 1);
@@ -217,16 +217,16 @@ public class ExecutionDataReaderWriterTest {
 
 	@Test(expected = IOException.class)
 	public void testNoExecutionDataVisitor() throws IOException {
-		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
-				createData(8)));
+		writer.visitClassExecution(
+				new ExecutionData(Long.MIN_VALUE, "Sample", createData(8)));
 		createReader().read();
 	}
 
 	@Test
 	public void testMinClassId() throws IOException {
 		final boolean[] data = createData(8);
-		writer.visitClassExecution(new ExecutionData(Long.MIN_VALUE, "Sample",
-				data));
+		writer.visitClassExecution(
+				new ExecutionData(Long.MIN_VALUE, "Sample", data));
 		assertFalse(createReaderWithVisitors().read());
 		assertArrayEquals(data, store.get(Long.MIN_VALUE).getProbes());
 	}
@@ -234,8 +234,8 @@ public class ExecutionDataReaderWriterTest {
 	@Test
 	public void testMaxClassId() throws IOException {
 		final boolean[] data = createData(8);
-		writer.visitClassExecution(new ExecutionData(Long.MAX_VALUE, "Sample",
-				data));
+		writer.visitClassExecution(
+				new ExecutionData(Long.MAX_VALUE, "Sample", data));
 		assertFalse(createReaderWithVisitors().read());
 		assertArrayEquals(data, store.get(Long.MAX_VALUE).getProbes());
 	}
@@ -295,7 +295,8 @@ public class ExecutionDataReaderWriterTest {
 			}
 		});
 		broken[0] = true;
-		writer.visitClassExecution(new ExecutionData(3, "Sample", createData(1)));
+		writer.visitClassExecution(
+				new ExecutionData(3, "Sample", createData(1)));
 	}
 
 	private ExecutionDataReader createReaderWithVisitors() throws IOException {
@@ -328,8 +329,8 @@ public class ExecutionDataReaderWriterTest {
 	}
 
 	protected ExecutionDataReader createReader() throws IOException {
-		return new ExecutionDataReader(new ByteArrayInputStream(
-				buffer.toByteArray()));
+		return new ExecutionDataReader(
+				new ByteArrayInputStream(buffer.toByteArray()));
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
@@ -206,8 +206,8 @@ public class ExecutionDataStoreTest implements IExecutionDataVisitor {
 	}
 
 	@Test
-	public void testReset() throws InstantiationException,
-			IllegalAccessException {
+	public void testReset()
+			throws InstantiationException, IllegalAccessException {
 		final boolean[] data1 = new boolean[] { true, true, false };
 		store.put(new ExecutionData(1000, "Sample", data1));
 		store.reset();

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
@@ -46,8 +46,8 @@ public class ExecutionDataTest {
 
 	@Test
 	public void testReset() {
-		final ExecutionData e = new ExecutionData(5, "Example", new boolean[] {
-				true, false, true });
+		final ExecutionData e = new ExecutionData(5, "Example",
+				new boolean[] { true, false, true });
 		e.reset();
 		assertFalse(e.getProbes()[0]);
 		assertFalse(e.getProbes()[1]);
@@ -72,10 +72,10 @@ public class ExecutionDataTest {
 
 	@Test
 	public void testMerge() {
-		final ExecutionData a = new ExecutionData(5, "Example", new boolean[] {
-				false, true, false, true });
-		final ExecutionData b = new ExecutionData(5, "Example", new boolean[] {
-				false, false, true, true });
+		final ExecutionData a = new ExecutionData(5, "Example",
+				new boolean[] { false, true, false, true });
+		final ExecutionData b = new ExecutionData(5, "Example",
+				new boolean[] { false, false, true, true });
 		a.merge(b);
 
 		// b is merged into a:
@@ -93,10 +93,10 @@ public class ExecutionDataTest {
 
 	@Test
 	public void testMergeSubtract() {
-		final ExecutionData a = new ExecutionData(5, "Example", new boolean[] {
-				false, true, false, true });
-		final ExecutionData b = new ExecutionData(5, "Example", new boolean[] {
-				false, false, true, true });
+		final ExecutionData a = new ExecutionData(5, "Example",
+				new boolean[] { false, true, false, true });
+		final ExecutionData b = new ExecutionData(5, "Example",
+				new boolean[] { false, false, true, true });
 		a.merge(b, false);
 
 		// b is subtracted from a:

--- a/org.jacoco.core.test/src/org/jacoco/core/data/SessionInfoTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/SessionInfoTest.java
@@ -36,15 +36,12 @@ public class SessionInfoTest {
 
 	@Test
 	public void testCompare() {
-		assertEquals(0,
-				new SessionInfo("id", 1000, 2000).compareTo(new SessionInfo(
-						"id", 1234, 2000)));
-		assertEquals(-1,
-				new SessionInfo("id", 3333, 1999).compareTo(new SessionInfo(
-						"id", 1234, 2000)));
-		assertEquals(+1,
-				new SessionInfo("id", 1234, 2001).compareTo(new SessionInfo(
-						"id", 2222, 2000)));
+		assertEquals(0, new SessionInfo("id", 1000, 2000)
+				.compareTo(new SessionInfo("id", 1234, 2000)));
+		assertEquals(-1, new SessionInfo("id", 3333, 1999)
+				.compareTo(new SessionInfo("id", 1234, 2000)));
+		assertEquals(+1, new SessionInfo("id", 1234, 2001)
+				.compareTo(new SessionInfo("id", 2222, 2000)));
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
@@ -197,8 +197,8 @@ public class InstrumenterTest {
 		new ObjectOutputStream(buffer).writeObject(obj1);
 
 		// Deserialize with original class definition:
-		Object obj2 = new ObjectInputStream(new ByteArrayInputStream(
-				buffer.toByteArray())).readObject();
+		Object obj2 = new ObjectInputStream(
+				new ByteArrayInputStream(buffer.toByteArray())).readObject();
 		assertEquals("Hello42", obj2.toString());
 	}
 
@@ -225,8 +225,8 @@ public class InstrumenterTest {
 				new ByteArrayInputStream(buffer.toByteArray()), out, "Test");
 
 		assertEquals(1, count);
-		ZipInputStream zipin = new ZipInputStream(new ByteArrayInputStream(
-				out.toByteArray()));
+		ZipInputStream zipin = new ZipInputStream(
+				new ByteArrayInputStream(out.toByteArray()));
 		assertEquals("Test.class", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
 	}
@@ -371,23 +371,26 @@ public class InstrumenterTest {
 
 		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
 		GZIPOutputStream gzipOutput = new GZIPOutputStream(pack200buffer);
-		Pack200.newPacker().pack(
-				new JarInputStream(new ByteArrayInputStream(
-						jarbuffer.toByteArray())), gzipOutput);
+		Pack200.newPacker()
+				.pack(new JarInputStream(
+						new ByteArrayInputStream(jarbuffer.toByteArray())),
+						gzipOutput);
 		gzipOutput.finish();
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		int count = instrumenter.instrumentAll(new ByteArrayInputStream(
-				pack200buffer.toByteArray()), out, "Test");
+		int count = instrumenter.instrumentAll(
+				new ByteArrayInputStream(pack200buffer.toByteArray()), out,
+				"Test");
 
 		jarbuffer.reset();
 		Pack200.newUnpacker()
-				.unpack(new GZIPInputStream(new ByteArrayInputStream(
-						out.toByteArray())), new JarOutputStream(jarbuffer));
+				.unpack(new GZIPInputStream(
+						new ByteArrayInputStream(out.toByteArray())),
+						new JarOutputStream(jarbuffer));
 
 		assertEquals(1, count);
-		ZipInputStream zipin = new ZipInputStream(new ByteArrayInputStream(
-				jarbuffer.toByteArray()));
+		ZipInputStream zipin = new ZipInputStream(
+				new ByteArrayInputStream(jarbuffer.toByteArray()));
 		assertEquals("Test.class", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
 	}
@@ -434,8 +437,8 @@ public class InstrumenterTest {
 				new ByteArrayInputStream(buffer.toByteArray()), out, "Test");
 
 		assertEquals(0, count);
-		ZipInputStream zipin = new ZipInputStream(new ByteArrayInputStream(
-				out.toByteArray()));
+		ZipInputStream zipin = new ZipInputStream(
+				new ByteArrayInputStream(out.toByteArray()));
 		assertEquals("META-INF/MANIFEST.MF", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
 	}
@@ -453,8 +456,8 @@ public class InstrumenterTest {
 				new ByteArrayInputStream(buffer.toByteArray()), out, "Test");
 
 		assertEquals(0, count);
-		ZipInputStream zipin = new ZipInputStream(new ByteArrayInputStream(
-				out.toByteArray()));
+		ZipInputStream zipin = new ZipInputStream(
+				new ByteArrayInputStream(out.toByteArray()));
 		assertEquals("META-INF/ALIAS.SF", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
@@ -160,7 +160,8 @@ public class ContentTypeDetectorTest {
 	}
 
 	@Test
-	public void should_detect_java_13_with_preview_features() throws IOException {
+	public void should_detect_java_13_with_preview_features()
+			throws IOException {
 		initData(0xCA, 0xFE, 0xBA, 0xBE, 0xFF, 0xFF, 0x00, 0x39);
 		assertEquals(ContentTypeDetector.CLASSFILE, detector.getType());
 		assertContent();
@@ -174,7 +175,8 @@ public class ContentTypeDetectorTest {
 	}
 
 	@Test
-	public void should_detect_java_14_with_preview_features() throws IOException {
+	public void should_detect_java_14_with_preview_features()
+			throws IOException {
 		initData(0xCA, 0xFE, 0xBA, 0xBE, 0xFF, 0xFF, 0x00, 0x3A);
 		assertEquals(ContentTypeDetector.CLASSFILE, detector.getType());
 		assertContent();
@@ -208,9 +210,10 @@ public class ContentTypeDetectorTest {
 		zip.close();
 
 		final ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
-		Pack200.newPacker().pack(
-				new JarInputStream(new ByteArrayInputStream(
-						zipbuffer.toByteArray())), pack200buffer);
+		Pack200.newPacker()
+				.pack(new JarInputStream(
+						new ByteArrayInputStream(zipbuffer.toByteArray())),
+						pack200buffer);
 		initData(pack200buffer.toByteArray());
 		assertEquals(ContentTypeDetector.PACK200FILE, detector.getType());
 		assertContent();

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -47,16 +47,16 @@ public class Pack200StreamsTest {
 		zipout.finish();
 
 		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
-		Pack200Streams.pack(jarbuffer.toByteArray(), new NoCloseOutputStream(
-				pack200buffer));
+		Pack200Streams.pack(jarbuffer.toByteArray(),
+				new NoCloseOutputStream(pack200buffer));
 
 		jarbuffer.reset();
 		Pack200.newUnpacker().unpack(
 				new ByteArrayInputStream(pack200buffer.toByteArray()),
 				new JarOutputStream(jarbuffer));
 
-		ZipInputStream zipin = new ZipInputStream(new ByteArrayInputStream(
-				jarbuffer.toByteArray()));
+		ZipInputStream zipin = new ZipInputStream(
+				new ByteArrayInputStream(jarbuffer.toByteArray()));
 		assertEquals("Test.class", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
 	}
@@ -70,9 +70,10 @@ public class Pack200StreamsTest {
 		zipout.finish();
 
 		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
-		Pack200.newPacker().pack(
-				new JarInputStream(new ByteArrayInputStream(
-						jarbuffer.toByteArray())), pack200buffer);
+		Pack200.newPacker()
+				.pack(new JarInputStream(
+						new ByteArrayInputStream(jarbuffer.toByteArray())),
+						pack200buffer);
 
 		InputStream result = Pack200Streams.unpack(new NoCloseInputStream(
 				new ByteArrayInputStream(pack200buffer.toByteArray())));

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/ClassCoverageImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/ClassCoverageImplTest.java
@@ -116,8 +116,7 @@ public class ClassCoverageImplTest {
 	private MethodCoverageImpl createMethod(boolean covered) {
 		final MethodCoverageImpl m = new MethodCoverageImpl("sample", "()V",
 				null);
-		m.increment(
-				covered ? CounterImpl.COUNTER_0_1 : CounterImpl.COUNTER_1_0,
+		m.increment(covered ? CounterImpl.COUNTER_0_1 : CounterImpl.COUNTER_1_0,
 				CounterImpl.COUNTER_0_0, ISourceNode.UNKNOWN_LINE);
 		m.incrementMethodCounter();
 		return m;

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodCoverageImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodCoverageImplTest.java
@@ -60,8 +60,8 @@ public class MethodCoverageImplTest {
 	@Test
 	public void testIncrementCoveredInstructions() {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
-		node.increment(CounterImpl.getInstance(12, 13),
-				CounterImpl.COUNTER_0_0, 3);
+		node.increment(CounterImpl.getInstance(12, 13), CounterImpl.COUNTER_0_0,
+				3);
 		node.incrementMethodCounter();
 		assertEquals(CounterImpl.COUNTER_0_1, node.getMethodCounter());
 		assertEquals(CounterImpl.COUNTER_0_1, node.getComplexityCounter());
@@ -79,7 +79,8 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(2, 0),
 				3);
-		assertEquals(CounterImpl.getInstance(1, 0), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(1, 0),
+				node.getComplexityCounter());
 	}
 
 	@Test
@@ -87,7 +88,8 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(1, 1),
 				3);
-		assertEquals(CounterImpl.getInstance(1, 0), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(1, 0),
+				node.getComplexityCounter());
 	}
 
 	@Test
@@ -95,7 +97,8 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(0, 2),
 				3);
-		assertEquals(CounterImpl.getInstance(0, 1), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(0, 1),
+				node.getComplexityCounter());
 	}
 
 	@Test
@@ -103,7 +106,8 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(3, 0),
 				3);
-		assertEquals(CounterImpl.getInstance(2, 0), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(2, 0),
+				node.getComplexityCounter());
 	}
 
 	@Test
@@ -111,7 +115,8 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(2, 1),
 				3);
-		assertEquals(CounterImpl.getInstance(2, 0), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(2, 0),
+				node.getComplexityCounter());
 	}
 
 	@Test
@@ -119,7 +124,8 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(1, 2),
 				3);
-		assertEquals(CounterImpl.getInstance(1, 1), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(1, 1),
+				node.getComplexityCounter());
 	}
 
 	@Test
@@ -127,6 +133,7 @@ public class MethodCoverageImplTest {
 		MethodCoverageImpl node = new MethodCoverageImpl("sample", "()V", null);
 		node.increment(CounterImpl.COUNTER_0_0, CounterImpl.getInstance(0, 3),
 				3);
-		assertEquals(CounterImpl.getInstance(0, 2), node.getComplexityCounter());
+		assertEquals(CounterImpl.getInstance(0, 2),
+				node.getComplexityCounter());
 	}
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/PackageCoverageTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/PackageCoverageTest.java
@@ -29,12 +29,12 @@ public class PackageCoverageTest {
 
 	@Test
 	public void testProperties() {
-		Collection<IClassCoverage> classes = Collections
-				.singleton((IClassCoverage) new ClassCoverageImpl(
-						"org/jacoco/test/Sample", 0, false));
-		Collection<ISourceFileCoverage> sourceFiles = Collections
-				.singleton((ISourceFileCoverage) new SourceFileCoverageImpl(
-						"Sample.java", "org/jacoco/test/Sample"));
+		Collection<IClassCoverage> classes = Collections.singleton(
+				(IClassCoverage) new ClassCoverageImpl("org/jacoco/test/Sample",
+						0, false));
+		Collection<ISourceFileCoverage> sourceFiles = Collections.singleton(
+				(ISourceFileCoverage) new SourceFileCoverageImpl("Sample.java",
+						"org/jacoco/test/Sample"));
 		PackageCoverageImpl data = new PackageCoverageImpl("org/jacoco/test",
 				classes, sourceFiles);
 		assertEquals(ICoverageNode.ElementType.PACKAGE, data.getElementType());

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/SourceNodeImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/SourceNodeImplTest.java
@@ -25,7 +25,8 @@ public class SourceNodeImplTest {
 
 	@Test
 	public void testInit() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		assertEquals(ElementType.CLASS, node.getElementType());
 		assertEquals("Foo", node.getName());
 		assertEquals(ISourceNode.UNKNOWN_LINE, node.getFirstLine());
@@ -35,7 +36,8 @@ public class SourceNodeImplTest {
 
 	@Test
 	public void testGetLine() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		node.ensureCapacity(10, 20);
 		assertEquals(LineImpl.EMPTY, node.getLine(5));
 		assertEquals(LineImpl.EMPTY, node.getLine(15));
@@ -44,21 +46,24 @@ public class SourceNodeImplTest {
 
 	@Test
 	public void testEnsureCapacityUnknown1() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		node.ensureCapacity(10, ISourceNode.UNKNOWN_LINE);
 		assertEquals(LineImpl.EMPTY, node.getLine(10));
 	}
 
 	@Test
 	public void testEnsureCapacityUnknown2() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		node.ensureCapacity(ISourceNode.UNKNOWN_LINE, 10);
 		assertEquals(LineImpl.EMPTY, node.getLine(10));
 	}
 
 	@Test
 	public void testIncrementLineUnknown() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		node.increment(CounterImpl.getInstance(1, 2),
 				CounterImpl.getInstance(3, 4), ISourceNode.UNKNOWN_LINE);
 		assertEquals(CounterImpl.getInstance(1, 2),
@@ -69,18 +74,19 @@ public class SourceNodeImplTest {
 
 	@Test
 	public void testIncrementLines() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		node.increment(CounterImpl.getInstance(1, 1), CounterImpl.COUNTER_0_0,
 				10);
 		node.increment(CounterImpl.getInstance(2, 2), CounterImpl.COUNTER_0_0,
 				12);
 
-		assertEquals(CounterImpl.getInstance(1, 1), node.getLine(10)
-				.getInstructionCounter());
-		assertEquals(CounterImpl.COUNTER_0_0, node.getLine(11)
-				.getInstructionCounter());
-		assertEquals(CounterImpl.getInstance(2, 2), node.getLine(12)
-				.getInstructionCounter());
+		assertEquals(CounterImpl.getInstance(1, 1),
+				node.getLine(10).getInstructionCounter());
+		assertEquals(CounterImpl.COUNTER_0_0,
+				node.getLine(11).getInstructionCounter());
+		assertEquals(CounterImpl.getInstance(2, 2),
+				node.getLine(12).getInstructionCounter());
 	}
 
 	@Test
@@ -165,20 +171,22 @@ public class SourceNodeImplTest {
 
 	private void testIncrementLine(int mi1, int ci1, int mi2, int ci2,
 			int expectedMissedLines, int expectedCoveredLines) {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		node.increment(CounterImpl.getInstance(mi1, ci1),
 				CounterImpl.COUNTER_0_0, 33);
 		node.increment(CounterImpl.getInstance(mi2, ci2),
 				CounterImpl.COUNTER_0_0, 33);
 		assertEquals(CounterImpl.getInstance(expectedMissedLines,
 				expectedCoveredLines), node.getLineCounter());
-		assertEquals(CounterImpl.getInstance(mi1 + mi2, ci1 + ci2), node
-				.getLine(33).getInstructionCounter());
+		assertEquals(CounterImpl.getInstance(mi1 + mi2, ci1 + ci2),
+				node.getLine(33).getInstructionCounter());
 	}
 
 	@Test
 	public void testIncrementChildNoLines() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 		final SourceNodeImpl child = new SourceNodeImpl(ElementType.CLASS,
 				"Foo") {
 			{
@@ -198,7 +206,8 @@ public class SourceNodeImplTest {
 
 	@Test
 	public void testIncrementChildWithLines() {
-		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS, "Foo");
+		final SourceNodeImpl node = new SourceNodeImpl(ElementType.CLASS,
+				"Foo");
 
 		final SourceNodeImpl child = new SourceNodeImpl(ElementType.CLASS,
 				"Foo");

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/EnumEmptyConstructorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/EnumEmptyConstructorFilterTest.java
@@ -39,7 +39,8 @@ public class EnumEmptyConstructorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(m.instructions.getFirst(), m.instructions.getLast()));
+		assertIgnored(
+				new Range(m.instructions.getFirst(), m.instructions.getLast()));
 	}
 
 	/**

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SynchronizedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SynchronizedFilterTest.java
@@ -153,7 +153,7 @@ public class SynchronizedFilterTest extends FilterTestBase {
 		filter.filter(m, context, output);
 
 		assertIgnored(new Range((LabelNode) handler.info,
-			((LabelNode) exit.info).getPrevious()));
+				((LabelNode) exit.info).getPrevious()));
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesJavac11FilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesJavac11FilterTest.java
@@ -50,8 +50,8 @@ public class TryWithResourcesJavac11FilterTest extends FilterTestBase {
 
 		m.visitVarInsn(Opcodes.ALOAD, 0);
 		range1.fromInclusive = m.instructions.getLast();
-		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close",
-			"()V", false);
+		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close", "()V",
+				false);
 		m.visitJumpInsn(Opcodes.GOTO, e);
 		range1.toInclusive = m.instructions.getLast();
 
@@ -59,15 +59,15 @@ public class TryWithResourcesJavac11FilterTest extends FilterTestBase {
 		range2.fromInclusive = m.instructions.getLast();
 		m.visitVarInsn(Opcodes.ASTORE, 1);
 		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close",
-			"()V", false);
+		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close", "()V",
+				false);
 		m.visitJumpInsn(Opcodes.GOTO, t);
 
 		m.visitVarInsn(Opcodes.ASTORE, 2);
 		m.visitVarInsn(Opcodes.ALOAD, 1);
 		m.visitVarInsn(Opcodes.ALOAD, 2);
 		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/Throwable",
-			"addSuppressed", "(Ljava/lang/Throwable;)V", false);
+				"addSuppressed", "(Ljava/lang/Throwable;)V", false);
 		m.visitLabel(t);
 		m.visitVarInsn(Opcodes.ALOAD, 1);
 		m.visitInsn(Opcodes.ATHROW);
@@ -104,8 +104,8 @@ public class TryWithResourcesJavac11FilterTest extends FilterTestBase {
 		range1.fromInclusive = m.instructions.getLast();
 		m.visitJumpInsn(Opcodes.IFNULL, e);
 		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close",
-				"()V", false);
+		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close", "()V",
+				false);
 		m.visitJumpInsn(Opcodes.GOTO, e);
 		range1.toInclusive = m.instructions.getLast();
 
@@ -115,8 +115,8 @@ public class TryWithResourcesJavac11FilterTest extends FilterTestBase {
 		m.visitVarInsn(Opcodes.ALOAD, 0);
 		m.visitJumpInsn(Opcodes.IFNULL, t);
 		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close",
-				"()V", false);
+		m.visitMethodInsn(Opcodes.INVOKEINTERFACE, "Resource", "close", "()V",
+				false);
 		m.visitJumpInsn(Opcodes.GOTO, t);
 
 		m.visitVarInsn(Opcodes.ASTORE, 2);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/data/CRC64Test.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/data/CRC64Test.java
@@ -77,9 +77,9 @@ public class CRC64Test {
 	 */
 	@Test
 	public void test2() {
-		final long sum = CRC64.classId(new byte[] { (byte) 0xff, (byte) 0xff,
-				(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
-				(byte) 0xff, (byte) 0xff });
+		final long sum = CRC64.classId(
+				new byte[] { (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+						(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff });
 		assertEquals(0x5300000000000000L, sum);
 	}
 
@@ -90,8 +90,8 @@ public class CRC64Test {
 	 */
 	@Test
 	public void test3() throws UnsupportedEncodingException {
-		final long sum = CRC64.classId("JACOCO_JACOCO_JACOCO_JACOCO"
-				.getBytes("ASCII"));
+		final long sum = CRC64
+				.classId("JACOCO_JACOCO_JACOCO_JACOCO".getBytes("ASCII"));
 		assertEquals(0xD8016B38AAD48308L, sum);
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/ClassProbesAdapterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/ClassProbesAdapterTest.java
@@ -32,14 +32,14 @@ public class ClassProbesAdapterTest {
 		boolean frame = false;
 
 		@Override
-		public void visitJumpInsnWithProbe(int opcode, Label label,
-				int probeId, IFrame frame) {
+		public void visitJumpInsnWithProbe(int opcode, Label label, int probeId,
+				IFrame frame) {
 			frame.accept(this);
 		}
 
 		@Override
-		public void visitTableSwitchInsnWithProbes(int min, int max,
-				Label dflt, Label[] labels, IFrame frame) {
+		public void visitTableSwitchInsnWithProbes(int min, int max, Label dflt,
+				Label[] labels, IFrame frame) {
 			frame.accept(this);
 		}
 
@@ -50,8 +50,8 @@ public class ClassProbesAdapterTest {
 		}
 
 		@Override
-		public void visitFrame(int type, int nLocal, Object[] local,
-				int nStack, Object[] stack) {
+		public void visitFrame(int type, int nLocal, Object[] local, int nStack,
+				Object[] stack) {
 			frame = true;
 		}
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
@@ -128,8 +128,8 @@ public class LabelFlowAnalyzerTest {
 	public void testFlowScenario11() {
 		// Even if the same label is referenced multiple times but from the same
 		// source instruction this is only counted as one target.
-		analyzer.visitLookupSwitchInsn(label, new int[] { 0, 1 }, new Label[] {
-				label, label });
+		analyzer.visitLookupSwitchInsn(label, new int[] { 0, 1 },
+				new Label[] { label, label });
 		assertFalse(LabelInfo.isMultiTarget(label));
 		assertFalse(LabelInfo.isSuccessor(label));
 	}
@@ -138,7 +138,8 @@ public class LabelFlowAnalyzerTest {
 	public void testFlowScenario12() {
 		// Even if the same label is referenced multiple times but from the same
 		// source instruction this is only counted as one target.
-		analyzer.visitTableSwitchInsn(0, 1, label, new Label[] { label, label });
+		analyzer.visitTableSwitchInsn(0, 1, label,
+				new Label[] { label, label });
 		assertFalse(LabelInfo.isMultiTarget(label));
 		assertFalse(LabelInfo.isSuccessor(label));
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodProbesAdapterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodProbesAdapterTest.java
@@ -64,16 +64,16 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		}
 
 		@Override
-		public void visitJumpInsnWithProbe(int opcode, Label label,
-				int probeId, IFrame frame) {
+		public void visitJumpInsnWithProbe(int opcode, Label label, int probeId,
+				IFrame frame) {
 			rec("visitJumpInsnWithProbe", Integer.valueOf(opcode), label,
 					Integer.valueOf(probeId));
 			frame.accept(this);
 		}
 
 		@Override
-		public void visitTableSwitchInsnWithProbes(int min, int max,
-				Label dflt, Label[] labels, IFrame frame) {
+		public void visitTableSwitchInsnWithProbes(int min, int max, Label dflt,
+				Label[] labels, IFrame frame) {
 			rec("visitTableSwitchInsnWithProbes", Integer.valueOf(min),
 					Integer.valueOf(max), dflt, labels);
 			frame.accept(this);
@@ -171,10 +171,10 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 
 		adapter.visitJumpInsn(Opcodes.GOTO, label);
 
-		expectedVisitor
-				.visitJumpInsnWithProbe(Opcodes.GOTO, label, 1000, frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitJumpInsnWithProbe(Opcodes.GOTO, label, 1000,
+				frame);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 	}
 
 	@Test
@@ -186,10 +186,10 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		adapter.visitJumpInsn(Opcodes.IFLT, label);
 
 		expectedVisitor.visitInsn(Opcodes.ICONST_0);
-		expectedVisitor
-				.visitJumpInsnWithProbe(Opcodes.IFLT, label, 1000, frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitJumpInsnWithProbe(Opcodes.IFLT, label, 1000,
+				frame);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 	}
 
 	@Test
@@ -214,8 +214,8 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		expectedVisitor.visitInsn(Opcodes.ICONST_0);
 		expectedVisitor.visitJumpInsnWithProbe(Opcodes.IF_ICMPEQ, label, 1000,
 				frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 	}
 
 	@Test
@@ -231,8 +231,8 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		expectedVisitor.visitInsn(Opcodes.ICONST_0);
 		expectedVisitor.visitLookupSwitchInsnWithProbes(label, keys, labels,
 				frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 		assertEquals(1000, LabelInfo.getProbeId(label));
 	}
 
@@ -250,8 +250,8 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		expectedVisitor.visitInsn(Opcodes.ICONST_0);
 		expectedVisitor.visitLookupSwitchInsnWithProbes(label, keys, labels,
 				frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 		assertEquals(LabelInfo.NO_PROBE, LabelInfo.getProbeId(label));
 		assertEquals(1000, LabelInfo.getProbeId(label2));
 	}
@@ -279,8 +279,8 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		expectedVisitor.visitInsn(Opcodes.ICONST_0);
 		expectedVisitor.visitTableSwitchInsnWithProbes(0, 1, label, labels,
 				frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 		assertEquals(1000, LabelInfo.getProbeId(label));
 	}
 
@@ -297,8 +297,8 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 		expectedVisitor.visitInsn(Opcodes.ICONST_0);
 		expectedVisitor.visitTableSwitchInsnWithProbes(0, 1, label, labels,
 				frame);
-		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" },
-				0, null);
+		expectedVisitor.visitFrame(Opcodes.F_FULL, 1, new Object[] { "Foo" }, 0,
+				null);
 		assertEquals(LabelInfo.NO_PROBE, LabelInfo.getProbeId(label));
 		assertEquals(1000, LabelInfo.getProbeId(label2));
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassInstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassInstrumenterTest.java
@@ -28,9 +28,9 @@ public class ClassInstrumenterTest implements IProbeArrayStrategy {
 
 	@Before
 	public void setup() {
-		instrumenter = new ClassInstrumenter(this, new ClassVisitor(
-				InstrSupport.ASM_API_VERSION) {
-		});
+		instrumenter = new ClassInstrumenter(this,
+				new ClassVisitor(InstrSupport.ASM_API_VERSION) {
+				});
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -49,14 +49,15 @@ public class ClassInstrumenterTest implements IProbeArrayStrategy {
 
 	@Test
 	public void testNoMethodVisitor() {
-		instrumenter = new ClassInstrumenter(this, new ClassVisitor(
-				InstrSupport.ASM_API_VERSION) {
-			@Override
-			public MethodVisitor visitMethod(int access, String name,
-					String desc, String signature, String[] exceptions) {
-				return null;
-			}
-		});
+		instrumenter = new ClassInstrumenter(this,
+				new ClassVisitor(InstrSupport.ASM_API_VERSION) {
+					@Override
+					public MethodVisitor visitMethod(int access, String name,
+							String desc, String signature,
+							String[] exceptions) {
+						return null;
+					}
+				});
 		assertNull(instrumenter.visitMethod(0, "foo", "()V", null, null));
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/DuplicateFrameEliminatorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/DuplicateFrameEliminatorTest.java
@@ -83,14 +83,14 @@ public class DuplicateFrameEliminatorTest {
 
 	@Test
 	public void testTypeInsn() {
-		testInstructionBetweenFrames(new TypeInsnNode(Opcodes.NEW,
-				"java/lang/Object"));
+		testInstructionBetweenFrames(
+				new TypeInsnNode(Opcodes.NEW, "java/lang/Object"));
 	}
 
 	@Test
 	public void testFieldInsn() {
-		testInstructionBetweenFrames(new FieldInsnNode(Opcodes.GETFIELD, "Foo",
-				"f", "I"));
+		testInstructionBetweenFrames(
+				new FieldInsnNode(Opcodes.GETFIELD, "Foo", "f", "I"));
 	}
 
 	@Test
@@ -107,8 +107,8 @@ public class DuplicateFrameEliminatorTest {
 
 	@Test
 	public void testJumpInsn() {
-		testInstructionBetweenFrames(new JumpInsnNode(Opcodes.GOTO,
-				new LabelNode()));
+		testInstructionBetweenFrames(
+				new JumpInsnNode(Opcodes.GOTO, new LabelNode()));
 	}
 
 	@Test
@@ -135,8 +135,8 @@ public class DuplicateFrameEliminatorTest {
 
 	@Test
 	public void testMultiANewArrayInsn() {
-		testInstructionBetweenFrames(new MultiANewArrayInsnNode(
-				"java/lang/String", 4));
+		testInstructionBetweenFrames(
+				new MultiANewArrayInsnNode("java/lang/String", 4));
 	}
 
 	private void testInstructionBetweenFrames(AbstractInsnNode node) {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/MethodInstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/MethodInstrumenterTest.java
@@ -196,8 +196,8 @@ public class MethodInstrumenterTest {
 		final Label L2 = new Label();
 		LabelInfo.setProbeId(L0, 0);
 		LabelInfo.setProbeId(L1, 1);
-		instrumenter.visitTableSwitchInsnWithProbes(3, 5, L0, new Label[] { L1,
-				L1, L2 }, frame);
+		instrumenter.visitTableSwitchInsnWithProbes(3, 5, L0,
+				new Label[] { L1, L1, L2 }, frame);
 
 		expectedVisitor.visitTableSwitchInsn(3, 4, L0,
 				new Label[] { L1, L1, L2 });

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
@@ -42,7 +42,8 @@ public class ProbeInserterTest {
 		expected = new MethodRecorder();
 		expectedVisitor = expected.getVisitor();
 		arrayStrategy = new IProbeArrayStrategy() {
-			public int storeInstance(MethodVisitor mv, boolean clinit, int variable) {
+			public int storeInstance(MethodVisitor mv, boolean clinit,
+					int variable) {
 				mv.visitLdcInsn(clinit ? "clinit" : "init");
 				return 5;
 			}
@@ -234,11 +235,13 @@ public class ProbeInserterTest {
 		ProbeInserter pi = new ProbeInserter(0, "m", "(J)V", actualVisitor,
 				arrayStrategy);
 
-		pi.visitFrame(Opcodes.F_NEW, 3, new Object[] { "Foo", Opcodes.LONG,
-				"java/lang/String" }, 0, new Object[0]);
+		pi.visitFrame(Opcodes.F_NEW, 3,
+				new Object[] { "Foo", Opcodes.LONG, "java/lang/String" }, 0,
+				new Object[0]);
 
-		expectedVisitor.visitFrame(Opcodes.F_NEW, 4, new Object[] { "Foo",
-				Opcodes.LONG, "[Z", "java/lang/String" }, 0, new Object[0]);
+		expectedVisitor.visitFrame(Opcodes.F_NEW, 4,
+				new Object[] { "Foo", Opcodes.LONG, "[Z", "java/lang/String" },
+				0, new Object[0]);
 	}
 
 	@Test
@@ -260,8 +263,8 @@ public class ProbeInserterTest {
 		pi.visitFrame(Opcodes.F_NEW, 2, new Object[] { Opcodes.DOUBLE, "Foo" },
 				0, new Object[0]);
 
-		expectedVisitor.visitFrame(Opcodes.F_NEW, 3, new Object[] { "[Z",
-				Opcodes.DOUBLE, "Foo" }, 0, new Object[0]);
+		expectedVisitor.visitFrame(Opcodes.F_NEW, 3,
+				new Object[] { "[Z", Opcodes.DOUBLE, "Foo" }, 0, new Object[0]);
 	}
 
 	@Test
@@ -272,8 +275,8 @@ public class ProbeInserterTest {
 		pi.visitFrame(Opcodes.F_NEW, 0, new Object[] {}, 0, new Object[] {});
 
 		// The locals in this frame are filled with TOP up to the probe variable
-		expectedVisitor.visitFrame(Opcodes.F_NEW, 2, new Object[] {
-				Opcodes.TOP, "[Z", }, 0, new Object[] {});
+		expectedVisitor.visitFrame(Opcodes.F_NEW, 2,
+				new Object[] { Opcodes.TOP, "[Z", }, 0, new Object[] {});
 	}
 
 	@Test
@@ -284,8 +287,9 @@ public class ProbeInserterTest {
 		pi.visitFrame(Opcodes.F_NEW, 0, new Object[] {}, 0, new Object[] {});
 
 		// The locals in this frame are filled with TOP up to the probe variable
-		expectedVisitor.visitFrame(Opcodes.F_NEW, 3, new Object[] {
-				Opcodes.TOP, Opcodes.TOP, "[Z", }, 0, new Object[] {});
+		expectedVisitor.visitFrame(Opcodes.F_NEW, 3,
+				new Object[] { Opcodes.TOP, Opcodes.TOP, "[Z", }, 0,
+				new Object[] {});
 	}
 
 	@Test
@@ -297,9 +301,11 @@ public class ProbeInserterTest {
 				new Object[] {});
 
 		// The locals in this frame are filled with TOP up to the probe variable
-		expectedVisitor.visitFrame(Opcodes.F_NEW, 5, new Object[] {
-				Opcodes.DOUBLE, Opcodes.TOP, Opcodes.TOP, Opcodes.TOP, "[Z", },
-				0, new Object[] {});
+		expectedVisitor
+				.visitFrame(
+						Opcodes.F_NEW, 5, new Object[] { Opcodes.DOUBLE,
+								Opcodes.TOP, Opcodes.TOP, Opcodes.TOP, "[Z", },
+						0, new Object[] {});
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/SignatureRemoverTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/SignatureRemoverTest.java
@@ -112,14 +112,12 @@ public class SignatureRemoverTest {
 				+ "Name: org/jacoco/example/B.class\r\n" //
 				+ "OtherInfo: keep this\r\n" //
 				+ "\r\n";
-		assertEquals(
-				createManifest(expected.getBytes("ISO-8859-1")),
+		assertEquals(createManifest(expected.getBytes("ISO-8859-1")),
 				createManifest(out.toByteArray()));
 	}
 
 	private static Manifest createManifest(final byte[] bytes)
 			throws IOException {
-		return new Manifest(
-				new ByteArrayInputStream(bytes));
+		return new Manifest(new ByteArrayInputStream(bytes));
 	}
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
@@ -93,7 +93,8 @@ public class AgentOptionsTest {
 		assertFalse(options.getAppend());
 		assertEquals("org.*:com.*", options.getIncludes());
 		assertEquals("*Test", options.getExcludes());
-		assertEquals("org.jacoco.test.TestLoader", options.getExclClassloader());
+		assertEquals("org.jacoco.test.TestLoader",
+				options.getExclClassloader());
 		assertTrue(options.getInclBootstrapClasses());
 		assertTrue(options.getInclNoLocationClasses());
 		assertEquals("testsession", options.getSessionId());
@@ -157,14 +158,16 @@ public class AgentOptionsTest {
 	public void testGetExclClassloader() {
 		AgentOptions options = new AgentOptions(
 				"exclclassloader=org.jacoco.test.TestLoader");
-		assertEquals("org.jacoco.test.TestLoader", options.getExclClassloader());
+		assertEquals("org.jacoco.test.TestLoader",
+				options.getExclClassloader());
 	}
 
 	@Test
 	public void testSetExclClassloader() {
 		AgentOptions options = new AgentOptions();
 		options.setExclClassloader("org.jacoco.test.TestLoader");
-		assertEquals("org.jacoco.test.TestLoader", options.getExclClassloader());
+		assertEquals("org.jacoco.test.TestLoader",
+				options.getExclClassloader());
 		assertEquals("exclclassloader=org.jacoco.test.TestLoader",
 				options.toString());
 	}
@@ -415,9 +418,8 @@ public class AgentOptionsTest {
 
 		String vmArgument = options.getVMArgument(defaultAgentJarFile);
 
-		assertEquals(
-				String.format("-javaagent:%s=append=true",
-						defaultAgentJarFile.toString()), vmArgument);
+		assertEquals(String.format("-javaagent:%s=append=true",
+				defaultAgentJarFile.toString()), vmArgument);
 	}
 
 	@Test
@@ -450,22 +452,21 @@ public class AgentOptionsTest {
 		String vmArgument = options.prependVMArguments("a b c",
 				defaultAgentJarFile);
 
-		assertEquals(
-				String.format("-javaagent:%s= a b c",
-						defaultAgentJarFile.toString()), vmArgument);
+		assertEquals(String.format("-javaagent:%s= a b c",
+				defaultAgentJarFile.toString()), vmArgument);
 	}
 
 	@Test
 	public void testPrependVMArgumentsReplace() {
 		AgentOptions options = new AgentOptions();
 
-		String vmArgument = options.prependVMArguments(String.format(
-				"a b -javaagent:%s=append=false c", defaultAgentJarFile),
+		String vmArgument = options.prependVMArguments(
+				String.format("a b -javaagent:%s=append=false c",
+						defaultAgentJarFile),
 				defaultAgentJarFile);
 
-		assertEquals(
-				String.format("-javaagent:%s= a b c",
-						defaultAgentJarFile.toString()), vmArgument);
+		assertEquals(String.format("-javaagent:%s= a b c",
+				defaultAgentJarFile.toString()), vmArgument);
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/ModifiedSystemClassRuntimeTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/ModifiedSystemClassRuntimeTest.java
@@ -57,8 +57,9 @@ public class ModifiedSystemClassRuntimeTest extends RuntimeTestBase {
 	 * "java.lang.reflect.Module" introduced in JDK 9.
 	 */
 	private Instrumentation newInstrumentationMock() {
-		return (Instrumentation) Proxy.newProxyInstance(getClass()
-				.getClassLoader(), new Class[] { Instrumentation.class },
+		return (Instrumentation) Proxy.newProxyInstance(
+				getClass().getClassLoader(),
+				new Class[] { Instrumentation.class },
 				new MyInvocationHandler());
 	}
 
@@ -75,8 +76,8 @@ public class ModifiedSystemClassRuntimeTest extends RuntimeTestBase {
 			added = true;
 			try {
 				// Our class should get instrumented:
-				final byte[] data = TargetLoader
-						.getClassDataAsBytes(ModifiedSystemClassRuntimeTest.class);
+				final byte[] data = TargetLoader.getClassDataAsBytes(
+						ModifiedSystemClassRuntimeTest.class);
 				verifyInstrumentedClass(TARGET_CLASS_NAME,
 						transformer.transform((ClassLoader) null,
 								TARGET_CLASS_NAME, null, null, data));

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/OfflineInstrumentationAccessGeneratorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/OfflineInstrumentationAccessGeneratorTest.java
@@ -100,13 +100,14 @@ public class OfflineInstrumentationAccessGeneratorTest {
 				null);
 
 		// Constructor
-		GeneratorAdapter gen = new GeneratorAdapter(writer.visitMethod(
-				Opcodes.ACC_PUBLIC, "<init>", "()V", null, new String[0]),
+		GeneratorAdapter gen = new GeneratorAdapter(
+				writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null,
+						new String[0]),
 				Opcodes.ACC_PUBLIC, "<init>", "()V");
 		gen.visitCode();
 		gen.loadThis();
-		gen.invokeConstructor(Type.getType(Object.class), new Method("<init>",
-				"()V"));
+		gen.invokeConstructor(Type.getType(Object.class),
+				new Method("<init>", "()V"));
 		gen.loadThis();
 		final int size = generator.generateDataAccessor(classid, className, 2,
 				gen);
@@ -117,8 +118,8 @@ public class OfflineInstrumentationAccessGeneratorTest {
 		gen.visitEnd();
 
 		// get()
-		gen = new GeneratorAdapter(writer.visitMethod(Opcodes.ACC_PUBLIC,
-				"get", "()[Z", null, new String[0]), Opcodes.ACC_PUBLIC, "get",
+		gen = new GeneratorAdapter(writer.visitMethod(Opcodes.ACC_PUBLIC, "get",
+				"()[Z", null, new String[0]), Opcodes.ACC_PUBLIC, "get",
 				"()[Z");
 		gen.visitCode();
 		gen.getStatic(classType, InstrSupport.DATAFIELD_NAME,
@@ -130,8 +131,9 @@ public class OfflineInstrumentationAccessGeneratorTest {
 		writer.visitEnd();
 
 		final TargetLoader loader = new TargetLoader();
-		return (ITarget) loader.add(className.replace('/', '.'),
-				writer.toByteArray()).newInstance();
+		return (ITarget) loader
+				.add(className.replace('/', '.'), writer.toByteArray())
+				.newInstance();
 	}
 
 	/**

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/RemoteControlReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/RemoteControlReaderWriterTest.java
@@ -31,8 +31,8 @@ import org.junit.Test;
  * The tests don't care about the written binary format, they just verify
  * symmetry.
  */
-public class RemoteControlReaderWriterTest extends
-		ExecutionDataReaderWriterTest {
+public class RemoteControlReaderWriterTest
+		extends ExecutionDataReaderWriterTest {
 
 	private RemoteControlWriter writer;
 
@@ -94,8 +94,8 @@ public class RemoteControlReaderWriterTest extends
 
 	@Override
 	protected RemoteControlReader createReader() throws IOException {
-		return new RemoteControlReader(new ByteArrayInputStream(
-				buffer.toByteArray()));
+		return new RemoteControlReader(
+				new ByteArrayInputStream(buffer.toByteArray()));
 	}
 
 	@Override

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/RuntimeDataTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/RuntimeDataTest.java
@@ -139,8 +139,8 @@ public class RuntimeDataTest {
 
 		writer.visitEnd();
 		final TargetLoader loader = new TargetLoader();
-		Callable<?> callable = (Callable<?>) loader.add("Sample",
-				writer.toByteArray()).newInstance();
+		Callable<?> callable = (Callable<?>) loader
+				.add("Sample", writer.toByteArray()).newInstance();
 		final Object[] args = (Object[]) callable.call();
 		assertEquals(3, args.length, 0.0);
 		assertEquals(Long.valueOf(1000), args[0]);
@@ -150,8 +150,8 @@ public class RuntimeDataTest {
 
 	@Test
 	public void testGenerateAccessCall() throws Exception {
-		final boolean[] probes = data.getExecutionData(Long.valueOf(1234),
-				"Sample", 5).getProbes();
+		final boolean[] probes = data
+				.getExecutionData(Long.valueOf(1234), "Sample", 5).getProbes();
 
 		final ClassWriter writer = new ClassWriter(0);
 		writer.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC, "Sample", null,

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/RuntimeTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/RuntimeTestBase.java
@@ -55,8 +55,8 @@ public abstract class RuntimeTestBase {
 	}
 
 	@Test
-	public void testDataAccessor() throws InstantiationException,
-			IllegalAccessException {
+	public void testDataAccessor()
+			throws InstantiationException, IllegalAccessException {
 		ITarget t = generateAndInstantiateClass(1234);
 		data.collect(storage, storage, false);
 		storage.assertData(1234, t.get());
@@ -65,18 +65,18 @@ public abstract class RuntimeTestBase {
 	@Test
 	public void testNoLocalVariablesInDataAccessor()
 			throws InstantiationException, IllegalAccessException {
-		runtime.generateDataAccessor(1001, "Target", 5, new MethodVisitor(
-				InstrSupport.ASM_API_VERSION) {
-			@Override
-			public void visitVarInsn(int opcode, int var) {
-				fail("No usage of local variables allowed.");
-			}
-		});
+		runtime.generateDataAccessor(1001, "Target", 5,
+				new MethodVisitor(InstrSupport.ASM_API_VERSION) {
+					@Override
+					public void visitVarInsn(int opcode, int var) {
+						fail("No usage of local variables allowed.");
+					}
+				});
 	}
 
 	@Test
-	public void testExecutionRecording() throws InstantiationException,
-			IllegalAccessException {
+	public void testExecutionRecording()
+			throws InstantiationException, IllegalAccessException {
 		generateAndInstantiateClass(1001).a();
 		data.collect(storage, storage, false);
 		storage.assertSize(1);
@@ -86,8 +86,8 @@ public abstract class RuntimeTestBase {
 	}
 
 	@Test
-	public void testLoadSameClassTwice() throws InstantiationException,
-			IllegalAccessException {
+	public void testLoadSameClassTwice()
+			throws InstantiationException, IllegalAccessException {
 		generateAndInstantiateClass(1001).a();
 		generateAndInstantiateClass(1001).b();
 		data.collect(storage, storage, false);
@@ -119,13 +119,14 @@ public abstract class RuntimeTestBase {
 				null);
 
 		// Constructor
-		GeneratorAdapter gen = new GeneratorAdapter(writer.visitMethod(
-				Opcodes.ACC_PUBLIC, "<init>", "()V", null, new String[0]),
+		GeneratorAdapter gen = new GeneratorAdapter(
+				writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null,
+						new String[0]),
 				Opcodes.ACC_PUBLIC, "<init>", "()V");
 		gen.visitCode();
 		gen.loadThis();
-		gen.invokeConstructor(Type.getType(Object.class), new Method("<init>",
-				"()V"));
+		gen.invokeConstructor(Type.getType(Object.class),
+				new Method("<init>", "()V"));
 		gen.loadThis();
 		final int size = runtime.generateDataAccessor(classid, className, 2,
 				gen);
@@ -136,8 +137,8 @@ public abstract class RuntimeTestBase {
 		gen.visitEnd();
 
 		// get()
-		gen = new GeneratorAdapter(writer.visitMethod(Opcodes.ACC_PUBLIC,
-				"get", "()[Z", null, new String[0]), Opcodes.ACC_PUBLIC, "get",
+		gen = new GeneratorAdapter(writer.visitMethod(Opcodes.ACC_PUBLIC, "get",
+				"()[Z", null, new String[0]), Opcodes.ACC_PUBLIC, "get",
 				"()[Z");
 		gen.visitCode();
 		gen.getStatic(classType, InstrSupport.DATAFIELD_NAME,
@@ -175,8 +176,9 @@ public abstract class RuntimeTestBase {
 		writer.visitEnd();
 
 		final TargetLoader loader = new TargetLoader();
-		return (ITarget) loader.add(className.replace('/', '.'),
-				writer.toByteArray()).newInstance();
+		return (ITarget) loader
+				.add(className.replace('/', '.'), writer.toByteArray())
+				.newInstance();
 	}
 
 	/**

--- a/org.jacoco.core.test/src/org/jacoco/core/test/TargetLoader.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/TargetLoader.java
@@ -62,7 +62,8 @@ public class TargetLoader extends ClassLoader {
 		return readBytes(getClassData(loader, name));
 	}
 
-	public static byte[] getClassDataAsBytes(Class<?> clazz) throws IOException {
+	public static byte[] getClassDataAsBytes(Class<?> clazz)
+			throws IOException {
 		return readBytes(getClassData(clazz));
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/InstrumentationTimeScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/InstrumentationTimeScenario.java
@@ -28,7 +28,8 @@ public class InstrumentationTimeScenario extends TimedScenario {
 	private final int count;
 
 	protected InstrumentationTimeScenario(Class<?> target, int count) {
-		super(String.format("instrumenting %s classes", Integer.valueOf(count)));
+		super(String.format("instrumenting %s classes",
+				Integer.valueOf(count)));
 		this.target = target;
 		this.count = count;
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/PerfOutputWriter.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/PerfOutputWriter.java
@@ -37,8 +37,10 @@ public class PerfOutputWriter implements IPerfOutput {
 				System.getProperty("java.vm.vendor"));
 		writer.printf("JVM Version:     %s%n%n",
 				System.getProperty("java.vm.version"));
-		writer.println("scenario                         instr     ref    overhead");
-		writer.println("----------------------------------------------------------");
+		writer.println(
+				"scenario                         instr     ref    overhead");
+		writer.println(
+				"----------------------------------------------------------");
 	}
 
 	public void writeTimeResult(final String description, final long duration,

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/StatementExecutorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/StatementExecutorTest.java
@@ -42,8 +42,8 @@ public class StatementExecutorTest {
 
 	@Test
 	public void should_prefix_arguments() {
-		StatementExecutor executor = new StatementExecutor(this,
-				"Hello", "world");
+		StatementExecutor executor = new StatementExecutor(this, "Hello",
+				"world");
 
 		executor.visitInvocation("ctx", "target1", "!");
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -132,7 +132,8 @@ public abstract class ValidationTestBase {
 		}
 		assertEquals(
 				"sum of missed instructions of all lines should be equal to missed instructions of file",
-				source.getCoverage().getInstructionCounter().getMissedCount(), c.getMissedCount());
+				source.getCoverage().getInstructionCounter().getMissedCount(),
+				c.getMissedCount());
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/tools/ExecFileLoaderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/tools/ExecFileLoaderTest.java
@@ -119,8 +119,8 @@ public class ExecFileLoaderTest {
 		final FileOutputStream out = new FileOutputStream(file);
 		final ExecutionDataWriter writer = new ExecutionDataWriter(out);
 		final int value = id.length();
-		writer.visitClassExecution(new ExecutionData(value, id,
-				new boolean[] { true }));
+		writer.visitClassExecution(
+				new ExecutionData(value, id, new boolean[] { true }));
 		writer.visitSessionInfo(new SessionInfo(id, value, value));
 		out.close();
 		return file;

--- a/org.jacoco.core/src/org/jacoco/core/analysis/CoverageNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/CoverageNodeImpl.java
@@ -69,12 +69,12 @@ public class CoverageNodeImpl implements ICoverageNode {
 	 *            counters to add
 	 */
 	public void increment(final ICoverageNode child) {
-		instructionCounter = instructionCounter.increment(child
-				.getInstructionCounter());
+		instructionCounter = instructionCounter
+				.increment(child.getInstructionCounter());
 		branchCounter = branchCounter.increment(child.getBranchCounter());
 		lineCounter = lineCounter.increment(child.getLineCounter());
-		complexityCounter = complexityCounter.increment(child
-				.getComplexityCounter());
+		complexityCounter = complexityCounter
+				.increment(child.getComplexityCounter());
 		methodCounter = methodCounter.increment(child.getMethodCounter());
 		classCounter = classCounter.increment(child.getClassCounter());
 	}

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
@@ -135,7 +135,8 @@ public interface ICoverageNode {
 	/**
 	 * Checks whether this node contains code relevant for code coverage.
 	 *
-	 * @return <code>true</code> if this node contains code relevant for code coverage
+	 * @return <code>true</code> if this node contains code relevant for code
+	 *         coverage
 	 */
 	boolean containsCode();
 

--- a/org.jacoco.core/src/org/jacoco/core/analysis/NodeComparator.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/NodeComparator.java
@@ -73,7 +73,8 @@ public class NodeComparator implements Comparator<ICoverageNode>, Serializable {
 	 *            collection to create a copy of
 	 * @return sorted copy
 	 */
-	public <T extends ICoverageNode> List<T> sort(final Collection<T> summaries) {
+	public <T extends ICoverageNode> List<T> sort(
+			final Collection<T> summaries) {
 		final List<T> result = new ArrayList<T>(summaries);
 		Collections.sort(result, this);
 		return result;

--- a/org.jacoco.core/src/org/jacoco/core/analysis/package-info.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/package-info.java
@@ -15,9 +15,8 @@
  * <p>
  * Coverage calculation and analysis. The coverage information is calculated
  * with an {@link org.jacoco.core.analysis.Analyzer} instance from class files
- * (target) and
- * {@linkplain org.jacoco.core.data.IExecutionDataVisitor execution data}
- * (actual).
+ * (target) and {@linkplain org.jacoco.core.data.IExecutionDataVisitor execution
+ * data} (actual).
  * </p>
  *
  * <p>

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
@@ -57,7 +57,8 @@ public final class ExecutionData {
 	 * @param probeCount
 	 *            probe count
 	 */
-	public ExecutionData(final long id, final String name, final int probeCount) {
+	public ExecutionData(final long id, final String name,
+			final int probeCount) {
 		this.id = id;
 		this.name = name;
 		this.probes = new boolean[probeCount];
@@ -183,14 +184,14 @@ public final class ExecutionData {
 	public void assertCompatibility(final long id, final String name,
 			final int probecount) throws IllegalStateException {
 		if (this.id != id) {
-			throw new IllegalStateException(format(
-					"Different ids (%016x and %016x).", Long.valueOf(this.id),
-					Long.valueOf(id)));
+			throw new IllegalStateException(
+					format("Different ids (%016x and %016x).",
+							Long.valueOf(this.id), Long.valueOf(id)));
 		}
 		if (!this.name.equals(name)) {
-			throw new IllegalStateException(format(
-					"Different class names %s and %s for id %016x.", this.name,
-					name, Long.valueOf(id)));
+			throw new IllegalStateException(
+					format("Different class names %s and %s for id %016x.",
+							this.name, name, Long.valueOf(id)));
 		}
 		if (this.probes.length != probecount) {
 			throw new IllegalStateException(format(

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
@@ -77,8 +77,8 @@ public class ExecutionDataReader {
 	 * @throws IncompatibleExecDataVersionException
 	 *             incompatible data version from different JaCoCo release
 	 */
-	public boolean read() throws IOException,
-			IncompatibleExecDataVersionException {
+	public boolean read()
+			throws IOException, IncompatibleExecDataVersionException {
 		byte type;
 		do {
 			int i = in.read();
@@ -116,8 +116,8 @@ public class ExecutionDataReader {
 			readExecutionData();
 			return true;
 		default:
-			throw new IOException(format("Unknown block type %x.",
-					Byte.valueOf(blocktype)));
+			throw new IOException(
+					format("Unknown block type %x.", Byte.valueOf(blocktype)));
 		}
 	}
 
@@ -148,8 +148,8 @@ public class ExecutionDataReader {
 		final long id = in.readLong();
 		final String name = in.readUTF();
 		final boolean[] probes = in.readBooleanArray();
-		executionDataVisitor.visitClassExecution(new ExecutionData(id, name,
-				probes));
+		executionDataVisitor
+				.visitClassExecution(new ExecutionData(id, name, probes));
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
@@ -69,7 +69,8 @@ public final class ExecutionDataStore implements IExecutionDataVisitor {
 	 *             to a corresponding one, that is already contained
 	 * @see ExecutionData#assertCompatibility(long, String, int)
 	 */
-	public void subtract(final ExecutionData data) throws IllegalStateException {
+	public void subtract(final ExecutionData data)
+			throws IllegalStateException {
 		final Long id = Long.valueOf(data.getId());
 		final ExecutionData entry = entries.get(id);
 		if (entry != null) {

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
@@ -21,10 +21,12 @@ import org.jacoco.core.internal.data.CompactDataOutput;
 /**
  * Serialization of execution data into binary streams.
  */
-public class ExecutionDataWriter implements ISessionInfoVisitor,
-		IExecutionDataVisitor {
+public class ExecutionDataWriter
+		implements ISessionInfoVisitor, IExecutionDataVisitor {
 
-	/** File format version, will be incremented for each incompatible change. */
+	/**
+	 * File format version, will be incremented for each incompatible change.
+	 */
 	public static final char FORMAT_VERSION;
 
 	static {

--- a/org.jacoco.core/src/org/jacoco/core/instr/package-info.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/package-info.java
@@ -13,8 +13,8 @@
 
 /**
  * <p>
- *  Instrumentation of Java class files for code coverage. The main entry point
- *  is the class {@link org.jacoco.core.instr.Instrumenter}.
+ * Instrumentation of Java class files for code coverage. The main entry point
+ * is the class {@link org.jacoco.core.instr.Instrumenter}.
  * </p>
  */
 package org.jacoco.core.instr;

--- a/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java
@@ -57,8 +57,8 @@ public final class Pack200Streams {
 	 */
 	public static void pack(final byte[] source, final OutputStream output)
 			throws IOException {
-		final JarInputStream jar = new JarInputStream(new ByteArrayInputStream(
-				source));
+		final JarInputStream jar = new JarInputStream(
+				new ByteArrayInputStream(source));
 		Pack200.newPacker().pack(jar, output);
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/BundleCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/BundleCoverageImpl.java
@@ -29,8 +29,8 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 /**
  * Implementation of {@link IBundleCoverage}.
  */
-public class BundleCoverageImpl extends CoverageNodeImpl implements
-		IBundleCoverage {
+public class BundleCoverageImpl extends CoverageNodeImpl
+		implements IBundleCoverage {
 
 	private final Collection<IPackageCoverage> packages;
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassCoverageImpl.java
@@ -21,7 +21,8 @@ import org.jacoco.core.analysis.IMethodCoverage;
 /**
  * Implementation of {@link IClassCoverage}.
  */
-public class ClassCoverageImpl extends SourceNodeImpl implements IClassCoverage {
+public class ClassCoverageImpl extends SourceNodeImpl
+		implements IClassCoverage {
 
 	private final long id;
 	private final boolean noMatch;

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/CounterImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/CounterImpl.java
@@ -23,7 +23,8 @@ public abstract class CounterImpl implements ICounter {
 	/** Max counter value for which singletons are created */
 	private static final int SINGLETON_LIMIT = 30;
 
-	private static final CounterImpl[][] SINGLETONS = new CounterImpl[SINGLETON_LIMIT + 1][];
+	private static final CounterImpl[][] SINGLETONS = new CounterImpl[SINGLETON_LIMIT
+			+ 1][];
 
 	static {
 		for (int i = 0; i <= SINGLETON_LIMIT; i++) {

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/LineImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/LineImpl.java
@@ -26,7 +26,8 @@ public abstract class LineImpl implements ILine {
 	/** Max branch counter value for which singletons are created */
 	private static final int SINGLETON_BRA_LIMIT = 4;
 
-	private static final LineImpl[][][][] SINGLETONS = new LineImpl[SINGLETON_INS_LIMIT + 1][][][];
+	private static final LineImpl[][][][] SINGLETONS = new LineImpl[SINGLETON_INS_LIMIT
+			+ 1][][][];
 
 	static {
 		for (int i = 0; i <= SINGLETON_INS_LIMIT; i++) {
@@ -83,8 +84,8 @@ public abstract class LineImpl implements ILine {
 	 */
 	private static final class Fix extends LineImpl {
 		public Fix(final int im, final int ic, final int bm, final int bc) {
-			super(CounterImpl.getInstance(im, ic), CounterImpl.getInstance(bm,
-					bc));
+			super(CounterImpl.getInstance(im, ic),
+					CounterImpl.getInstance(bm, bc));
 		}
 
 		@Override
@@ -101,7 +102,8 @@ public abstract class LineImpl implements ILine {
 	/** branch counter */
 	protected CounterImpl branches;
 
-	private LineImpl(final CounterImpl instructions, final CounterImpl branches) {
+	private LineImpl(final CounterImpl instructions,
+			final CounterImpl branches) {
 		this.instructions = instructions;
 		this.branches = branches;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageImpl.java
@@ -18,8 +18,8 @@ import org.jacoco.core.analysis.IMethodCoverage;
 /**
  * Implementation of {@link IMethodCoverage}.
  */
-public class MethodCoverageImpl extends SourceNodeImpl implements
-		IMethodCoverage {
+public class MethodCoverageImpl extends SourceNodeImpl
+		implements IMethodCoverage {
 
 	private final String desc;
 
@@ -59,7 +59,8 @@ public class MethodCoverageImpl extends SourceNodeImpl implements
 	 * branches have been incremented for this method coverage node.
 	 */
 	public void incrementMethodCounter() {
-		final ICounter base = this.instructionCounter.getCoveredCount() == 0 ? CounterImpl.COUNTER_1_0
+		final ICounter base = this.instructionCounter.getCoveredCount() == 0
+				? CounterImpl.COUNTER_1_0
 				: CounterImpl.COUNTER_0_1;
 		this.methodCounter = this.methodCounter.increment(base);
 		this.complexityCounter = this.complexityCounter.increment(base);

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/PackageCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/PackageCoverageImpl.java
@@ -22,8 +22,8 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 /**
  * Implementation of {@link IPackageCoverage}.
  */
-public class PackageCoverageImpl extends CoverageNodeImpl implements
-		IPackageCoverage {
+public class PackageCoverageImpl extends CoverageNodeImpl
+		implements IPackageCoverage {
 
 	private final Collection<IClassCoverage> classes;
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceFileCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceFileCoverageImpl.java
@@ -17,8 +17,8 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 /**
  * Implementation of {@link ISourceFileCoverage}.
  */
-public class SourceFileCoverageImpl extends SourceNodeImpl implements
-		ISourceFileCoverage {
+public class SourceFileCoverageImpl extends SourceNodeImpl
+		implements ISourceFileCoverage {
 
 	private final String packagename;
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
@@ -81,11 +81,11 @@ public class SourceNodeImpl extends CoverageNodeImpl implements ISourceNode {
 	 *            child node to add
 	 */
 	public void increment(final ISourceNode child) {
-		instructionCounter = instructionCounter.increment(child
-				.getInstructionCounter());
+		instructionCounter = instructionCounter
+				.increment(child.getInstructionCounter());
 		branchCounter = branchCounter.increment(child.getBranchCounter());
-		complexityCounter = complexityCounter.increment(child
-				.getComplexityCounter());
+		complexityCounter = complexityCounter
+				.increment(child.getComplexityCounter());
 		methodCounter = methodCounter.increment(child.getMethodCounter());
 		classCounter = classCounter.increment(child.getClassCounter());
 		final int firstLine = child.getFirstLine();

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesAdapter.java
@@ -21,8 +21,8 @@ import org.objectweb.asm.commons.AnalyzerAdapter;
  * A {@link org.objectweb.asm.ClassVisitor} that calculates probes for every
  * method.
  */
-public class ClassProbesAdapter extends ClassVisitor implements
-		IProbeIdGenerator {
+public class ClassProbesAdapter extends ClassVisitor
+		implements IProbeIdGenerator {
 
 	private static final MethodProbesVisitor EMPTY_METHOD_PROBES_VISITOR = new MethodProbesVisitor() {
 	};
@@ -60,7 +60,8 @@ public class ClassProbesAdapter extends ClassVisitor implements
 
 	@Override
 	public final MethodVisitor visitMethod(final int access, final String name,
-			final String desc, final String signature, final String[] exceptions) {
+			final String desc, final String signature,
+			final String[] exceptions) {
 		final MethodProbesVisitor methodProbes;
 		final MethodProbesVisitor mv = cv.visitMethod(access, name, desc,
 				signature, exceptions);

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/FrameSnapshot.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/FrameSnapshot.java
@@ -59,7 +59,8 @@ class FrameSnapshot implements IFrame {
 	 * {@link MethodVisitor#visitFrame(int, int, Object[], int, Object[])}
 	 * method.
 	 */
-	private static Object[] reduce(final List<Object> source, final int popCount) {
+	private static Object[] reduce(final List<Object> source,
+			final int popCount) {
 		final List<Object> copy = new ArrayList<Object>(source);
 		final int size = source.size() - popCount;
 		copy.subList(size, source.size()).clear();

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
@@ -65,8 +65,8 @@ public final class MethodProbesAdapter extends MethodVisitor {
 	@Override
 	public void visitTryCatchBlock(final Label start, final Label end,
 			final Label handler, final String type) {
-		probesVisitor.visitTryCatchBlock(getTryCatchLabel(start), getTryCatchLabel(end),
-				handler, type);
+		probesVisitor.visitTryCatchBlock(getTryCatchLabel(start),
+				getTryCatchLabel(end), handler, type);
 	}
 
 	private Label getTryCatchLabel(Label label) {
@@ -155,8 +155,8 @@ public final class MethodProbesAdapter extends MethodVisitor {
 	public void visitTableSwitchInsn(final int min, final int max,
 			final Label dflt, final Label... labels) {
 		if (markLabels(dflt, labels)) {
-			probesVisitor.visitTableSwitchInsnWithProbes(min, max, dflt,
-					labels, frame(1));
+			probesVisitor.visitTableSwitchInsnWithProbes(min, max, dflt, labels,
+					frame(1));
 		} else {
 			probesVisitor.visitTableSwitchInsn(min, max, dflt, labels);
 		}

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodSanitizer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodSanitizer.java
@@ -31,8 +31,8 @@ import org.objectweb.asm.commons.JSRInlinerAdapter;
  */
 class MethodSanitizer extends JSRInlinerAdapter {
 
-	MethodSanitizer(final MethodVisitor mv, final int access,
-			final String name, final String desc, final String signature,
+	MethodSanitizer(final MethodVisitor mv, final int access, final String name,
+			final String desc, final String signature,
 			final String[] exceptions) {
 		super(InstrSupport.ASM_API_VERSION, mv, access, name, desc, signature,
 				exceptions);

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassFieldProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassFieldProbeArrayStrategy.java
@@ -28,7 +28,8 @@ class ClassFieldProbeArrayStrategy implements IProbeArrayStrategy {
 	/**
 	 * Frame stack with a single boolean array.
 	 */
-	private static final Object[] FRAME_STACK_ARRZ = new Object[] { InstrSupport.DATAFIELD_DESC };
+	private static final Object[] FRAME_STACK_ARRZ = new Object[] {
+			InstrSupport.DATAFIELD_DESC };
 
 	/**
 	 * Empty frame locals.

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassInstrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassInstrumenter.java
@@ -59,7 +59,8 @@ public class ClassInstrumenter extends ClassProbesVisitor {
 
 	@Override
 	public MethodProbesVisitor visitMethod(final int access, final String name,
-			final String desc, final String signature, final String[] exceptions) {
+			final String desc, final String signature,
+			final String[] exceptions) {
 
 		InstrSupport.assertNotInstrumented(name, className);
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/CondyProbeArrayStrategy.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.jacoco.core.internal.instr;
 
+import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ConstantDynamic;
-import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/InterfaceFieldProbeArrayStrategy.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/InterfaceFieldProbeArrayStrategy.java
@@ -28,7 +28,8 @@ class InterfaceFieldProbeArrayStrategy implements IProbeArrayStrategy {
 	/**
 	 * Frame stack with a single boolean array.
 	 */
-	private static final Object[] FRAME_STACK_ARRZ = new Object[] { InstrSupport.DATAFIELD_DESC };
+	private static final Object[] FRAME_STACK_ARRZ = new Object[] {
+			InstrSupport.DATAFIELD_DESC };
 
 	/**
 	 * Empty frame locals.

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/MethodInstrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/MethodInstrumenter.java
@@ -160,7 +160,8 @@ class MethodInstrumenter extends MethodProbesVisitor {
 		return intermediate;
 	}
 
-	private void insertIntermediateProbe(final Label label, final IFrame frame) {
+	private void insertIntermediateProbe(final Label label,
+			final IFrame frame) {
 		final int probeId = LabelInfo.getProbeId(label);
 		if (probeId != LabelInfo.NO_PROBE && !LabelInfo.isDone(label)) {
 			mv.visitLabel(LabelInfo.getIntermediateLabel(label));

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeCounter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeCounter.java
@@ -31,7 +31,8 @@ class ProbeCounter extends ClassProbesVisitor {
 
 	@Override
 	public MethodProbesVisitor visitMethod(final int access, final String name,
-			final String desc, final String signature, final String[] exceptions) {
+			final String desc, final String signature,
+			final String[] exceptions) {
 		if (!InstrSupport.CLINIT_NAME.equals(name)
 				&& (access & Opcodes.ACC_ABSTRACT) == 0) {
 			methods = true;

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
@@ -56,8 +56,8 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
 	 *            callback to create the code that retrieves the reference to
 	 *            the probe array
 	 */
-	ProbeInserter(final int access, final String name, final String desc, final MethodVisitor mv,
-			final IProbeArrayStrategy arrayStrategy) {
+	ProbeInserter(final int access, final String name, final String desc,
+			final MethodVisitor mv, final IProbeArrayStrategy arrayStrategy) {
 		super(InstrSupport.ASM_API_VERSION, mv);
 		this.clinit = InstrSupport.CLINIT_NAME.equals(name);
 		this.arrayStrategy = arrayStrategy;

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/SignatureRemover.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/SignatureRemover.java
@@ -103,7 +103,8 @@ public class SignatureRemover {
 	}
 
 	private void filterManifestEntryAttributes(final Attributes attrs) {
-		for (final Iterator<Object> i = attrs.keySet().iterator(); i.hasNext();) {
+		for (final Iterator<Object> i = attrs.keySet().iterator(); i
+				.hasNext();) {
 			if (String.valueOf(i.next()).endsWith(DIGEST_SUFFIX)) {
 				i.remove();
 			}

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -220,8 +220,8 @@ public final class AgentOptions {
 				}
 				final String key = entry.substring(0, pos);
 				if (!VALID_OPTIONS.contains(key)) {
-					throw new IllegalArgumentException(format(
-							"Unknown agent option \"%s\".", key));
+					throw new IllegalArgumentException(
+							format("Unknown agent option \"%s\".", key));
 				}
 
 				final String value = entry.substring(pos + 1);

--- a/org.jacoco.core/src/org/jacoco/core/runtime/LoggerRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/LoggerRuntime.java
@@ -134,9 +134,7 @@ public class LoggerRuntime extends AbstractRuntime {
 		// Stack[1]: Ljava/util/logging/Logger;
 		// Stack[0]: [Ljava/lang/Object;
 
-		mv.visitMethodInsn(
-				Opcodes.INVOKEVIRTUAL,
-				"java/util/logging/Logger",
+		mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/util/logging/Logger",
 				"log",
 				"(Ljava/util/logging/Level;Ljava/lang/String;[Ljava/lang/Object;)V",
 				false);

--- a/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/ModifiedSystemClassRuntime.java
@@ -121,10 +121,10 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 			final String className, final String accessFieldName)
 			throws ClassNotFoundException {
 		final ClassFileTransformer transformer = new ClassFileTransformer() {
-			public byte[] transform(final ClassLoader loader,
-					final String name, final Class<?> classBeingRedefined,
-					final ProtectionDomain protectionDomain, final byte[] source)
-					throws IllegalClassFormatException {
+			public byte[] transform(final ClassLoader loader, final String name,
+					final Class<?> classBeingRedefined,
+					final ProtectionDomain protectionDomain,
+					final byte[] source) throws IllegalClassFormatException {
 				if (name.equals(className)) {
 					return instrument(source, accessFieldName);
 				}
@@ -137,8 +137,9 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 		try {
 			clazz.getField(accessFieldName);
 		} catch (final NoSuchFieldException e) {
-			throw new RuntimeException(format(
-					"Class %s could not be instrumented.", className), e);
+			throw new RuntimeException(
+					format("Class %s could not be instrumented.", className),
+					e);
 		}
 		return new ModifiedSystemClassRuntime(clazz, accessFieldName);
 	}
@@ -170,9 +171,10 @@ public class ModifiedSystemClassRuntime extends AbstractRuntime {
 
 	private static void createDataField(final ClassVisitor visitor,
 			final String dataField) {
-		visitor.visitField(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC
-				| Opcodes.ACC_SYNTHETIC | Opcodes.ACC_TRANSIENT, dataField,
-				ACCESS_FIELD_TYPE, null, null);
+		visitor.visitField(
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC
+						| Opcodes.ACC_TRANSIENT,
+				dataField, ACCESS_FIELD_TYPE, null, null);
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/runtime/OfflineInstrumentationAccessGenerator.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/OfflineInstrumentationAccessGenerator.java
@@ -23,8 +23,8 @@ import org.objectweb.asm.Opcodes;
  * obtain probe arrays. This generator is designed for offline instrumentation
  * only.
  */
-public class OfflineInstrumentationAccessGenerator implements
-		IExecutionDataAccessorGenerator {
+public class OfflineInstrumentationAccessGenerator
+		implements IExecutionDataAccessorGenerator {
 
 	private final String runtimeClassName;
 

--- a/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlWriter.java
@@ -20,8 +20,8 @@ import org.jacoco.core.data.ExecutionDataWriter;
 /**
  * {@link ExecutionDataWriter} with commands added for runtime remote control.
  */
-public class RemoteControlWriter extends ExecutionDataWriter implements
-		IRemoteCommandVisitor {
+public class RemoteControlWriter extends ExecutionDataWriter
+		implements IRemoteCommandVisitor {
 
 	/** Block identifier to confirm successful command execution. */
 	public static final byte BLOCK_CMDOK = 0x20;

--- a/org.jacoco.core/src/org/jacoco/core/runtime/RuntimeData.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/RuntimeData.java
@@ -180,7 +180,8 @@ public class RuntimeData {
 	 *            visitor to emit generated code
 	 */
 	public static void generateArgumentArray(final long classid,
-			final String classname, final int probecount, final MethodVisitor mv) {
+			final String classname, final int probecount,
+			final MethodVisitor mv) {
 		mv.visitInsn(Opcodes.ICONST_3);
 		mv.visitTypeInsn(Opcodes.ANEWARRAY, "java/lang/Object");
 
@@ -202,8 +203,8 @@ public class RuntimeData {
 		mv.visitInsn(Opcodes.DUP);
 		mv.visitInsn(Opcodes.ICONST_2);
 		InstrSupport.push(mv, probecount);
-		mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer",
-				"valueOf", "(I)Ljava/lang/Integer;", false);
+		mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "valueOf",
+				"(I)Ljava/lang/Integer;", false);
 		mv.visitInsn(Opcodes.AASTORE);
 	}
 
@@ -224,7 +225,8 @@ public class RuntimeData {
 	 *            visitor to emit generated code
 	 */
 	public static void generateAccessCall(final long classid,
-			final String classname, final int probecount, final MethodVisitor mv) {
+			final String classname, final int probecount,
+			final MethodVisitor mv) {
 		// stack[0]: Ljava/lang/Object;
 
 		generateArgumentArray(classid, classname, probecount, mv);

--- a/org.jacoco.core/src/org/jacoco/core/runtime/SystemPropertiesRuntime.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/SystemPropertiesRuntime.java
@@ -51,8 +51,8 @@ public class SystemPropertiesRuntime extends AbstractRuntime {
 		// Stack[1]: Ljava/lang/String;
 		// Stack[0]: Ljava/util/Properties;
 
-		mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/util/Properties",
-				"get", "(Ljava/lang/Object;)Ljava/lang/Object;", false);
+		mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/util/Properties", "get",
+				"(Ljava/lang/Object;)Ljava/lang/Object;", false);
 
 		// Stack[0]: Ljava/lang/Object;
 

--- a/org.jacoco.core/src/org/jacoco/core/tools/ExecFileLoader.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/ExecFileLoader.java
@@ -112,7 +112,8 @@ public class ExecFileLoader {
 		final FileOutputStream fileStream = new FileOutputStream(file, append);
 		// Avoid concurrent writes from other processes:
 		fileStream.getChannel().lock();
-		final OutputStream bufferedStream = new BufferedOutputStream(fileStream);
+		final OutputStream bufferedStream = new BufferedOutputStream(
+				fileStream);
 		try {
 			save(bufferedStream);
 		} finally {

--- a/org.jacoco.examples.test/src/org/jacoco/examples/ClassInfoTest.java
+++ b/org.jacoco.examples.test/src/org/jacoco/examples/ClassInfoTest.java
@@ -36,15 +36,17 @@ public class ClassInfoTest {
 		final String[] args = new String[] { createClassFile() };
 		new ClassInfo(console.stream).execute(args);
 
-		console.expect(containsLine("class name:   org/jacoco/examples/ClassInfoTest"));
+		console.expect(containsLine(
+				"class name:   org/jacoco/examples/ClassInfoTest"));
 		console.expect(containsLine("methods:      3"));
 		console.expect(containsLine("branches:     2"));
 		console.expect(containsLine("complexity:   4"));
 	}
 
 	private String createClassFile() throws IOException {
-		InputStream in = getClass().getResource(
-				getClass().getSimpleName() + ".class").openStream();
+		InputStream in = getClass()
+				.getResource(getClass().getSimpleName() + ".class")
+				.openStream();
 		File f = File.createTempFile("Example", ".class");
 		FileOutputStream out = new FileOutputStream(f);
 		int b;

--- a/org.jacoco.examples.test/src/org/jacoco/examples/ExecDumpTest.java
+++ b/org.jacoco.examples.test/src/org/jacoco/examples/ExecDumpTest.java
@@ -41,9 +41,11 @@ public class ExecDumpTest {
 		new ExecDump(console.stream).execute(args);
 
 		console.expect(containsLine("exec file: " + file));
-		console.expect(containsLine("CLASS ID         HITS/PROBES   CLASS NAME"));
+		console.expect(
+				containsLine("CLASS ID         HITS/PROBES   CLASS NAME"));
 		console.expect(containsString("Session \"testid\":"));
-		console.expect(containsLine("0000000000001234    2 of   3   foo/MyClass"));
+		console.expect(
+				containsLine("0000000000001234    2 of   3   foo/MyClass"));
 	}
 
 	private String createExecFile() throws IOException {

--- a/org.jacoco.examples/src/org/jacoco/examples/ClassInfo.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ClassInfo.java
@@ -58,16 +58,16 @@ public final class ClassInfo implements ICoverageVisitor {
 	public void visitCoverage(final IClassCoverage coverage) {
 		out.printf("class name:   %s%n", coverage.getName());
 		out.printf("class id:     %016x%n", Long.valueOf(coverage.getId()));
-		out.printf("instructions: %s%n", Integer.valueOf(coverage
-				.getInstructionCounter().getTotalCount()));
+		out.printf("instructions: %s%n", Integer
+				.valueOf(coverage.getInstructionCounter().getTotalCount()));
 		out.printf("branches:     %s%n",
 				Integer.valueOf(coverage.getBranchCounter().getTotalCount()));
 		out.printf("lines:        %s%n",
 				Integer.valueOf(coverage.getLineCounter().getTotalCount()));
 		out.printf("methods:      %s%n",
 				Integer.valueOf(coverage.getMethodCounter().getTotalCount()));
-		out.printf("complexity:   %s%n%n", Integer.valueOf(coverage
-				.getComplexityCounter().getTotalCount()));
+		out.printf("complexity:   %s%n%n", Integer
+				.valueOf(coverage.getComplexityCounter().getTotalCount()));
 	}
 
 	/**

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecDump.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecDump.java
@@ -63,8 +63,8 @@ public final class ExecDump {
 		final ExecutionDataReader reader = new ExecutionDataReader(in);
 		reader.setSessionInfoVisitor(new ISessionInfoVisitor() {
 			public void visitSessionInfo(final SessionInfo info) {
-				out.printf("Session \"%s\": %s - %s%n", info.getId(), new Date(
-						info.getStartTimeStamp()),
+				out.printf("Session \"%s\": %s - %s%n", info.getId(),
+						new Date(info.getStartTimeStamp()),
 						new Date(info.getDumpTimeStamp()));
 			}
 		});

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataServer.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataServer.java
@@ -56,8 +56,8 @@ public final class ExecutionDataServer {
 		}
 	}
 
-	private static class Handler implements Runnable, ISessionInfoVisitor,
-			IExecutionDataVisitor {
+	private static class Handler
+			implements Runnable, ISessionInfoVisitor, IExecutionDataVisitor {
 
 		private final Socket socket;
 

--- a/org.jacoco.examples/src/org/jacoco/examples/MBeanClient.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/MBeanClient.java
@@ -46,8 +46,9 @@ public final class MBeanClient {
 				.getMBeanServerConnection();
 
 		final IProxy proxy = (IProxy) MBeanServerInvocationHandler
-				.newProxyInstance(connection, new ObjectName(
-						"org.jacoco:type=Runtime"), IProxy.class, false);
+				.newProxyInstance(connection,
+						new ObjectName("org.jacoco:type=Runtime"), IProxy.class,
+						false);
 
 		// Retrieve JaCoCo version and session id:
 		System.out.println("Version: " + proxy.getVersion());

--- a/org.jacoco.examples/src/org/jacoco/examples/ReportGenerator.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ReportGenerator.java
@@ -96,8 +96,8 @@ public class ReportGenerator {
 
 		// Populate the report structure with the bundle coverage information.
 		// Call visitGroup if you need groups in your report.
-		visitor.visitBundle(bundleCoverage, new DirectorySourceFileLocator(
-				sourceDirectory, "utf-8", 4));
+		visitor.visitBundle(bundleCoverage,
+				new DirectorySourceFileLocator(sourceDirectory, "utf-8", 4));
 
 		// Signal end of structure information to allow report to write all
 		// information out
@@ -130,8 +130,8 @@ public class ReportGenerator {
 	 */
 	public static void main(final String[] args) throws IOException {
 		for (int i = 0; i < args.length; i++) {
-			final ReportGenerator generator = new ReportGenerator(new File(
-					args[i]));
+			final ReportGenerator generator = new ReportGenerator(
+					new File(args[i]));
 			generator.create();
 		}
 	}

--- a/org.jacoco.report.test/src/org/jacoco/report/FileMultiReportOutputTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/FileMultiReportOutputTest.java
@@ -43,8 +43,8 @@ public class FileMultiReportOutputTest {
 		stream.close();
 		output.close();
 
-		final InputStream actual = new FileInputStream(new File(
-				folder.getRoot(), "a/b/c/test"));
+		final InputStream actual = new FileInputStream(
+				new File(folder.getRoot(), "a/b/c/test"));
 		assertEquals(1, actual.read());
 		assertEquals(2, actual.read());
 		assertEquals(3, actual.read());

--- a/org.jacoco.report.test/src/org/jacoco/report/JavaNamesTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/JavaNamesTest.java
@@ -64,9 +64,9 @@ public class JavaNamesTest {
 
 	@Test
 	public void testGetClassName5() {
-		assertEquals("Bar.new ISample() {...}", names.getClassName(
-				"com/foo/Bar$1", null, "java/lang/Object",
-				new String[] { "org/foo/ISample" }));
+		assertEquals("Bar.new ISample() {...}",
+				names.getClassName("com/foo/Bar$1", null, "java/lang/Object",
+						new String[] { "org/foo/ISample" }));
 	}
 
 	@Test
@@ -143,9 +143,9 @@ public class JavaNamesTest {
 
 	@Test
 	public void testGetMethodName8() {
-		assertEquals("update(Map.Entry)", names.getMethodName(
-				"com/example/SomeClass", "update", "(Ljava/util/Map$Entry;)V",
-				null));
+		assertEquals("update(Map.Entry)",
+				names.getMethodName("com/example/SomeClass", "update",
+						"(Ljava/util/Map$Entry;)V", null));
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/MultiReportVisitorTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/MultiReportVisitorTest.java
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class MultiReportVisitorTest {
 
-	private static class MockVisitor extends MockGroupVisitor implements
-			IReportVisitor {
+	private static class MockVisitor extends MockGroupVisitor
+			implements IReportVisitor {
 
 		MockVisitor() {
 			super("Report");

--- a/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
@@ -48,7 +48,7 @@ public class ReportStructureTestDriver {
 
 		public Reader getSourceFile(String packageName, String fileName)
 				throws IOException {
-			return  new StringReader("");
+			return new StringReader("");
 		}
 
 		public int getTabWidth() {

--- a/org.jacoco.report.test/src/org/jacoco/report/ZipMultiReportOutputTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/ZipMultiReportOutputTest.java
@@ -109,8 +109,9 @@ public class ZipMultiReportOutputTest {
 
 		final Map<String, byte[]> entries = readEntries();
 		assertEquals(
-				new HashSet<String>(Arrays.asList("dir/index.html",
-						"readme.txt")), entries.keySet());
+				new HashSet<String>(
+						Arrays.asList("dir/index.html", "readme.txt")),
+				entries.keySet());
 		assertArrayEquals(content1, entries.get("dir/index.html"));
 		assertArrayEquals(content2, entries.get("readme.txt"));
 	}
@@ -131,8 +132,9 @@ public class ZipMultiReportOutputTest {
 
 		final Map<String, byte[]> entries = readEntries();
 		assertEquals(
-				new HashSet<String>(Arrays.asList("dir/index.html",
-						"readme.txt")), entries.keySet());
+				new HashSet<String>(
+						Arrays.asList("dir/index.html", "readme.txt")),
+				entries.keySet());
 		assertArrayEquals(content1, entries.get("dir/index.html"));
 		assertArrayEquals(content2, entries.get("readme.txt"));
 	}
@@ -184,8 +186,8 @@ public class ZipMultiReportOutputTest {
 			while ((b = input.read()) != -1) {
 				entryBuffer.write(b);
 			}
-			byte[] old = entries
-					.put(entry.getName(), entryBuffer.toByteArray());
+			byte[] old = entries.put(entry.getName(),
+					entryBuffer.toByteArray());
 			assertNull("Duplicate entry " + entry.getName(), old);
 		}
 		return entries;

--- a/org.jacoco.report.test/src/org/jacoco/report/check/BundleCheckerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/BundleCheckerTest.java
@@ -56,7 +56,8 @@ public class BundleCheckerTest implements IViolationsOutput {
 		addRule(ElementType.BUNDLE);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for bundle Test: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage(
+				"Rule violated for bundle Test: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -64,7 +65,8 @@ public class BundleCheckerTest implements IViolationsOutput {
 		addRule(ElementType.PACKAGE);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for package org.jacoco.example: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage(
+				"Rule violated for package org.jacoco.example: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -72,7 +74,8 @@ public class BundleCheckerTest implements IViolationsOutput {
 		addRule(ElementType.SOURCEFILE);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for source file org/jacoco/example/FooClass.java: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage(
+				"Rule violated for source file org/jacoco/example/FooClass.java: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -80,7 +83,8 @@ public class BundleCheckerTest implements IViolationsOutput {
 		addRule(ElementType.CLASS);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for class org.jacoco.example.FooClass: instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage(
+				"Rule violated for class org.jacoco.example.FooClass: instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test
@@ -88,7 +92,8 @@ public class BundleCheckerTest implements IViolationsOutput {
 		addRule(ElementType.METHOD);
 		final BundleChecker checker = new BundleChecker(rules, names, this);
 		checker.checkBundle(createBundle());
-		assertMessage("Rule violated for method org.jacoco.example.FooClass.fooMethod(): instructions covered ratio is 0.50, but expected minimum is 0.75");
+		assertMessage(
+				"Rule violated for method org.jacoco.example.FooClass.fooMethod(): instructions covered ratio is 0.50, but expected minimum is 0.75");
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/check/RulesCheckerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/check/RulesCheckerTest.java
@@ -51,8 +51,8 @@ public class RulesCheckerTest implements IViolationsOutput {
 		limit.setMaximum("5");
 		checker.setRules(Arrays.asList(rule));
 		driver.sendGroup(checker.createVisitor(this));
-		assertEquals(
-				Arrays.asList("Rule violated for bundle bundle: instructions missed count is 10, but expected maximum is 5"),
+		assertEquals(Arrays.asList(
+				"Rule violated for bundle bundle: instructions missed count is 10, but expected maximum is 5"),
 				messages);
 	}
 
@@ -79,8 +79,8 @@ public class RulesCheckerTest implements IViolationsOutput {
 				return null;
 			}
 
-			public String getMethodName(String vmclassname,
-					String vmmethodname, String vmdesc, String vmsignature) {
+			public String getMethodName(String vmclassname, String vmmethodname,
+					String vmdesc, String vmsignature) {
 				return null;
 			}
 
@@ -91,8 +91,8 @@ public class RulesCheckerTest implements IViolationsOutput {
 		});
 
 		driver.sendGroup(checker.createVisitor(this));
-		assertEquals(
-				Arrays.asList("Rule violated for class MyClass: instructions missed count is 10, but expected maximum is 5"),
+		assertEquals(Arrays.asList(
+				"Rule violated for class MyClass: instructions missed count is 10, but expected maximum is 5"),
 				messages);
 	}
 

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/CSVFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/CSVFormatterTest.java
@@ -117,8 +117,8 @@ public class CSVFormatterTest {
 				return null;
 			}
 
-			public String getMethodName(String vmclassname,
-					String vmmethodname, String vmdesc, String vmsignature) {
+			public String getMethodName(String vmclassname, String vmmethodname,
+					String vmdesc, String vmsignature) {
 				return null;
 			}
 
@@ -137,8 +137,8 @@ public class CSVFormatterTest {
 	}
 
 	private List<String> getLines(String encoding) throws IOException {
-		final BufferedReader reader = new BufferedReader(new InputStreamReader(
-				output.getContentsAsStream(), encoding));
+		final BufferedReader reader = new BufferedReader(
+				new InputStreamReader(output.getContentsAsStream(), encoding));
 		final List<String> lines = new ArrayList<String>();
 		String line;
 		while ((line = reader.readLine()) != null) {

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/CSVGroupHandlerTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/CSVGroupHandlerTest.java
@@ -49,8 +49,7 @@ public class CSVGroupHandlerTest {
 		driver.sendBundle(handler);
 		final BufferedReader reader = getResultReader();
 		reader.readLine();
-		assertEquals(
-				"bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
+		assertEquals("bundle,org.jacoco.example,FooClass,10,15,1,2,0,3,1,2,0,1",
 				reader.readLine());
 		assertEquals("no more lines expected", null, reader.readLine());
 	}

--- a/org.jacoco.report.test/src/org/jacoco/report/csv/ClassRowWriterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/csv/ClassRowWriterTest.java
@@ -50,8 +50,8 @@ public class ClassRowWriterTest {
 				throw new AssertionError();
 			}
 
-			public String getMethodName(String vmclassname,
-					String vmmethodname, String vmdesc, String vmsignature) {
+			public String getMethodName(String vmclassname, String vmmethodname,
+					String vmdesc, String vmsignature) {
 				throw new AssertionError();
 			}
 

--- a/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/html/HTMLFormatterTest.java
@@ -135,8 +135,8 @@ public class HTMLFormatterTest {
 				return null;
 			}
 
-			public String getMethodName(String vmclassname,
-					String vmmethodname, String vmdesc, String vmsignature) {
+			public String getMethodName(String vmclassname, String vmmethodname,
+					String vmdesc, String vmsignature) {
 				return null;
 			}
 

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/ReportOutputFolderTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/ReportOutputFolderTest.java
@@ -87,7 +87,8 @@ public class ReportOutputFolderTest {
 	public void testRelativeLinkInSibling1() throws IOException {
 		final ReportOutputFolder folder = root.subFolder("f1").subFolder("f2");
 		final ReportOutputFolder base = root.subFolder("g1").subFolder("g2");
-		assertEquals("../../f1/f2/test.html", folder.getLink(base, "test.html"));
+		assertEquals("../../f1/f2/test.html",
+				folder.getLink(base, "test.html"));
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/BundlePageTest.java
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package org.jacoco.report.internal.html.page;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.IPackageCoverage;
@@ -24,11 +29,6 @@ import org.jacoco.core.internal.analysis.PackageCoverageImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for {@link BundlePage}.

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/MethodItemTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/MethodItemTest.java
@@ -61,14 +61,16 @@ public class MethodItemTest {
 
 	@Test
 	public void testGetLink() {
-		final MethodItem item = new MethodItem(node, "test()", new SourceLink());
+		final MethodItem item = new MethodItem(node, "test()",
+				new SourceLink());
 		assertEquals("../Source.java", item.getLink(null));
 	}
 
 	@Test
 	public void testGetLinkWithLine() {
 		node.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 15);
-		final MethodItem item = new MethodItem(node, "test()", new SourceLink());
+		final MethodItem item = new MethodItem(node, "test()",
+				new SourceLink());
 		assertEquals("../Source.java#L15", item.getLink(null));
 	}
 

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackagePageTest.java
@@ -117,12 +117,12 @@ public class PackagePageTest extends PageTestBase {
 				support.findStr(doc, "/html/body/div[1]/span[1]/a"));
 		assertEquals("el_class", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/a/@class"));
-		assertEquals("Foo1",
-				support.findStr(doc, "/html/body/table[1]/tbody/tr[1]/td[1]/a"));
+		assertEquals("Foo1", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/a"));
 		assertEquals("el_class", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[2]/td[1]/a/@class"));
-		assertEquals("Foo2",
-				support.findStr(doc, "/html/body/table[1]/tbody/tr[2]/td[1]/a"));
+		assertEquals("Foo2", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[2]/td[1]/a"));
 
 		output.assertFile("index.source.html");
 	}

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackageSourcePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/PackageSourcePageTest.java
@@ -52,15 +52,13 @@ public class PackageSourcePageTest extends PageTestBase {
 		super.setup();
 		SourceFileCoverageImpl src1 = new SourceFileCoverageImpl("Src1.java",
 				"org/jacoco/example");
-		src1.increment(CounterImpl.COUNTER_1_0,
-				CounterImpl.COUNTER_0_0, 1);
+		src1.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 1);
 		SourceFileCoverageImpl src2 = new SourceFileCoverageImpl("Src2.java",
 				"org/jacoco/example");
-		src2.increment(CounterImpl.COUNTER_1_0,
-				CounterImpl.COUNTER_0_0, 1);
+		src2.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 1);
 		node = new PackageCoverageImpl("org/jacoco/example",
-				Collections.<IClassCoverage> emptyList(), Arrays.<ISourceFileCoverage>asList(src1,
-						src2));
+				Collections.<IClassCoverage> emptyList(),
+				Arrays.<ISourceFileCoverage> asList(src1, src2));
 		sourceLocator = new ISourceFileLocator() {
 
 			public int getTabWidth() {
@@ -106,8 +104,8 @@ public class PackageSourcePageTest extends PageTestBase {
 				support.findStr(doc, "/html/body/div[1]/span[1]/a"));
 		assertEquals("el_source", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/a/@class"));
-		assertEquals("Src1.java",
-				support.findStr(doc, "/html/body/table[1]/tbody/tr[1]/td[1]/a"));
+		assertEquals("Src1.java", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/a"));
 		assertEquals("el_source", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[2]/td[1]/span/@class"));
 		assertEquals("Src2.java", support.findStr(doc,

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ReportPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/ReportPageTest.java
@@ -39,7 +39,8 @@ public class ReportPageTest extends PageTestBase {
 		private final String label;
 		private final String style;
 
-		protected TestReportPage(String label, String style, ReportPage parent) {
+		protected TestReportPage(String label, String style,
+				ReportPage parent) {
 			super(parent, rootFolder, ReportPageTest.this.context);
 			this.label = label;
 			this.style = style;

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SessionsPageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SessionsPageTest.java
@@ -73,8 +73,8 @@ public class SessionsPageTest extends PageTestBase {
 		final SessionsPage page = new SessionsPage(noSessions, noExecutionData,
 				index, null, rootFolder, context);
 		page.render();
-		final Document doc = support.parse(output
-				.getFile("jacoco-sessions.html"));
+		final Document doc = support
+				.parse(output.getFile("jacoco-sessions.html"));
 		assertEquals("No session information available.",
 				support.findStr(doc, "/html/body/p[1]"));
 		assertEquals("No execution data available.",
@@ -90,8 +90,8 @@ public class SessionsPageTest extends PageTestBase {
 		final SessionsPage page = new SessionsPage(sessions, noExecutionData,
 				index, null, rootFolder, context);
 		page.render();
-		final Document doc = support.parse(output
-				.getFile("jacoco-sessions.html"));
+		final Document doc = support
+				.parse(output.getFile("jacoco-sessions.html"));
 		assertEquals("el_session", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/span/@class"));
 		assertEquals("Session-A", support.findStr(doc,
@@ -131,14 +131,14 @@ public class SessionsPageTest extends PageTestBase {
 		final SessionsPage page = new SessionsPage(noSessions, data, index,
 				null, rootFolder, context);
 		page.render();
-		final Document doc = support.parse(output
-				.getFile("jacoco-sessions.html"));
+		final Document doc = support
+				.parse(output.getFile("jacoco-sessions.html"));
 		assertEquals("el_class", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/a/@class"));
 		assertEquals("Foo.html", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[1]/a/@href"));
-		assertEquals("ClassA",
-				support.findStr(doc, "/html/body/table[1]/tbody/tr[1]/td[1]/a"));
+		assertEquals("ClassA", support.findStr(doc,
+				"/html/body/table[1]/tbody/tr[1]/td[1]/a"));
 		assertEquals("0000000000001002", support.findStr(doc,
 				"/html/body/table[1]/tbody/tr[1]/td[2]/code"));
 		assertEquals("ClassB",

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SourceFilePageTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/page/SourceFilePageTest.java
@@ -35,9 +35,8 @@ public class SourceFilePageTest extends PageTestBase {
 	@Override
 	public void setup() throws Exception {
 		super.setup();
-		sourceReader = new InputStreamReader(
-				new FileInputStream(
-						"./src/org/jacoco/report/internal/html/page/SourceFilePageTest.java"),
+		sourceReader = new InputStreamReader(new FileInputStream(
+				"./src/org/jacoco/report/internal/html/page/SourceFilePageTest.java"),
 				"UTF-8");
 	}
 
@@ -49,8 +48,8 @@ public class SourceFilePageTest extends PageTestBase {
 				null, rootFolder, context);
 		page.render();
 
-		final Document result = support.parse(output
-				.getFile("SourceFilePageTest.java.html"));
+		final Document result = support
+				.parse(output.getFile("SourceFilePageTest.java.html"));
 
 		// additional style sheet
 		assertEquals("jacoco-resources/report.css", support.findStr(result,

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/resources/ResourcesTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/resources/ResourcesTest.java
@@ -75,13 +75,15 @@ public class ResourcesTest {
 	@Test
 	public void testGetElementStyle() {
 		assertEquals("el_group", Resources.getElementStyle(ElementType.GROUP));
-		assertEquals("el_bundle", Resources.getElementStyle(ElementType.BUNDLE));
+		assertEquals("el_bundle",
+				Resources.getElementStyle(ElementType.BUNDLE));
 		assertEquals("el_package",
 				Resources.getElementStyle(ElementType.PACKAGE));
 		assertEquals("el_source",
 				Resources.getElementStyle(ElementType.SOURCEFILE));
 		assertEquals("el_class", Resources.getElementStyle(ElementType.CLASS));
-		assertEquals("el_method", Resources.getElementStyle(ElementType.METHOD));
+		assertEquals("el_method",
+				Resources.getElementStyle(ElementType.METHOD));
 	}
 
 }

--- a/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
@@ -192,8 +192,7 @@ public class XMLFormatterTest {
 		assertPathMatches("1", "count(/report/package[@name='empty']/class)");
 		assertPathMatches("empty/Empty",
 				"/report/package[@name='empty']/class/@name");
-		assertPathMatches("0",
-				"count(report/package[@name='empty']/class/*)");
+		assertPathMatches("0", "count(report/package[@name='empty']/class/*)");
 
 		assertPathMatches("1",
 				"count(/report/package[@name='empty']/sourcefile)");

--- a/org.jacoco.report/src/org/jacoco/report/IReportGroupVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/IReportGroupVisitor.java
@@ -18,11 +18,12 @@ import org.jacoco.core.analysis.IBundleCoverage;
 
 /**
  * Output-Interface for hierarchical report structures. To allow sequential
- * processing and save memory the group structure has to be traversed in a
- * "deep first" fashion. The interface is implemented by the report formatters
- * and can be used to emit coverage report structures.
+ * processing and save memory the group structure has to be traversed in a "deep
+ * first" fashion. The interface is implemented by the report formatters and can
+ * be used to emit coverage report structures.
  * 
- * The following constraints apply in using {@link IReportGroupVisitor} instances:
+ * The following constraints apply in using {@link IReportGroupVisitor}
+ * instances:
  * 
  * <ul>
  * <li>A visitor instance can be used to either submit bundles (

--- a/org.jacoco.report/src/org/jacoco/report/IReportVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/IReportVisitor.java
@@ -21,8 +21,8 @@ import org.jacoco.core.data.SessionInfo;
 
 /**
  * Interface for all implementations to retrieve structured report data. Unlike
- * nested {@link IReportGroupVisitor} instances the root visitor accepts exactly one
- * bundle or group.
+ * nested {@link IReportGroupVisitor} instances the root visitor accepts exactly
+ * one bundle or group.
  */
 public interface IReportVisitor extends IReportGroupVisitor {
 

--- a/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/InputStreamSourceFileLocator.java
@@ -21,8 +21,8 @@ import java.io.Reader;
  * Abstract base class for {@link ISourceFileLocator} locator implementations
  * based on {@link InputStream}s. It handles the encoding and tab width.
  */
-public abstract class InputStreamSourceFileLocator implements
-		ISourceFileLocator {
+public abstract class InputStreamSourceFileLocator
+		implements ISourceFileLocator {
 
 	private final String encoding;
 	private final int tabWidth;

--- a/org.jacoco.report/src/org/jacoco/report/MultiReportVisitor.java
+++ b/org.jacoco.report/src/org/jacoco/report/MultiReportVisitor.java
@@ -25,8 +25,8 @@ import org.jacoco.core.data.SessionInfo;
  * A report visitor that is composed from multiple other visitors. This can be
  * used to create more than one report format in one run.
  */
-public class MultiReportVisitor extends MultiGroupVisitor implements
-		IReportVisitor {
+public class MultiReportVisitor extends MultiGroupVisitor
+		implements IReportVisitor {
 
 	private final List<IReportVisitor> visitors;
 
@@ -71,7 +71,8 @@ class MultiGroupVisitor implements IReportGroupVisitor {
 		}
 	}
 
-	public IReportGroupVisitor visitGroup(final String name) throws IOException {
+	public IReportGroupVisitor visitGroup(final String name)
+			throws IOException {
 		final List<IReportGroupVisitor> children = new ArrayList<IReportGroupVisitor>();
 		for (final IReportGroupVisitor v : visitors) {
 			children.add(v.visitGroup(name));

--- a/org.jacoco.report/src/org/jacoco/report/check/BundleChecker.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/BundleChecker.java
@@ -97,7 +97,8 @@ class BundleChecker {
 			}
 		}
 		if (traverseSourceFiles) {
-			for (final ISourceFileCoverage s : packageCoverage.getSourceFiles()) {
+			for (final ISourceFileCoverage s : packageCoverage
+					.getSourceFiles()) {
 				check(s);
 			}
 		}
@@ -142,9 +143,9 @@ class BundleChecker {
 			final String elementname, final Rule rule, final Limit limit) {
 		final String message = limit.check(node);
 		if (message != null) {
-			output.onViolation(node, rule, limit, String.format(
-					"Rule violated for %s %s: %s", elementtype, elementname,
-					message));
+			output.onViolation(node, rule, limit,
+					String.format("Rule violated for %s %s: %s", elementtype,
+							elementname, message));
 		}
 	}
 

--- a/org.jacoco.report/src/org/jacoco/report/check/IViolationsOutput.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/IViolationsOutput.java
@@ -32,6 +32,7 @@ public interface IViolationsOutput {
 	 * @param message
 	 *            readable message describing this violation
 	 */
-	void onViolation(ICoverageNode node, Rule rule, Limit limit, String message);
+	void onViolation(ICoverageNode node, Rule rule, Limit limit,
+			String message);
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/csv/CSVGroupHandler.java
+++ b/org.jacoco.report/src/org/jacoco/report/csv/CSVGroupHandler.java
@@ -33,7 +33,8 @@ class CSVGroupHandler implements IReportGroupVisitor {
 		this(writer, null);
 	}
 
-	private CSVGroupHandler(final ClassRowWriter writer, final String groupName) {
+	private CSVGroupHandler(final ClassRowWriter writer,
+			final String groupName) {
 		this.writer = writer;
 		this.groupName = groupName;
 	}
@@ -51,7 +52,8 @@ class CSVGroupHandler implements IReportGroupVisitor {
 		}
 	}
 
-	public IReportGroupVisitor visitGroup(final String name) throws IOException {
+	public IReportGroupVisitor visitGroup(final String name)
+			throws IOException {
 		return new CSVGroupHandler(writer, appendName(name));
 	}
 

--- a/org.jacoco.report/src/org/jacoco/report/csv/ClassRowWriter.java
+++ b/org.jacoco.report/src/org/jacoco/report/csv/ClassRowWriter.java
@@ -26,8 +26,8 @@ import org.jacoco.report.ILanguageNames;
 class ClassRowWriter {
 
 	private static final CounterEntity[] COUNTERS = { CounterEntity.INSTRUCTION,
-			CounterEntity.BRANCH, CounterEntity.LINE,
-			CounterEntity.COMPLEXITY, CounterEntity.METHOD };
+			CounterEntity.BRANCH, CounterEntity.LINE, CounterEntity.COMPLEXITY,
+			CounterEntity.METHOD };
 
 	private final DelimitedWriter writer;
 

--- a/org.jacoco.report/src/org/jacoco/report/html/HTMLFormatter.java
+++ b/org.jacoco.report/src/org/jacoco/report/html/HTMLFormatter.java
@@ -133,14 +133,14 @@ public class HTMLFormatter implements IHTMLReportContext {
 	private Table createTable() {
 		final Table t = new Table();
 		t.add("Element", null, new LabelColumn(), false);
-		t.add("Missed Instructions", Styles.BAR, new BarColumn(CounterEntity.INSTRUCTION,
-				locale), true);
+		t.add("Missed Instructions", Styles.BAR,
+				new BarColumn(CounterEntity.INSTRUCTION, locale), true);
 		t.add("Cov.", Styles.CTR2,
 				new PercentageColumn(CounterEntity.INSTRUCTION, locale), false);
-		t.add("Missed Branches", Styles.BAR, new BarColumn(CounterEntity.BRANCH, locale),
-				false);
-		t.add("Cov.", Styles.CTR2, new PercentageColumn(CounterEntity.BRANCH, locale),
-				false);
+		t.add("Missed Branches", Styles.BAR,
+				new BarColumn(CounterEntity.BRANCH, locale), false);
+		t.add("Cov.", Styles.CTR2,
+				new PercentageColumn(CounterEntity.BRANCH, locale), false);
 		addMissedTotalColumns(t, "Cxty", CounterEntity.COMPLEXITY);
 		addMissedTotalColumns(t, "Lines", CounterEntity.LINE);
 		addMissedTotalColumns(t, "Methods", CounterEntity.METHOD);

--- a/org.jacoco.report/src/org/jacoco/report/internal/ReportOutputFolder.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/ReportOutputFolder.java
@@ -73,8 +73,8 @@ public class ReportOutputFolder {
 		if (folder != null) {
 			return folder;
 		}
-		folder = new ReportOutputFolder(output, this, path + normalizedName
-				+ "/");
+		folder = new ReportOutputFolder(output, this,
+				path + normalizedName + "/");
 		subFolders.put(normalizedName, folder);
 		return folder;
 	}

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/NodePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/NodePage.java
@@ -25,8 +25,8 @@ import org.jacoco.report.internal.html.table.ITableItem;
  * @param <NodeType>
  *            type of the node represented by this page
  */
-public abstract class NodePage<NodeType extends ICoverageNode> extends
-		ReportPage implements ITableItem {
+public abstract class NodePage<NodeType extends ICoverageNode>
+		extends ReportPage implements ITableItem {
 
 	private final NodeType node;
 

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackagePage.java
@@ -50,8 +50,8 @@ public class PackagePage extends TablePage<IPackageCoverage> {
 			final ISourceFileLocator locator, final ReportOutputFolder folder,
 			final IHTMLReportContext context) {
 		super(node, parent, folder, context);
-		packageSourcePage = new PackageSourcePage(node, parent, locator,
-				folder, context, this);
+		packageSourcePage = new PackageSourcePage(node, parent, locator, folder,
+				context, this);
 		sourceCoverageExists = !node.getSourceFiles().isEmpty();
 	}
 

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackageSourcePage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/PackageSourcePage.java
@@ -84,8 +84,8 @@ public class PackageSourcePage extends TablePage<IPackageCoverage> {
 				continue;
 			}
 			final String sourcename = s.getName();
-			final Reader reader = locator
-					.getSourceFile(packagename, sourcename);
+			final Reader reader = locator.getSourceFile(packagename,
+					sourcename);
 			if (reader == null) {
 				addItem(new SourceFileItem(s));
 			} else {

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/SessionsPage.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/SessionsPage.java
@@ -82,8 +82,8 @@ public class SessionsPage extends ReportPage {
 		final ILanguageNames names = context.getLanguageNames();
 		Collections.sort(this.executionData, new Comparator<ExecutionData>() {
 			public int compare(final ExecutionData e1, final ExecutionData e2) {
-				return names.getQualifiedClassName(e1.getName()).compareTo(
-						names.getQualifiedClassName(e2.getName()));
+				return names.getQualifiedClassName(e1.getName())
+						.compareTo(names.getQualifiedClassName(e2.getName()));
 			}
 		});
 	}
@@ -133,8 +133,8 @@ public class SessionsPage extends ReportPage {
 		for (final ExecutionData e : executionData) {
 			final HTMLElement tr = tbody.tr();
 			final String link = index.getLinkToClass(e.getId());
-			final String qualifiedName = names.getQualifiedClassName(e
-					.getName());
+			final String qualifiedName = names
+					.getQualifiedClassName(e.getName());
 			if (link == null) {
 				tr.td().span(Styles.EL_CLASS).text(qualifiedName);
 			} else {

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/page/SourceHighlighter.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/page/SourceHighlighter.java
@@ -68,8 +68,8 @@ final class SourceHighlighter {
 	 */
 	public void render(final HTMLElement parent, final ISourceNode source,
 			final Reader contents) throws IOException {
-		final HTMLElement pre = parent.pre(Styles.SOURCE + " lang-" + lang
-				+ " linenums");
+		final HTMLElement pre = parent
+				.pre(Styles.SOURCE + " lang-" + lang + " linenums");
 		final BufferedReader lineBuffer = new BufferedReader(contents);
 		String line;
 		int nr = 0;

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/table/BarColumn.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/table/BarColumn.java
@@ -56,9 +56,9 @@ public class BarColumn implements IColumnRenderer {
 	public BarColumn(final CounterEntity entity, final Locale locale) {
 		this.entity = entity;
 		this.integerFormat = DecimalFormat.getIntegerInstance(locale);
-		this.comparator = new TableItemComparator(CounterComparator.MISSEDITEMS
-				.reverse().on(entity)
-				.second(CounterComparator.TOTALITEMS.reverse().on(entity)));
+		this.comparator = new TableItemComparator(
+				CounterComparator.MISSEDITEMS.reverse().on(entity).second(
+						CounterComparator.TOTALITEMS.reverse().on(entity)));
 	}
 
 	public boolean init(final List<? extends ITableItem> items,

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/table/CounterColumn.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/table/CounterColumn.java
@@ -45,8 +45,8 @@ public abstract class CounterColumn implements IColumnRenderer {
 	 */
 	public static CounterColumn newTotal(final CounterEntity entity,
 			final Locale locale) {
-		return new CounterColumn(entity, locale, CounterComparator.TOTALITEMS
-				.reverse().on(entity)) {
+		return new CounterColumn(entity, locale,
+				CounterComparator.TOTALITEMS.reverse().on(entity)) {
 			@Override
 			protected int getValue(final ICounter counter) {
 				return counter.getTotalCount();
@@ -65,8 +65,8 @@ public abstract class CounterColumn implements IColumnRenderer {
 	 */
 	public static CounterColumn newMissed(final CounterEntity entity,
 			final Locale locale) {
-		return new CounterColumn(entity, locale, CounterComparator.MISSEDITEMS
-				.reverse().on(entity)) {
+		return new CounterColumn(entity, locale,
+				CounterComparator.MISSEDITEMS.reverse().on(entity)) {
 			@Override
 			protected int getValue(final ICounter counter) {
 				return counter.getMissedCount();
@@ -85,8 +85,8 @@ public abstract class CounterColumn implements IColumnRenderer {
 	 */
 	public static CounterColumn newCovered(final CounterEntity entity,
 			final Locale locale) {
-		return new CounterColumn(entity, locale, CounterComparator.COVEREDITEMS
-				.reverse().on(entity)) {
+		return new CounterColumn(entity, locale,
+				CounterComparator.COVEREDITEMS.reverse().on(entity)) {
 			@Override
 			protected int getValue(final ICounter counter) {
 				return counter.getCoveredCount();

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/table/Table.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/table/Table.java
@@ -156,8 +156,9 @@ public class Table {
 			this.renderer = renderer;
 			index = new SortIndex<ITableItem>(renderer.getComparator());
 			this.style = style;
-			this.headerStyle = Styles.combine(defaultSorting ? Styles.DOWN
-					: null, Styles.SORTABLE, style);
+			this.headerStyle = Styles.combine(
+					defaultSorting ? Styles.DOWN : null, Styles.SORTABLE,
+					style);
 		}
 
 		void init(final HTMLElement tr, final List<? extends ITableItem> items,
@@ -185,7 +186,8 @@ public class Table {
 				throws IOException {
 			if (visible) {
 				final HTMLElement td = tr.td(style);
-				td.attr("id", idprefix + String.valueOf(index.getPosition(idx)));
+				td.attr("id",
+						idprefix + String.valueOf(index.getPosition(idx)));
 				renderer.item(td, item, resources, base);
 			}
 		}


### PR DESCRIPTION
I would like to propose a consistent formatting of our code base in a single commit.

With this PR all *.java files now comply with the Eclipse 2019-09 formatter. I also applied the formatter to the test code snippets in `jacoco-maven-plugin.test` which are not autoformatted because they are not in Eclipse source folders.

### Reasoning

From the very beginning we had "auto formatting" configured for JaCoCo resulting in a consistent formatting of all source files. A couple of years ago the Eclipse formatter was reworked. Basically it does now IMHO a better job when in comes to line wrapping. This has introduced inconsistencies in our source base between "old" files and newly created source files. Also when working on files formatted the old way autoformating  introduces unrelated changes.
