### PR TITLE
Check code formatting during build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java text eol=lf

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -474,6 +474,11 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>3.5.1</version>
         </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>1.24.3</version>
+       </plugin>
       </plugins>
     </pluginManagement>
 
@@ -549,6 +554,31 @@
                 </requireReleaseDeps>
               </rules>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java>
+            <lineEndings>UNIX</lineEndings>
+            <includes>
+              <include>src/**/*.java</include>
+            </includes>
+            <eclipse>
+              <version>4.12.0</version>
+              <file>../org.jacoco.core/.settings/org.eclipse.jdt.core.prefs</file>
+            </eclipse>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
@marchof thanks to your explanation ❤️ in https://github.com/jacoco/jacoco/pull/954 

> A couple of years ago the Eclipse formatter was reworked.

I  finally understood why Eclipse Code Formatter in IntelliJ at some moment in time started to change formatting when applied on old code. And why [Spotless](https://github.com/diffplug/spotless) was doing the same during my previous attempt to use it for checking of formatting during build.

Given that after https://github.com/jacoco/jacoco/pull/955 formatting will be completely consistent, I propose to add check into build. This will also allow contributors to easily fix formatting even without proper IDE setup - following message is printed when check fails: `Run 'mvn spotless:apply' to fix these violations.` 🎉