### PR TITLE
Absence of Pack200 in JDK 14 should not cause failure of JaCoCo build

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -31,13 +31,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.jar.JarInputStream;
-import java.util.jar.Pack200;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.internal.Pack200Streams;
 import org.jacoco.core.internal.data.CRC64;
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Before;
@@ -303,10 +302,7 @@ public class AnalyzerTest {
 
 		final ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
 		GZIPOutputStream gzipOutput = new GZIPOutputStream(pack200buffer);
-		Pack200.newPacker()
-				.pack(new JarInputStream(
-						new ByteArrayInputStream(zipbuffer.toByteArray())),
-						gzipOutput);
+		Pack200Streams.pack(zipbuffer.toByteArray(), gzipOutput);
 		gzipOutput.finish();
 
 		final int count = analyzer.analyzeAll(

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -42,6 +42,7 @@ import org.jacoco.core.test.TargetLoader;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.TemporaryFolder;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
@@ -293,6 +294,13 @@ public class AnalyzerTest {
 
 	@Test
 	public void testAnalyzeAll_Pack200() throws IOException {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		final ByteArrayOutputStream zipbuffer = new ByteArrayOutputStream();
 		final ZipOutputStream zip = new ZipOutputStream(zipbuffer);
 		zip.putNextEntry(

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
@@ -26,9 +26,6 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.jar.JarInputStream;
-import java.util.jar.JarOutputStream;
-import java.util.jar.Pack200;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
@@ -36,6 +33,7 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 import org.jacoco.core.analysis.AnalyzerTest;
+import org.jacoco.core.internal.Pack200Streams;
 import org.jacoco.core.internal.data.CRC64;
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
@@ -406,10 +404,7 @@ public class InstrumenterTest {
 
 		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
 		GZIPOutputStream gzipOutput = new GZIPOutputStream(pack200buffer);
-		Pack200.newPacker()
-				.pack(new JarInputStream(
-						new ByteArrayInputStream(jarbuffer.toByteArray())),
-						gzipOutput);
+		Pack200Streams.pack(jarbuffer.toByteArray(), gzipOutput);
 		gzipOutput.finish();
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -417,15 +412,10 @@ public class InstrumenterTest {
 				new ByteArrayInputStream(pack200buffer.toByteArray()), out,
 				"Test");
 
-		jarbuffer.reset();
-		Pack200.newUnpacker()
-				.unpack(new GZIPInputStream(
-						new ByteArrayInputStream(out.toByteArray())),
-						new JarOutputStream(jarbuffer));
-
 		assertEquals(1, count);
 		ZipInputStream zipin = new ZipInputStream(
-				new ByteArrayInputStream(jarbuffer.toByteArray()));
+				Pack200Streams.unpack(new GZIPInputStream(
+						new ByteArrayInputStream(out.toByteArray()))));
 		assertEquals("Test.class", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
 	}

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
@@ -40,6 +40,7 @@ import org.jacoco.core.runtime.IExecutionDataAccessorGenerator;
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -396,6 +397,13 @@ public class InstrumenterTest {
 
 	@Test
 	public void testInstrumentAll_Pack200() throws IOException {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
 		zipout.putNextEntry(new ZipEntry("Test.class"));

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
@@ -19,8 +19,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.jar.JarInputStream;
-import java.util.jar.Pack200;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -225,10 +223,7 @@ public class ContentTypeDetectorTest {
 		zip.close();
 
 		final ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
-		Pack200.newPacker()
-				.pack(new JarInputStream(
-						new ByteArrayInputStream(zipbuffer.toByteArray())),
-						pack200buffer);
+		Pack200Streams.pack(zipbuffer.toByteArray(), pack200buffer);
 		initData(pack200buffer.toByteArray());
 		assertEquals(ContentTypeDetector.PACK200FILE, detector.getType());
 		assertContent();

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/ContentTypeDetectorTest.java
@@ -25,6 +25,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
 
 /**
  * Unit tests for {@link ContentTypeDetector}.
@@ -216,6 +217,13 @@ public class ContentTypeDetectorTest {
 
 	@Test
 	public void testPack200File() throws IOException {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		final ByteArrayOutputStream zipbuffer = new ByteArrayOutputStream();
 		final ZipOutputStream zip = new ZipOutputStream(zipbuffer);
 		zip.putNextEntry(new ZipEntry("hello.txt"));

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -41,6 +41,13 @@ public class Pack200StreamsTest {
 
 	@Test
 	public void pack_should_pack() throws Exception {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
 		zipout.putNextEntry(new ZipEntry("Test.class"));
@@ -68,6 +75,13 @@ public class Pack200StreamsTest {
 
 	@Test
 	public void pack_should_throw_IOException_when_can_not_write_to_OutputStream() {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		final OutputStream outputStream = new BrokenOutputStream();
 		try {
 			Pack200Streams.pack(new byte[0], outputStream);
@@ -99,6 +113,13 @@ public class Pack200StreamsTest {
 
 	@Test
 	public void unpack_should_unpack() throws Exception {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
 		zipout.putNextEntry(new ZipEntry("Test.class"));
@@ -124,6 +145,13 @@ public class Pack200StreamsTest {
 
 	@Test
 	public void unpack_should_throw_IOException_when_can_not_read_from_InputStream() {
+		try {
+			Class.forName("java.util.jar.Pack200");
+		} catch (ClassNotFoundException e) {
+			throw new AssumptionViolatedException(
+					"this test requires JDK with Pack200");
+		}
+
 		final InputStream inputStream = new BrokenInputStream();
 		try {
 			Pack200Streams.unpack(inputStream);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -14,6 +14,7 @@ package org.jacoco.core.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
@@ -31,6 +32,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.jacoco.core.test.TargetLoader;
 import org.junit.Test;
+import org.junit.internal.AssumptionViolatedException;
 
 /**
  * Unit tests for {@link Pack200Streams}.
@@ -76,6 +78,24 @@ public class Pack200StreamsTest {
 	}
 
 	@Test
+	public void pack_should_throw_IOException_when_Pack200_not_available_in_JDK() {
+		try {
+			Class.forName("java.util.jar.Pack200");
+			throw new AssumptionViolatedException(
+					"this test requires JDK without Pack200");
+		} catch (ClassNotFoundException ignore) {
+		}
+
+		try {
+			Pack200Streams.pack(new byte[0], new ByteArrayOutputStream());
+			fail("expected exception");
+		} catch (IOException e) {
+			assertNull(e.getMessage());
+			assertTrue(e.getCause() instanceof ClassNotFoundException);
+		}
+	}
+
+	@Test
 	public void unpack_should_unpack() throws Exception {
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
@@ -108,6 +128,24 @@ public class Pack200StreamsTest {
 			fail("expected exception");
 		} catch (IOException e) {
 			assertEquals("fake broken input stream", e.getMessage());
+		}
+	}
+
+	@Test
+	public void unpack_should_throw_IOException_when_Pack200_not_available_in_JDK() {
+		try {
+			Class.forName("java.util.jar.Pack200");
+			throw new AssumptionViolatedException(
+					"this test requires JDK without Pack200");
+		} catch (ClassNotFoundException ignore) {
+		}
+
+		try {
+			Pack200Streams.unpack(new ByteArrayInputStream(new byte[0]));
+			fail("expected exception");
+		} catch (IOException e) {
+			assertNull(e.getMessage());
+			assertTrue(e.getCause() instanceof ClassNotFoundException);
 		}
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
-import java.util.jar.Pack200;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -39,7 +38,7 @@ import org.junit.Test;
 public class Pack200StreamsTest {
 
 	@Test
-	public void testPack() throws IOException {
+	public void pack_should_pack() throws Exception {
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
 		zipout.putNextEntry(new ZipEntry("Test.class"));
@@ -51,9 +50,13 @@ public class Pack200StreamsTest {
 				new NoCloseOutputStream(pack200buffer));
 
 		jarbuffer.reset();
-		Pack200.newUnpacker().unpack(
-				new ByteArrayInputStream(pack200buffer.toByteArray()),
-				new JarOutputStream(jarbuffer));
+		final Object unpacker = Class.forName("java.util.jar.Pack200")
+				.getMethod("newUnpacker").invoke(null);
+		Class.forName("java.util.jar.Pack200$Unpacker")
+				.getMethod("unpack", InputStream.class, JarOutputStream.class)
+				.invoke(unpacker,
+						new ByteArrayInputStream(pack200buffer.toByteArray()),
+						new JarOutputStream(jarbuffer));
 
 		ZipInputStream zipin = new ZipInputStream(
 				new ByteArrayInputStream(jarbuffer.toByteArray()));
@@ -73,7 +76,7 @@ public class Pack200StreamsTest {
 	}
 
 	@Test
-	public void testUnpack() throws IOException {
+	public void unpack_should_unpack() throws Exception {
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
 		zipout.putNextEntry(new ZipEntry("Test.class"));
@@ -81,8 +84,11 @@ public class Pack200StreamsTest {
 		zipout.finish();
 
 		ByteArrayOutputStream pack200buffer = new ByteArrayOutputStream();
-		Pack200.newPacker()
-				.pack(new JarInputStream(
+		final Object packer = Class.forName("java.util.jar.Pack200")
+				.getMethod("newPacker").invoke(null);
+		Class.forName("java.util.jar.Pack200$Packer")
+				.getMethod("pack", JarInputStream.class, OutputStream.class)
+				.invoke(packer, new JarInputStream(
 						new ByteArrayInputStream(jarbuffer.toByteArray())),
 						pack200buffer);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -73,7 +73,9 @@ public class Pack200StreamsTest {
 			Pack200Streams.pack(new byte[0], outputStream);
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("fake broken output stream", e.getMessage());
+			assertTrue(e.getCause() instanceof IOException);
+			assertEquals("fake broken output stream",
+					e.getCause().getMessage());
 		}
 	}
 
@@ -127,7 +129,8 @@ public class Pack200StreamsTest {
 			Pack200Streams.unpack(inputStream);
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("fake broken input stream", e.getMessage());
+			assertTrue(e.getCause() instanceof IOException);
+			assertEquals("fake broken input stream", e.getCause().getMessage());
 		}
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/Pack200StreamsTest.java
@@ -62,6 +62,17 @@ public class Pack200StreamsTest {
 	}
 
 	@Test
+	public void pack_should_throw_IOException_when_can_not_write_to_OutputStream() {
+		final OutputStream outputStream = new BrokenOutputStream();
+		try {
+			Pack200Streams.pack(new byte[0], outputStream);
+			fail("expected exception");
+		} catch (IOException e) {
+			assertEquals("fake broken output stream", e.getMessage());
+		}
+	}
+
+	@Test
 	public void testUnpack() throws IOException {
 		ByteArrayOutputStream jarbuffer = new ByteArrayOutputStream();
 		ZipOutputStream zipout = new ZipOutputStream(jarbuffer);
@@ -83,6 +94,17 @@ public class Pack200StreamsTest {
 		assertNull(zipin.getNextEntry());
 	}
 
+	@Test
+	public void unpack_should_throw_IOException_when_can_not_read_from_InputStream() {
+		final InputStream inputStream = new BrokenInputStream();
+		try {
+			Pack200Streams.unpack(inputStream);
+			fail("expected exception");
+		} catch (IOException e) {
+			assertEquals("fake broken input stream", e.getMessage());
+		}
+	}
+
 	static class NoCloseInputStream extends FilterInputStream {
 		public NoCloseInputStream(InputStream in) {
 			super(in);
@@ -102,6 +124,20 @@ public class Pack200StreamsTest {
 		@Override
 		public void close() throws IOException {
 			fail();
+		}
+	}
+
+	private static class BrokenInputStream extends InputStream {
+		@Override
+		public int read() throws IOException {
+			throw new IOException("fake broken input stream");
+		}
+	}
+
+	private static class BrokenOutputStream extends OutputStream {
+		@Override
+		public void write(int b) throws IOException {
+			throw new IOException("fake broken output stream");
 		}
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java
@@ -36,6 +36,7 @@ public final class Pack200Streams {
 	 * @throws IOException
 	 *             in case of errors with the streams
 	 */
+	@SuppressWarnings("resource")
 	public static InputStream unpack(final InputStream input)
 			throws IOException {
 		final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -70,6 +71,7 @@ public final class Pack200Streams {
 	 * @throws IOException
 	 *             in case of errors with the streams
 	 */
+	@SuppressWarnings("resource")
 	public static void pack(final byte[] source, final OutputStream output)
 			throws IOException {
 		final JarInputStream jar = new JarInputStream(

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,13 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>Support for Pack200 was removed in JDK 14. JaCoCo will now throw a detailed
+      exception when Pack200 archives are processed with the latest JDKs
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/984">#984</a>).</li>
+</ul>
+
 <h2>Release 0.8.5 (2019/10/11)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
Pack200 was deprecated in JDK 13 (https://openjdk.java.net/jeps/336)
with planned removal in JDK 14 (https://openjdk.java.net/jeps/367)
which happened recently (http://hg.openjdk.java.net/jdk/jdk/rev/f236fd5d0c2c)
and supposed to be part of upcoming [JDK 14 Early Access](http://jdk.java.net/14/)  Build 27.

This doesn't cause troubles with released JaCoCo 0.8.5 for cases without processing of Pack200, and in the last case it fails as following
```
$ java -jar jacoco-0.8.5/lib/jacococli.jar classinfo org.eclipse.eclemma.core_3.1.2.201903112331.jar.pack.gz
  INST   BRAN   LINE   METH   CXTY   ELEMENT
Exception in thread "main" java.lang.NoClassDefFoundError: java/util/jar/Pack200
        at org.jacoco.cli.internal.core.internal.Pack200Streams.unpack(Pack200Streams.java:43)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzePack200(Analyzer.java:294)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:200)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeGzip(Analyzer.java:287)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:198)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:226)
        at org.jacoco.cli.internal.commands.ClassInfo.execute(ClassInfo.java:59)
        at org.jacoco.cli.internal.Main.execute(Main.java:90)
        at org.jacoco.cli.internal.Main.main(Main.java:105)
Caused by: java.lang.ClassNotFoundException: java.util.jar.Pack200
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 9 more
```

However this causes compilation failure during JaCoCo build with JDK 14:
```
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ org.jacoco.core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 121 source files to /Users/evgeny.mandrikov/projects/jacoco/org.jacoco.core/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/evgeny.mandrikov/projects/jacoco/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java:[23,21] cannot find symbol
  symbol:   class Pack200
  location: package java.util.jar
[ERROR] /Users/evgeny.mandrikov/projects/jacoco/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java:[43,17] cannot find symbol
  symbol:   variable Pack200
  location: class org.jacoco.core.internal.Pack200Streams
[ERROR] /Users/evgeny.mandrikov/projects/jacoco/org.jacoco.core/src/org/jacoco/core/internal/Pack200Streams.java:[62,17] cannot find symbol
  symbol:   variable Pack200
  location: class org.jacoco.core.internal.Pack200Streams
```

This PR prevents compilation failure and makes support of Pack200 optional by using reflection for JDKs below 14.

Also note that after this change error message will contain location:

```
$ java -jar jacoco-0.8.6.201912130302/lib/jacococli.jar classinfo org.eclipse.eclemma.core_3.1.2.201903112331.jar.pack.gz
  INST   BRAN   LINE   METH   CXTY   ELEMENT
Exception in thread "main" java.io.IOException: Error while analyzing org.eclipse.eclemma.core_3.1.2.201903112331.jar.pack.gz.
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzerError(Analyzer.java:163)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzePack200(Analyzer.java:296)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:200)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeGzip(Analyzer.java:287)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:198)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:226)
        at org.jacoco.cli.internal.commands.ClassInfo.execute(ClassInfo.java:59)
        at org.jacoco.cli.internal.Main.execute(Main.java:90)
        at org.jacoco.cli.internal.Main.main(Main.java:105)
Caused by: java.io.IOException
        at org.jacoco.cli.internal.core.internal.Pack200Streams.newIOException(Pack200Streams.java:95)
        at org.jacoco.cli.internal.core.internal.Pack200Streams.unpack(Pack200Streams.java:51)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzePack200(Analyzer.java:294)
        ... 7 more
Caused by: java.lang.ClassNotFoundException: java.util.jar.Pack200
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:602)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:341)
        at org.jacoco.cli.internal.core.internal.Pack200Streams.unpack(Pack200Streams.java:44)
        ... 8 more
```
