### PR TITLE
jacoco#994 - absolute paths on windows, like ColdFusion makes

### DIFF
--- a/org.jacoco.report/src/org/jacoco/report/DirectorySourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/DirectorySourceFileLocator.java
@@ -46,8 +46,10 @@ public class DirectorySourceFileLocator extends InputStreamSourceFileLocator {
 	@Override
 	protected InputStream getSourceStream(final String path)
 			throws IOException {
-		final File file = new File(directory, path);
+		File file = new File(directory, path);
 		if (file.isFile()) {
+			return new FileInputStream(file);
+		} else if ((file=new File(path)).isFile()) {
 			return new FileInputStream(file);
 		} else {
 			return null;

--- a/org.jacoco.report/src/org/jacoco/report/DirectorySourceFileLocator.java
+++ b/org.jacoco.report/src/org/jacoco/report/DirectorySourceFileLocator.java
@@ -49,7 +49,7 @@ public class DirectorySourceFileLocator extends InputStreamSourceFileLocator {
 		File file = new File(directory, path);
 		if (file.isFile()) {
 			return new FileInputStream(file);
-		} else if ((file=new File(path)).isFile()) {
+		} else if ((file = new File(path)).isFile()) {
 			return new FileInputStream(file);
 		} else {
 			return null;


### PR DESCRIPTION
[for discussion...]

TODO: how to switch on --sourcefiles '', as it gives '/' as the directory

getSourceFile(packageName='', fileName='C:\Users\jpyeron\eclipse-2018-09-workspace\.metadata\.plugins\org.eclipse.wst.server.core\tmp0\wtpwebapps\coldfusion\index.cfm')

related to #939