### PR TITLE
Fix NPE

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/AbstractMatcherTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/AbstractMatcherTest.java
@@ -202,6 +202,10 @@ public class AbstractMatcherTest {
 
 	@Test
 	public void firstIsALoad0() {
+		// should set cursor to null when no opcodes are present
+		matcher.firstIsALoad0(m);
+		assertNull(matcher.cursor);
+
 		// should set cursor to null when opcode mismatch
 		m.visitInsn(Opcodes.NOP);
 		matcher.firstIsALoad0(m);

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/AbstractMatcher.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/AbstractMatcher.java
@@ -35,7 +35,7 @@ abstract class AbstractMatcher {
 	final void firstIsALoad0(final MethodNode methodNode) {
 		cursor = methodNode.instructions.getFirst();
 		skipNonOpcodes();
-		if (cursor.getOpcode() == Opcodes.ALOAD
+		if (cursor != null && cursor.getOpcode() == Opcodes.ALOAD
 				&& ((VarInsnNode) cursor).var == 0) {
 			return;
 		}


### PR DESCRIPTION
`firstIsALoad0` produces an NPE if the method instructions contain only Non-Opcode instructions.