### PR TITLE
WiP: Log total coverage

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
@@ -214,6 +214,12 @@ final class ReportSupport {
 		log.info(format("Analyzed bundle '%s' with %s classes",
 				bundle.getName(),
 				Integer.valueOf(bundle.getClassCounter().getTotalCount())));
+		log.info(format("%s of %s instructions have been covered (%s %%)",
+				Integer.valueOf(
+						bundle.getInstructionCounter().getCoveredCount()),
+				Integer.valueOf(bundle.getInstructionCounter().getTotalCount()),
+				Double.valueOf(bundle.getInstructionCounter().getCoveredRatio()
+						* 100)));
 		if (!nomatch.isEmpty()) {
 			log.warn(format(
 					"Classes in bundle '%s' do no match with execution data. "


### PR DESCRIPTION
I'm facing the same use case as @mauriceqch in #488 and understood and can use different solution options like the XSLT transformation or awk. Nevertheless I'd prefer if I could avoid extra tool usage (being another thing all co-workers need to understand) but have a way of simply print out some summary information easily within the Maven Build. I was thinking about something like sketched in this pull request. I would extend this (see below) but did not want to put any effort into this before getting your opinion on this topic. 

I would add a Maven property (e.g. jacoco.printSummary) to control, whether details should be logged. If set to true, I'd log all counters in a similar way as below.

What do you think about this?