### PR TITLE
Upgrade Groovy to 3.0.6 to support latest Java versions

### DIFF
--- a/org.jacoco.core.test.validation.groovy/pom.xml
+++ b/org.jacoco.core.test.validation.groovy/pom.xml
@@ -26,8 +26,8 @@
   <name>JaCoCo :: Test :: Core :: Validation Groovy</name>
 
   <properties>
-    <gmaven.version>1.6.2</gmaven.version>
-    <groovy.version>2.5.8</groovy.version>
+    <gmaven.version>1.11.0</gmaven.version>
+    <groovy.version>3.0.6</groovy.version>
   </properties>
 
   <dependencies>

--- a/org.jacoco.core.test.validation/pom.xml
+++ b/org.jacoco.core.test.validation/pom.xml
@@ -90,13 +90,9 @@
           <value>7</value>
         </property>
       </activation>
-      <properties>
-        <groovy.targetBytecode>1.7</groovy.targetBytecode>
-      </properties>
       <modules>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
-        <module>../org.jacoco.core.test.validation.groovy</module>
       </modules>
     </profile>
 
@@ -108,13 +104,9 @@
           <value>7</value>
         </property>
       </activation>
-      <properties>
-        <groovy.targetBytecode>1.7</groovy.targetBytecode>
-      </properties>
       <modules>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
-        <module>../org.jacoco.core.test.validation.groovy</module>
       </modules>
     </profile>
 
@@ -215,9 +207,7 @@
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
         <module>../org.jacoco.core.test.validation.java14</module>
-        <!-- Groovy 2.5.8 doesn't support bytecode version 14
         <module>../org.jacoco.core.test.validation.groovy</module>
-        -->
         <module>../org.jacoco.core.test.validation.scala</module>
       </modules>
     </profile>
@@ -240,9 +230,7 @@
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
         <module>../org.jacoco.core.test.validation.java14</module>
-        <!-- Groovy 2.5.8 doesn't support bytecode version 15
         <module>../org.jacoco.core.test.validation.groovy</module>
-        -->
         <module>../org.jacoco.core.test.validation.scala</module>
       </modules>
     </profile>
@@ -265,9 +253,7 @@
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
         <module>../org.jacoco.core.test.validation.java14</module>
-        <!-- Groovy 2.5.8 doesn't support bytecode version 16
         <module>../org.jacoco.core.test.validation.groovy</module>
-        -->
         <module>../org.jacoco.core.test.validation.scala</module>
       </modules>
     </profile>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -137,14 +137,14 @@
     <td>org.jacoco.core.test.validation.groovy</td>
     <td></td>
     <td></td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
+    <td></td>
+    <td>8</td>
+    <td>8</td>
+    <td>8</td>
+    <td>8</td>
+    <td>8</td>
+    <td>8</td>
+    <td>8</td>
   </tr>
   <tr>
     <td>org.jacoco.core.test.validation.kotlin</td>


### PR DESCRIPTION
Since GMavenPlus 1.9.0 Java 14 and Java 15 is supported. This version of
GMavenPlus requires Groovy 3.x, so also update Groovy to latest version.

For other JVM languages I propose that we focus on the last stable
release, so Groovy 3.x should be ok as a test target.

As Java 7 is not supported any more therefore Groovy tests are now
executed for >= Java 8

This closes #1022 being a rebased/updated version of it.