### PR TITLE
improve english grammer

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-nomatch/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-nomatch/verify.bsh
@@ -14,7 +14,7 @@ import java.io.*;
 import org.codehaus.plexus.util.*;
 
 String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
-if ( buildLog.indexOf( "Classes in bundle " ) < 0 || buildLog.indexOf(" do no match with execution data." ) < 0 ) {
+if ( buildLog.indexOf( "Classes in bundle " ) < 0 || buildLog.indexOf(" do not match with execution data." ) < 0 ) {
     throw new RuntimeException( "Warning 1 was not printed" );
 }
 if ( buildLog.indexOf( "For report generation the same class files must be used as at runtime." ) < 0 ) {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
@@ -216,7 +216,7 @@ final class ReportSupport {
 				Integer.valueOf(bundle.getClassCounter().getTotalCount())));
 		if (!nomatch.isEmpty()) {
 			log.warn(format(
-					"Classes in bundle '%s' do no match with execution data. "
+					"Classes in bundle '%s' do not match with execution data. "
 							+ "For report generation the same class files must be used as at runtime.",
 					bundle.getName()));
 			for (final IClassCoverage c : nomatch) {

--- a/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.xml
@@ -129,7 +129,7 @@
 				</classfiles>
 			</structure>
 		</jacoco:report>
-		<au:assertLogContains level="warn" text="Classes in bundle 'root' do no match with execution data."/>
+		<au:assertLogContains level="warn" text="Classes in bundle 'root' do not match with execution data."/>
 		<au:assertLogContains level="warn" text="For report generation the same class files must be used as at runtime."/>
 		<au:assertLogContains level="warn" text="Execution data for class org/jacoco/ant/TestTarget does not match."/>
 	</target>

--- a/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/ReportTask.java
@@ -585,7 +585,7 @@ public class ReportTask extends Task {
 				Integer.valueOf(bundle.getClassCounter().getTotalCount())));
 		if (!nomatch.isEmpty()) {
 			log(format(
-					"Classes in bundle '%s' do no match with execution data. "
+					"Classes in bundle '%s' do not match with execution data. "
 							+ "For report generation the same class files must be used as at runtime.",
 					bundle.getName()), Project.MSG_WARN);
 			for (final IClassCoverage c : nomatch) {


### PR DESCRIPTION
change language from "..do no match with execution data" to "..do not
match with execution data.

This is a simple change in grammer both to the code and the tests.
It can be seen when the classes that jacoco is looking at do not match the classes that were used by the tests.