### PR TITLE
Use ASM9 API

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
@@ -27,7 +27,7 @@ public final class InstrSupport {
 	}
 
 	/** ASM API version */
-	public static final int ASM_API_VERSION = Opcodes.ASM8;
+	public static final int ASM_API_VERSION = Opcodes.ASM9;
 
 	// === Data Field ===
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -23,13 +23,15 @@
 <h3>New Features</h3>
 <ul>
   <li>JaCoCo now officially supports Java 15
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1094">#1094</a>).</li>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1094">#1094</a>
+      <a href="https://github.com/jacoco/jacoco/issues/1097">#1097</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>
 <ul>
   <li>JaCoCo now depends on ASM 9.0
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1094">#1094</a>).</li>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1094">#1094</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/1097">#1097</a>).</li>
 </ul>
 
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -23,7 +23,7 @@
 <h3>New Features</h3>
 <ul>
   <li>JaCoCo now officially supports Java 15
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1094">#1094</a>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1094">#1094</a>,
       <a href="https://github.com/jacoco/jacoco/issues/1097">#1097</a>).</li>
 </ul>
 


### PR DESCRIPTION
For following `Example.java`

```
sealed class Shape
    permits Circle
{
}

final class Circle extends Shape {
}
```

compiled as

```
javac --enable-preview --release 15 -d classes Example.java
```

by

```
openjdk version "15" 2020-09-15
OpenJDK Runtime Environment (build 15+36-1562)
OpenJDK 64-Bit Server VM (build 15+36-1562, mixed mode, sharing)
```

Execution of

```
java -jar jacococli.jar instrument classes --dest instrumented
```

succeeds when using released JaCoCo 0.8.6,
however fails when using snapshot after https://github.com/jacoco/jacoco/pull/1094

```
Exception in thread "main" java.io.IOException: Error while instrumenting /private/tmp/j/classes/Shape.class.
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrumentError(Instrumenter.java:160)
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrument(Instrumenter.java:110)
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrument(Instrumenter.java:135)
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrument(Instrumenter.java:155)
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrumentAll(Instrumenter.java:194)
        at org.jacoco.cli.internal.commands.Instrument.instrument(Instrument.java:89)
        at org.jacoco.cli.internal.commands.Instrument.instrumentRecursive(Instrument.java:78)
        at org.jacoco.cli.internal.commands.Instrument.instrumentRecursive(Instrument.java:74)
        at org.jacoco.cli.internal.commands.Instrument.execute(Instrument.java:61)
        at org.jacoco.cli.internal.Main.execute(Main.java:90)
        at org.jacoco.cli.internal.Main.main(Main.java:105)
Caused by: java.lang.UnsupportedOperationException: PermittedSubclasses requires ASM9
        at org.jacoco.cli.internal.asm.ClassVisitor.visitPermittedSubclass(ClassVisitor.java:266)
        at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:673)
        at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:394)
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrument(Instrumenter.java:90)
        at org.jacoco.cli.internal.core.instr.Instrumenter.instrument(Instrumenter.java:108)
        ... 9 more
```

And will succeed after this change.
