### PR TITLE
improve clarity of violation message

### DIFF
--- a/org.jacoco.report/src/org/jacoco/report/check/Limit.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/Limit.java
@@ -190,9 +190,9 @@ public class Limit {
 	private String message(final String minmax, final BigDecimal v,
 			final BigDecimal ref, final RoundingMode mode) {
 		final BigDecimal rounded = v.setScale(ref.scale(), mode);
-		return String.format("unacceptable %s %s, because %s does not meet %s",
+		return String.format("unacceptable %s %s, because %s does not meet %s %s",
 				ENTITY_NAMES.get(entity),
-				rounded.toPlainString(), VALUE_NAMES.get(value), minmax);
+				rounded.toPlainString(), VALUE_NAMES.get(value), minmax, ref.toPlainString());
 	}
 
 	private String checkRatioLimit() {

--- a/org.jacoco.report/src/org/jacoco/report/check/Limit.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/Limit.java
@@ -190,9 +190,9 @@ public class Limit {
 	private String message(final String minmax, final BigDecimal v,
 			final BigDecimal ref, final RoundingMode mode) {
 		final BigDecimal rounded = v.setScale(ref.scale(), mode);
-		return String.format("%s %s is %s, but expected %s is %s",
-				ENTITY_NAMES.get(entity), VALUE_NAMES.get(value),
-				rounded.toPlainString(), minmax, ref.toPlainString());
+		return String.format("unacceptable %s %s, because %s does not meet %s",
+				ENTITY_NAMES.get(entity),
+				rounded.toPlainString(), VALUE_NAMES.get(value), minmax);
 	}
 
 	private String checkRatioLimit() {


### PR DESCRIPTION
The current message is confusing because the two numbers compared are different (number of things versus metric)

This proposes the following change:

    classes missed count is 3, but expected maximum is 1

becomes

    unacceptable classes is 3, because missed count does not meet maximum 1