### PR TITLE
Add `report-aggregate-all` goal to Maven plugin

### DIFF
--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child1/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child1/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all-customization</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child1</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <jacoco.destFile>target/child1.coverage</jacoco.destFile>
+  </properties>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child1/src/main/java/package1/Example1.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child1/src/main/java/package1/Example1.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1 {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child1/src/test/java/package1/Example1Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child1/src/test/java/package1/Example1Test.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1Test {
+
+	@Test
+	public void test() {
+		new Example1().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child2/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all-customization</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child2</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <jacoco.destFile>target/child2.coverage</jacoco.destFile>
+  </properties>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child2/src/main/java/package2/Example2.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+public class Example2 {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/child2/src/test/java/package2/Example2Test.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+import org.junit.Test;
+
+public class Example2Test {
+
+	@Test
+	public void test() {
+		new Example2().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-aggregate-all-customization</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child1</module>
+    <module>child2</module>
+    <module>report</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/report/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/report/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all-customization</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>report</artifactId>
+  <name>Aggregate Report</name>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate-all</goal>
+            </goals>
+            <configuration>
+              <ignoreMissingDataProjects>false</ignoreMissingDataProjects>
+              <dataFileIncludes>
+                <dataFileInclude>target/*.coverage</dataFileInclude>
+              </dataFileIncludes>
+              <dataFileExcludes>
+                <dataFileExclude>target/child2.coverage</dataFileExclude>
+              </dataFileExcludes>
+              <outputDirectory>target/jacoco-aggregate-customization</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all-customization/verify.bsh
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+import org.codehaus.plexus.util.*;
+import java.util.regex.*;
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+// Test customization of dataFileIncludes and dataFileExcludes
+
+if ( !Pattern.compile( "Loading execution data file \\S*child1.target.child1.coverage").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child1 was not loaded." );
+}
+
+if ( Pattern.compile( "Loading execution data file \\S*child2").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child2 was loaded." );
+}
+
+// Test customization of outputDirectory
+
+File reportChild1 = new File( basedir, "report/target/jacoco-aggregate-customization/child1/index.html" );
+if ( !reportChild1.isFile() ) {
+    throw new RuntimeException( "Report for child1 was not created." );
+}
+
+File reportChild2 = new File( basedir, "report/target/jacoco-aggregate-customization/child2/index.html" );
+if ( !reportChild2.isFile() ) {
+    throw new RuntimeException( "Report for child2 was not created." );
+}
+
+File reportReport = new File( basedir, "report/target/jacoco-aggregate-customization/report/index.html" );
+if ( !reportReport.isFile() ) {
+    throw new RuntimeException( "Report for report was not created." );
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child1-test</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>jacoco</groupId>
+      <artifactId>child1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/src/test/java/package1/Example1bTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/src/test/java/package1/Example1bTest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1bTest {
+
+	@Test
+	public void test() {
+		new Example1b().b();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child1</artifactId>
+  <packaging>jar</packaging>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1a.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1a.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1a {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1b.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1b.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1b {
+
+	public void b() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/test/java/package1/Example1aTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/test/java/package1/Example1aTest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1aTest {
+
+	@Test
+	public void test() {
+		new Example1a().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child2</artifactId>
+  <packaging>jar</packaging>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/main/java/package2/Example2.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+public class Example2 {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/test/java/package2/Example2Test.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+import org.junit.Test;
+
+public class Example2Test {
+
+	@Test
+	public void test() {
+		new Example2().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-aggregate-all</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child1</module>
+    <module>child1-test</module>
+    <module>child2</module>
+    <module>report</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/report/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/report/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>report</artifactId>
+  <name>Aggregate Report</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate-all</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/report/src/test/java/packagereport/ReportTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/report/src/test/java/packagereport/ReportTest.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package packagereport;
+
+import org.junit.Test;
+
+public class ReportTest {
+
+	@Test
+	public void test() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/verify.bsh
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+import org.codehaus.plexus.util.*;
+import java.util.regex.*;
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+if ( !Pattern.compile( "Loading execution data file \\S*child1.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child1 was not loaded." );
+}
+
+if ( !Pattern.compile( "Loading execution data file \\S*child1-test.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child1-test was not loaded." );
+}
+
+if (!Pattern.compile( "Loading execution data file \\S*child2.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child2 was not loaded." );
+}
+
+if ( !Pattern.compile( "Loading execution data file \\S*report.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from report was not loaded." );
+}
+
+File reportChild1 = new File( basedir, "report/target/site/jacoco-aggregate/child1/index.html" );
+if ( !reportChild1.isFile() ) {
+    throw new RuntimeException( "Report for child1 was not created." );
+}
+
+File reportChild2 = new File( basedir, "report/target/site/jacoco-aggregate/child2/index.html" );
+if ( !reportChild2.isFile() ) {
+    throw new RuntimeException( "Report for child2 was not created." );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2020 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    John Oliver, Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.jacoco.report.IReportGroupVisitor;
+
+/**
+ * <p>
+ * Creates a structured code coverage report (HTML, XML, and CSV) from multiple
+ * projects within reactor. The report is created from all modules this project
+ * depends on. From those projects class and source files as well as JaCoCo
+ * execution data files will be collected. In addition execution data is
+ * collected from the project itself. This also allows to create coverage
+ * reports when tests are in separate projects than the code under test, for
+ * example in case of integration tests.
+ * </p>
+ *
+ * <p>
+ * Using the dependency scope allows to distinguish projects which contribute
+ * execution data but should not become part of the report:
+ * </p>
+ *
+ * <ul>
+ * <li><code>compile</code>, <code>runtime</code>, <code>provided</code>:
+ * Project source and execution data is included in the report.</li>
+ * <li><code>test</code>: Only execution data is considered for the report.</li>
+ * </ul>
+ *
+ * @since 0.7.7
+ */
+@Mojo(name = "report-aggregate-all", aggregator = true, inheritByDefault = false, threadSafe = true)
+public class ReportAggregateAllMojo extends AbstractReportMojo {
+
+	/**
+	 * A list of execution data files to include in the report from each
+	 * project. May use wildcard characters (* and ?). When not specified all
+	 * *.exec files from the target folder will be included.
+	 */
+	@Parameter
+	List<String> dataFileIncludes;
+
+	/**
+	 * A list of execution data files to exclude from the report. May use
+	 * wildcard characters (* and ?). When not specified nothing will be
+	 * excluded.
+	 */
+	@Parameter
+	List<String> dataFileExcludes;
+
+	/**
+	 * Ignore projects with no execution data found
+	 */
+	@Parameter(property = "jacoco.ignoreMissingDataProjects", defaultValue = "true")
+	boolean ignoreMissingDataProjects;
+
+	/**
+	 * Output directory for the reports. Note that this parameter is only
+	 * relevant if the goal is run from the command line or from the default
+	 * build lifecycle. If the goal is run indirectly as part of a site
+	 * generation, the output directory configured in the Maven Site Plugin is
+	 * used instead.
+	 */
+	@Parameter(defaultValue = "${project.reporting.outputDirectory}/jacoco-aggregate")
+	private File outputDirectory;
+
+	/**
+	 * The projects in the reactor.
+	 */
+	@Parameter(property = "reactorProjects", readonly = true)
+	private List<MavenProject> reactorProjects;
+
+	@Override
+	boolean canGenerateReportRegardingDataFiles() {
+		return true;
+	}
+
+	@Override
+	boolean canGenerateReportRegardingClassesDirectory() {
+		return true;
+	}
+
+	@Override
+	void loadExecutionData(final ReportSupport support) throws IOException {
+		// https://issues.apache.org/jira/browse/MNG-5440
+		if (dataFileIncludes == null) {
+			dataFileIncludes = Arrays.asList("target/*.exec");
+		}
+
+		final FileFilter filter = new FileFilter(dataFileIncludes,
+				dataFileExcludes);
+		for (final MavenProject dependency : reactorProjects) {
+			loadExecutionData(support, filter, dependency.getBasedir());
+		}
+	}
+
+	private void loadExecutionData(final ReportSupport support,
+			final FileFilter filter, final File basedir) throws IOException {
+		for (final File execFile : filter.getFiles(basedir)) {
+			support.loadExecutionData(execFile);
+		}
+	}
+
+	@Override
+	void addFormatters(final ReportSupport support, final Locale locale)
+			throws IOException {
+		support.addAllFormatters(outputDirectory, outputEncoding, footer,
+				locale);
+	}
+
+	@Override
+	void createReport(final IReportGroupVisitor visitor,
+			final ReportSupport support) throws IOException {
+		final IReportGroupVisitor group = visitor.visitGroup(title);
+		final FileFilter filter = new FileFilter(dataFileIncludes,
+				dataFileExcludes);
+		for (final MavenProject dependency : reactorProjects) {
+			if (ignoreMissingDataProjects
+					&& filter.getFiles(dependency.getBasedir()).isEmpty()) {
+				getLog().info(String.format(
+						"Ignoring bundle '%s' due to missing execution data file.",
+						dependency.getArtifactId()));
+				continue;
+			}
+			support.processProject(group, dependency.getArtifactId(),
+					dependency, getIncludes(), getExcludes(), sourceEncoding);
+		}
+	}
+
+	@Override
+	protected String getOutputDirectory() {
+		return outputDirectory.getAbsolutePath();
+	}
+
+	@Override
+	public void setReportOutputDirectory(final File reportOutputDirectory) {
+		if (reportOutputDirectory != null && !reportOutputDirectory
+				.getAbsolutePath().endsWith("jacoco-aggregate")) {
+			outputDirectory = new File(reportOutputDirectory,
+					"jacoco-aggregate");
+		} else {
+			outputDirectory = reportOutputDirectory;
+		}
+	}
+
+	public String getOutputName() {
+		return "jacoco-aggregate/index";
+	}
+
+	public String getName(final Locale locale) {
+		return "JaCoCo Aggregate";
+	}
+}


### PR DESCRIPTION
Add a new `report-aggregate-all` goal to the JaCoCo maven plugin which
include executions and source files of all the reactor projects into a
single project.