### PR TITLE
Fix bundleName typo in ReportSupport

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportSupport.java
@@ -165,7 +165,7 @@ final class ReportSupport {
 	 *
 	 * @param visitor
 	 *            group visitor to emit the project's coverage to
-	 * @param bundeName
+	 * @param bundleName
 	 *            name for this project in the report
 	 * @param project
 	 *            the MavenProject
@@ -179,15 +179,15 @@ final class ReportSupport {
 	 *             if class files can't be read
 	 */
 	public void processProject(final IReportGroupVisitor visitor,
-			final String bundeName, final MavenProject project,
+			final String bundleName, final MavenProject project,
 			final List<String> includes, final List<String> excludes,
 			final String srcEncoding) throws IOException {
-		processProject(visitor, bundeName, project, includes, excludes,
+		processProject(visitor, bundleName, project, includes, excludes,
 				new SourceFileCollection(project, srcEncoding));
 	}
 
 	private void processProject(final IReportGroupVisitor visitor,
-			final String bundeName, final MavenProject project,
+			final String bundleName, final MavenProject project,
 			final List<String> includes, final List<String> excludes,
 			final ISourceFileLocator locator) throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
@@ -203,7 +203,7 @@ final class ReportSupport {
 			}
 		}
 
-		final IBundleCoverage bundle = builder.getBundle(bundeName);
+		final IBundleCoverage bundle = builder.getBundle(bundleName);
 		logBundleInfo(bundle, builder.getNoMatchClasses());
 
 		visitor.visitBundle(bundle, locator);


### PR DESCRIPTION
Fix bundleName mispelling in ReportSupport (was bundeName)