### PR TITLE
Use BeanShell instead of Groovy scripts

### DIFF
--- a/org.jacoco.examples.test/src/test/resources/verify-it.bsh
+++ b/org.jacoco.examples.test/src/test/resources/verify-it.bsh
@@ -10,8 +10,10 @@
  *    Mirko Friedenhagen - initial API and implementation
  *
  *******************************************************************************/
-File realBaseDir = new File(basedir, "../../../target/it-offline/build");
-assert new File(realBaseDir, "target/site/jacoco/index.html").exists();
-assert !new File(realBaseDir, "target/site/jacoco-it/index.html").exists();
-assert new File(realBaseDir, "build.log").getText().contains(":restore-instrumented-classes");
-return true;
+File realBaseDir = new File(basedir, "../../../target/it-it/build");
+if (!new File(realBaseDir, "target/site/jacoco/index.html").exists()) {
+  throw new RuntimeException();
+}
+if (!new File(realBaseDir, "target/site/jacoco-it/index.html").exists()) {
+  throw new RuntimeException();
+}

--- a/org.jacoco.examples.test/src/test/resources/verify-offline.bsh
+++ b/org.jacoco.examples.test/src/test/resources/verify-offline.bsh
@@ -10,7 +10,15 @@
  *    Mirko Friedenhagen - initial API and implementation
  *
  *******************************************************************************/
-File realBaseDir = new File(basedir, "../../../target/it/build");
-assert new File(realBaseDir, "target/site/jacoco/index.html").exists();
-assert !new File(realBaseDir, "target/site/jacoco-it/index.html").exists();
-return true;
+import org.codehaus.plexus.util.*;
+
+File realBaseDir = new File(basedir, "../../../target/it-offline/build");
+if (!new File(realBaseDir, "target/site/jacoco/index.html").exists()) {
+  throw new RuntimeException();
+}
+if (new File(realBaseDir, "target/site/jacoco-it/index.html").exists()) {
+  throw new RuntimeException();
+}
+if (!FileUtils.fileRead(new File(realBaseDir, "build.log")).contains(":restore-instrumented-classes")) {
+  throw new RuntimeException();
+}

--- a/org.jacoco.examples.test/src/test/resources/verify.bsh
+++ b/org.jacoco.examples.test/src/test/resources/verify.bsh
@@ -10,7 +10,10 @@
  *    Mirko Friedenhagen - initial API and implementation
  *
  *******************************************************************************/
-File realBaseDir = new File(basedir, "../../../target/it-it/build");
-assert new File(realBaseDir, "target/site/jacoco/index.html").exists();
-assert new File(realBaseDir, "target/site/jacoco-it/index.html").exists();
-return true;
+File realBaseDir = new File(basedir, "../../../target/it/build");
+if (!new File(realBaseDir, "target/site/jacoco/index.html").exists()) {
+  throw new RuntimeException();
+}
+if (new File(realBaseDir, "target/site/jacoco-it/index.html").exists()) {
+  throw new RuntimeException();
+}


### PR DESCRIPTION
This fixes build with JDKs from 9 to 16 EA b27 with
`MAVEN_OPTS=--illegal-access=deny`
and with JDK 16 EA b28, where `--illegal-access=deny`
is default due to integration of JEP 396.