### PR TITLE
Upgrading Scala validation tests to Scala 2.13.4

### DIFF
--- a/org.jacoco.core.test.validation.scala/pom.xml
+++ b/org.jacoco.core.test.validation.scala/pom.xml
@@ -24,6 +24,10 @@
 
   <name>JaCoCo :: Test :: Core :: Validation Scala</name>
 
+  <properties>
+    <scala.version>2.13.4</scala.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -33,7 +37,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.4</version>
+      <version>${scala.version}</version>
     </dependency>
   </dependencies>
 

--- a/org.jacoco.core.test.validation.scala/pom.xml
+++ b/org.jacoco.core.test.validation.scala/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.12.8</version>
+      <version>2.13.4</version>
     </dependency>
   </dependencies>
 
@@ -42,7 +42,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.0.2</version>
+        <version>4.4.0</version>
         <executions>
           <execution>
             <id>compile</id>


### PR DESCRIPTION
This is the latest version from Scala 2.12 series.