### PR TITLE
Enabling Scala tests for new bytecode profiles

### DIFF
--- a/org.jacoco.core.test.validation/pom.xml
+++ b/org.jacoco.core.test.validation/pom.xml
@@ -167,6 +167,7 @@
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
         <module>../org.jacoco.core.test.validation.groovy</module>
+        <module>../org.jacoco.core.test.validation.scala</module>
       </modules>
     </profile>
 
@@ -186,6 +187,7 @@
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
         <module>../org.jacoco.core.test.validation.groovy</module>
+        <module>../org.jacoco.core.test.validation.scala</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
Scala 2.12 should work also on Java 11 and 12.

https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html