### PR TITLE
Change assert for CLI DumpTest to pass on non-English systems

### DIFF
--- a/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/DumpTest.java
+++ b/org.jacoco.cli.test/src/org/jacoco/cli/internal/commands/DumpTest.java
@@ -87,7 +87,9 @@ public class DumpTest extends CommandTestBase {
 		} catch (IOException ignore) {
 		}
 
-		assertContains("[WARN] Connection refused", err);
+		// Locale independent parts of error message:
+		assertContains("[WARN]", err);
+		assertContains("Connection refused", err);
 	}
 
 	private int startMockServer() throws IOException {


### PR DESCRIPTION
For a non-English system the error message may differ.

E.g. on a Hungarian system it says:
"[WARN] Kapcsolat elutasítva (Connection refused)."
This fails the test as it does not include "[WARN] Connection refused".

Change the assert to allow for the changed error message.