### PR TITLE
Update filter for Kotlin 1.5 suspending functions

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SyntheticFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SyntheticFilterTest.java
@@ -130,6 +130,17 @@ public class SyntheticFilterTest extends FilterTestBase {
 		assertIgnored();
 	}
 
+	/**
+	 * For private suspending function Kotlin compiler versions prior to 1.5
+	 * produce package-local synthetic method that should not be filtered
+	 *
+	 * <pre>
+	 * private suspend fun example() {
+	 * }
+	 * </pre>
+	 *
+	 * @see #should_filter_synthetic_methods_whose_name_starts_with_access_dollar_even_if_last_argument_is_kotlin_coroutine_continuation()
+	 */
 	@Test
 	public void should_not_filter_synthetic_methods_whose_last_argument_is_kotlin_coroutine_continuation() {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
@@ -143,6 +154,38 @@ public class SyntheticFilterTest extends FilterTestBase {
 		filter.filter(m, context, output);
 
 		assertIgnored();
+	}
+
+	/**
+	 * For private suspending function Kotlin compiler versions starting from
+	 * 1.5 produce additional public synthetic method with name starting with
+	 * "access$" that should be filtered
+	 *
+	 * <pre>
+	 * private suspend fun example() {
+	 * }
+	 * </pre>
+	 *
+	 * @see #should_not_filter_synthetic_methods_whose_last_argument_is_kotlin_coroutine_continuation()
+	 */
+	@Test
+	public void should_filter_synthetic_methods_whose_name_starts_with_access_dollar_even_if_last_argument_is_kotlin_coroutine_continuation() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
+				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
+						| Opcodes.ACC_SYNTHETIC,
+				"access$example",
+				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
+				null);
+		context.classAnnotations
+				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
+		m.visitVarInsn(Opcodes.ALOAD, 0);
+		m.visitMethodInsn(Opcodes.INVOKESTATIC, "ExampleKt", "example",
+				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", false);
+		m.visitInsn(Opcodes.RETURN);
+
+		filter.filter(m, context, output);
+
+		assertMethodIgnored(m);
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilter.java
@@ -29,7 +29,11 @@ import org.objectweb.asm.tree.TableSwitchInsnNode;
  */
 public final class KotlinCoroutineFilter implements IFilter {
 
-	static boolean isLastArgumentContinuation(final MethodNode methodNode) {
+	static boolean isImplementationOfSuspendFunction(
+			final MethodNode methodNode) {
+		if (methodNode.name.startsWith("access$")) {
+			return false;
+		}
 		final Type methodType = Type.getMethodType(methodNode.desc);
 		final int lastArgument = methodType.getArgumentTypes().length - 1;
 		return lastArgument >= 0 && "kotlin.coroutines.Continuation".equals(

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SyntheticFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/SyntheticFilter.java
@@ -52,7 +52,8 @@ public final class SyntheticFilter implements IFilter {
 				return;
 			}
 
-			if (KotlinCoroutineFilter.isLastArgumentContinuation(methodNode)) {
+			if (KotlinCoroutineFilter
+					.isImplementationOfSuspendFunction(methodNode)) {
 				return;
 			}
 		}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -30,6 +30,9 @@
   <li>Branch added by the Kotlin compiler version 1.4.0 and above for "unsafe" cast
       operator is filtered out during generation of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1143">#1143</a>).</li>
+  <li><code>synthetic</code> methods added by the Kotlin compiler version 1.5.0 and
+      above for <code>private</code> suspending functions are filtered out
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1174">#1174</a>).</li>
   <li>Branches added by the Kotlin compiler version 1.4.20 and above for suspending
       lambdas are filtered out during generation of report
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1149">#1149</a>).</li>


### PR DESCRIPTION
Currently execution of

```
mvn clean package -Dkotlin.version=1.5.0-M2
```

leads to

```
Failed tests:
  all_missed_instructions_should_have_line_number(org.jacoco.core.test.validation.kotlin.KotlinCoroutineTest): sum of missed instructions of all lines should be equal to missed instructions of file expected:<4> but was:<2>
```

---

For the following `Example.kt`

```
private suspend fun example() {
    println("private")
}
```

Execution of

```
kotlin/bin/kotlinc Example.kt -d classes
javap -v -p classes/ExampleKt.class
```

using Kotlin compiler version `1.4` produces

```
{
  static final java.lang.Object example(kotlin.coroutines.Continuation<? super kotlin.Unit>);
    descriptor: (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: (0x1018) ACC_STATIC, ACC_FINAL, ACC_SYNTHETIC
    Code:
      stack=2, locals=3, args_size=1
         0: ldc           #9                  // String private
         2: astore_1
         3: iconst_0
         4: istore_2
         5: getstatic     #15                 // Field java/lang/System.out:Ljava/io/PrintStream;
         8: aload_1
         9: invokevirtual #21                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        12: getstatic     #27                 // Field kotlin/Unit.INSTANCE:Lkotlin/Unit;
        15: areturn
      LineNumberTable:
        line 2: 0
        line 3: 12
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0      16     0 $completion   Lkotlin/coroutines/Continuation;
    Signature: #7                           // (Lkotlin/coroutines/Continuation<-Lkotlin/Unit;>;)Ljava/lang/Object;
}
```

whereas using Kotlin compiler version `1.5-M2` produces

```
{
  private static final java.lang.Object example(kotlin.coroutines.Continuation<? super kotlin.Unit>);
    descriptor: (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: (0x001a) ACC_PRIVATE, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=3, args_size=1
         0: ldc           #9                  // String private
         2: astore_1
         3: iconst_0
         4: istore_2
         5: getstatic     #15                 // Field java/lang/System.out:Ljava/io/PrintStream;
         8: aload_1
         9: invokevirtual #21                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        12: getstatic     #27                 // Field kotlin/Unit.INSTANCE:Lkotlin/Unit;
        15: areturn
      LineNumberTable:
        line 2: 0
        line 3: 12
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0      16     0 $completion   Lkotlin/coroutines/Continuation;
    Signature: #7                           // (Lkotlin/coroutines/Continuation<-Lkotlin/Unit;>;)Ljava/lang/Object;

  public static final java.lang.Object access$example(kotlin.coroutines.Continuation);
    descriptor: (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
    flags: (0x1019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_SYNTHETIC
    Code:
      stack=1, locals=1, args_size=1
         0: aload_0
         1: invokestatic  #32                 // Method example:(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
         4: areturn
      LineNumberTable:
        line 1: 1
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0       5     0 $completion   Lkotlin/coroutines/Continuation;
}
```

---

This seems to be related to the following change in Kotlin compiler - 
https://github.com/JetBrains/kotlin/commit/85b9b5b85f204a141dda7974ccb9e897a8a3e3d2