### PR TITLE
Update KotlinControlStructuresTarget for Kotlin 1.5

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinControlStructuresTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinControlStructuresTarget.kt
@@ -72,7 +72,7 @@ object KotlinControlStructuresTarget {
 
     private fun missedForBlock() {
 
-        for (j in 0..-1) { // assertPartlyCovered(1, 1)
+        for (j in i2()..i1()) { // assertPartlyCovered(3, 1)
             nop() // assertNotCovered()
         }
 
@@ -80,7 +80,7 @@ object KotlinControlStructuresTarget {
 
     private fun executedForBlock() {
 
-        for (j in 0..0) { // assertFullyCovered(0, 2)
+        for (j in i1()..i2()) { // assertFullyCovered(1, 3)
             nop() // assertFullyCovered()
         }
 
@@ -125,7 +125,7 @@ object KotlinControlStructuresTarget {
 
     private fun continueStatement() {
 
-        for (j in 0..0) {
+        for (j in i1()..i2()) {
             if (t()) {
                 continue // assertFullyCovered()
             }


### PR DESCRIPTION
Currently execution of any of

```
mvn clean package -Dkotlin.version=1.5.0-M1
mvn clean package -Dkotlin.version=1.5.0-M2
mvn clean package -Dkotlin.version=1.5.0-RC
mvn clean package -Dkotlin.version=1.5.0
```

leads to

```
Failed tests:
  execute_assertions_in_comments(org.jacoco.core.test.validation.kotlin.KotlinControlStructuresTest): Instructions (KotlinControlStructuresTarget.kt:67) expected:<[PART]LY_COVERED> but was:<[FUL]LY_COVERED>
```

---

For the following Example.kt

```
fun example() {
  for (i in 0..-1) {
    nop()
  }
}

fun nop() {
}
```

Execution of

```
kotlin/bin/kotlinc Example.kt -d classes
javap -v -p classes/ExampleKt.class
```

using Kotlin compiler version 1.4 produces

```
  public static final void example();
    descriptor: ()V
    flags: ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=2, args_size=0
         0: iconst_0
         1: istore_0
         2: iconst_m1
         3: istore_1
         4: iload_0
         5: iload_1
         6: if_icmpgt     18
         9: invokestatic  #9                  // Method nop:()V
        12: iinc          0, 1
        15: goto          4
        18: return
      LineNumberTable:
        line 2: 0
        line 2: 4
        line 3: 9
        line 2: 12
        line 5: 18
```

whereas using Kotlin compiler version 1.5 produces

```
  public static final void example();
    descriptor: ()V
    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=1, locals=1, args_size=0
         0: iconst_0
         1: istore_0
         2: return
      LineNumberTable:
        line 2: 0
        line 5: 2
```

i.e. for-loop with range expression whose bounds are constants with end less than start is folded into nop by Kotlin compiler version 1.5

Without constants in for-loops behaviour is the same for compiler version 1.5 as for earlier versions.