### PR TITLE
Include JaCoCo version in instrumentation/analysis exception messages

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.jacoco.agent.rt.internal;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -215,11 +214,11 @@ public class CoverageTransformerTest {
 					protectionDomain, null);
 			fail("IllegalClassFormatException expected.");
 		} catch (IllegalClassFormatException e) {
-			assertEquals("Error while instrumenting org.jacoco.Sample.",
-					e.getMessage());
+			assertTrue(e.getMessage(), e.getMessage()
+					.startsWith("Error while instrumenting org.jacoco.Sample"));
 		}
 		recorder.assertException(IllegalClassFormatException.class,
-				"Error while instrumenting org.jacoco.Sample.",
+				"Error while instrumenting org.jacoco.Sample",
 				IOException.class);
 		recorder.clear();
 	}

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/CoverageTransformerTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.agent.rt.internal;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -214,11 +215,15 @@ public class CoverageTransformerTest {
 					protectionDomain, null);
 			fail("IllegalClassFormatException expected.");
 		} catch (IllegalClassFormatException e) {
-			assertTrue(e.getMessage(), e.getMessage()
-					.startsWith("Error while instrumenting org.jacoco.Sample"));
+			assertEquals(String.format(
+					"Error while instrumenting %s with JaCoCo %s/%s.",
+					"org.jacoco.Sample", JaCoCo.VERSION, JaCoCo.COMMITID_SHORT),
+					e.getMessage());
 		}
 		recorder.assertException(IllegalClassFormatException.class,
-				"Error while instrumenting org.jacoco.Sample",
+				String.format("Error while instrumenting %s with JaCoCo %s/%s.",
+						"org.jacoco.Sample", JaCoCo.VERSION,
+						JaCoCo.COMMITID_SHORT),
 				IOException.class);
 		recorder.clear();
 	}

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/ExceptionRecorder.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/ExceptionRecorder.java
@@ -14,6 +14,7 @@ package org.jacoco.agent.rt.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * {@link IExceptionLogger} implementation for testing purposes.
@@ -50,7 +51,7 @@ public class ExceptionRecorder implements IExceptionLogger {
 	public void assertException(final Class<? extends Throwable> exceptionType,
 			final String message, final Class<? extends Throwable> causeType) {
 		assertEquals(exceptionType, this.exceptionType);
-		assertEquals(message, this.message);
+		assertTrue(this.message, this.message.startsWith(message));
 		assertEquals(causeType, this.causeType);
 	}
 

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/ExceptionRecorder.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/ExceptionRecorder.java
@@ -14,7 +14,6 @@ package org.jacoco.agent.rt.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * {@link IExceptionLogger} implementation for testing purposes.
@@ -51,7 +50,7 @@ public class ExceptionRecorder implements IExceptionLogger {
 	public void assertException(final Class<? extends Throwable> exceptionType,
 			final String message, final Class<? extends Throwable> causeType) {
 		assertEquals(exceptionType, this.exceptionType);
-		assertTrue(this.message, this.message.startsWith(message));
+		assertEquals(message, this.message);
 		assertEquals(causeType, this.causeType);
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/JaCoCoTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/JaCoCoTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.core;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
@@ -24,6 +25,16 @@ public class JaCoCoTest {
 	@Test
 	public void testVERSION() {
 		assertNotNull(JaCoCo.VERSION);
+	}
+
+	@Test
+	public void testCOMMITID() {
+		assertNotNull(JaCoCo.COMMITID);
+	}
+
+	@Test
+	public void testCOMMITID_SHORT() {
+		assertEquals(7, JaCoCo.COMMITID_SHORT.length());
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/AnalyzerTest.java
@@ -36,6 +36,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import org.jacoco.core.JaCoCo;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.internal.Pack200Streams;
 import org.jacoco.core.internal.data.CRC64;
@@ -136,8 +137,7 @@ public class AnalyzerTest {
 			analyzer.analyzeClass(bytes, "UnsupportedVersion");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing UnsupportedVersion.",
-					e.getMessage());
+			assertExceptionMessage("UnsupportedVersion", e);
 			assertEquals("Unsupported class file major version 64",
 					e.getCause().getMessage());
 		}
@@ -164,7 +164,7 @@ public class AnalyzerTest {
 		final byte[] bytes = TargetLoader
 				.getClassDataAsBytes(AnalyzerTest.class);
 		executionData.get(Long.valueOf(CRC64.classId(bytes)),
-				"org/jacoco/core/analysis/AnalyzerTest", 200);
+				"org/jacoco/core/analysis/AnalyzerTest", 400);
 		analyzer.analyzeClass(bytes, "Test");
 		assertFalse(classes.get("org/jacoco/core/analysis/AnalyzerTest")
 				.isNoMatch());
@@ -173,7 +173,7 @@ public class AnalyzerTest {
 	@Test
 	public void testAnalyzeClassNoIdMatch() throws IOException {
 		executionData.get(Long.valueOf(0),
-				"org/jacoco/core/analysis/AnalyzerTest", 200);
+				"org/jacoco/core/analysis/AnalyzerTest", 400);
 		analyzer.analyzeClass(
 				TargetLoader.getClassDataAsBytes(AnalyzerTest.class), "Test");
 		assertTrue(classes.get("org/jacoco/core/analysis/AnalyzerTest")
@@ -189,7 +189,7 @@ public class AnalyzerTest {
 			analyzer.analyzeClass(brokenclass, "Broken.class");
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing Broken.class.", e.getMessage());
+			assertExceptionMessage("Broken.class", e);
 		}
 	}
 
@@ -209,7 +209,7 @@ public class AnalyzerTest {
 			analyzer.analyzeClass(new BrokenInputStream(), "BrokenStream");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing BrokenStream.", e.getMessage());
+			assertExceptionMessage("BrokenStream", e);
 		}
 	}
 
@@ -224,8 +224,7 @@ public class AnalyzerTest {
 					"UnsupportedVersion");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing UnsupportedVersion.",
-					e.getMessage());
+			assertExceptionMessage("UnsupportedVersion", e);
 			assertEquals("Unsupported class file major version 64",
 					e.getCause().getMessage());
 		}
@@ -274,7 +273,7 @@ public class AnalyzerTest {
 			analyzer.analyzeAll(new BrokenInputStream(), "Test");
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing Test.", e.getMessage());
+			assertExceptionMessage("Test", e);
 		}
 	}
 
@@ -289,7 +288,7 @@ public class AnalyzerTest {
 			analyzer.analyzeAll(new ByteArrayInputStream(buffer), "Test.gz");
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing Test.gz.", e.getMessage());
+			assertExceptionMessage("Test.gz", e);
 		}
 	}
 
@@ -333,7 +332,7 @@ public class AnalyzerTest {
 					"Test.pack200");
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing Test.pack200.", e.getMessage());
+			assertExceptionMessage("Test.pack200", e);
 		}
 	}
 
@@ -380,7 +379,7 @@ public class AnalyzerTest {
 			analyzer.analyzeAll(new ByteArrayInputStream(buffer), "Test.zip");
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals("Error while analyzing Test.zip.", e.getMessage());
+			assertExceptionMessage("Test.zip", e);
 		}
 	}
 
@@ -431,9 +430,8 @@ public class AnalyzerTest {
 					"test.zip");
 			fail("expected exception");
 		} catch (IOException e) {
-			assertEquals(
-					"Error while analyzing test.zip@org/jacoco/core/analysis/AnalyzerTest.class.",
-					e.getMessage());
+			assertExceptionMessage(
+					"test.zip@org/jacoco/core/analysis/AnalyzerTest.class", e);
 		}
 	}
 
@@ -450,6 +448,12 @@ public class AnalyzerTest {
 	private void assertClasses(String... classNames) {
 		assertEquals(new HashSet<String>(Arrays.asList(classNames)),
 				classes.keySet());
+	}
+
+	private void assertExceptionMessage(String name, Exception ex) {
+		String expected = "Error while analyzing " + name + " with JaCoCo "
+				+ JaCoCo.VERSION + "/" + JaCoCo.COMMITID_SHORT + ".";
+		assertEquals(expected, ex.getMessage());
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/InstrumenterTest.java
@@ -33,6 +33,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import org.jacoco.core.JaCoCo;
 import org.jacoco.core.analysis.AnalyzerTest;
 import org.jacoco.core.internal.Pack200Streams;
 import org.jacoco.core.internal.data.CRC64;
@@ -127,8 +128,7 @@ public class InstrumenterTest {
 			instrumenter.instrument(bytes, "UnsupportedVersion");
 			fail("exception expected");
 		} catch (final IOException e) {
-			assertEquals("Error while instrumenting UnsupportedVersion.",
-					e.getMessage());
+			assertExceptionMessage("UnsupportedVersion", e);
 			assertEquals("Unsupported class file major version 64",
 					e.getCause().getMessage());
 		}
@@ -156,8 +156,7 @@ public class InstrumenterTest {
 			instrumenter.instrument(brokenclass, "Broken.class");
 			fail();
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting Broken.class.",
-					e.getMessage());
+			assertExceptionMessage("Broken.class", e);
 		}
 	}
 
@@ -178,8 +177,7 @@ public class InstrumenterTest {
 			instrumenter.instrument(new BrokenInputStream(), "BrokenStream");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting BrokenStream.",
-					e.getMessage());
+			assertExceptionMessage("BrokenStream", e);
 		}
 	}
 
@@ -194,8 +192,7 @@ public class InstrumenterTest {
 					new ByteArrayOutputStream(), "BrokenStream");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting BrokenStream.",
-					e.getMessage());
+			assertExceptionMessage("BrokenStream", e);
 		}
 	}
 
@@ -230,8 +227,7 @@ public class InstrumenterTest {
 					new ByteArrayOutputStream(), "UnsupportedVersion");
 			fail("exception expected");
 		} catch (final IOException e) {
-			assertEquals("Error while instrumenting UnsupportedVersion.",
-					e.getMessage());
+			assertExceptionMessage("UnsupportedVersion", e);
 			assertEquals("Unsupported class file major version 64",
 					e.getCause().getMessage());
 		}
@@ -297,7 +293,7 @@ public class InstrumenterTest {
 					new ByteArrayOutputStream(), "Broken");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting Broken.", e.getMessage());
+			assertExceptionMessage("Broken", e);
 		}
 	}
 
@@ -324,7 +320,7 @@ public class InstrumenterTest {
 			instrumenter.instrumentAll(inputStream, new ByteArrayOutputStream(),
 					"Broken");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting Broken.", e.getMessage());
+			assertExceptionMessage("Broken", e);
 		}
 	}
 
@@ -346,7 +342,7 @@ public class InstrumenterTest {
 					new ByteArrayOutputStream(), "Test.zip");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting Test.zip.", e.getMessage());
+			assertExceptionMessage("Test.zip", e);
 		}
 	}
 
@@ -371,9 +367,7 @@ public class InstrumenterTest {
 					new ByteArrayOutputStream(), "broken.zip");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals(
-					"Error while instrumenting broken.zip@brokenentry.txt.",
-					e.getMessage());
+			assertExceptionMessage("broken.zip@brokenentry.txt", e);
 		}
 	}
 
@@ -394,8 +388,7 @@ public class InstrumenterTest {
 					"test.zip");
 			fail();
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting test.zip@Test.class.",
-					e.getMessage());
+			assertExceptionMessage("test.zip@Test.class", e);
 		}
 	}
 
@@ -412,7 +405,7 @@ public class InstrumenterTest {
 					new ByteArrayOutputStream(), "Test.gz");
 			fail("exception expected");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting Test.gz.", e.getMessage());
+			assertExceptionMessage("Test.gz", e);
 		}
 	}
 
@@ -462,8 +455,7 @@ public class InstrumenterTest {
 			instrumenter.instrumentAll(new ByteArrayInputStream(buffer),
 					new ByteArrayOutputStream(), "Test.pack200");
 		} catch (IOException e) {
-			assertEquals("Error while instrumenting Test.pack200.",
-					e.getMessage());
+			assertExceptionMessage("Test.pack200", e);
 		}
 	}
 
@@ -514,6 +506,12 @@ public class InstrumenterTest {
 				new ByteArrayInputStream(out.toByteArray()));
 		assertEquals("META-INF/ALIAS.SF", zipin.getNextEntry().getName());
 		assertNull(zipin.getNextEntry());
+	}
+
+	private void assertExceptionMessage(String name, Exception ex) {
+		String expected = "Error while instrumenting " + name + " with JaCoCo "
+				+ JaCoCo.VERSION + "/" + JaCoCo.COMMITID_SHORT + ".";
+		assertEquals(expected, ex.getMessage());
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/JaCoCo.java
+++ b/org.jacoco.core/src/org/jacoco/core/JaCoCo.java
@@ -19,8 +19,16 @@ import java.util.ResourceBundle;
  */
 public final class JaCoCo {
 
-	/** Qualified build version of the JaCoCo core library. */
+	/** Version of JaCoCo core. */
 	public static final String VERSION;
+
+	/** Commit ID of the source tree of JaCoCo core. */
+	public static final String COMMITID;
+
+	/**
+	 * Shortened (7 digit) commit ID of the source tree of JaCoCo core.
+	 */
+	public static final String COMMITID_SHORT;
 
 	/** Absolute URL of the current JaCoCo home page */
 	public static final String HOMEURL;
@@ -32,6 +40,8 @@ public final class JaCoCo {
 		final ResourceBundle bundle = ResourceBundle
 				.getBundle("org.jacoco.core.jacoco");
 		VERSION = bundle.getString("VERSION");
+		COMMITID = bundle.getString("COMMITID");
+		COMMITID_SHORT = COMMITID.substring(0, 7);
 		HOMEURL = bundle.getString("HOMEURL");
 		RUNTIMEPACKAGE = bundle.getString("RUNTIMEPACKAGE");
 	}

--- a/org.jacoco.core/src/org/jacoco/core/JaCoCo.java
+++ b/org.jacoco.core/src/org/jacoco/core/JaCoCo.java
@@ -19,7 +19,7 @@ import java.util.ResourceBundle;
  */
 public final class JaCoCo {
 
-	/** Version of JaCoCo core. */
+	/** Qualified version of JaCoCo core. */
 	public static final String VERSION;
 
 	/** Commit ID of the source tree of JaCoCo core. */

--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -21,6 +21,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import org.jacoco.core.JaCoCo;
 import org.jacoco.core.data.ExecutionData;
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.internal.ContentTypeDetector;
@@ -160,7 +161,8 @@ public class Analyzer {
 	private IOException analyzerError(final String location,
 			final Exception cause) {
 		final IOException ex = new IOException(
-				String.format("Error while analyzing %s.", location));
+				String.format("Error while analyzing %s with JaCoCo %s/%s.",
+						location, JaCoCo.VERSION, JaCoCo.COMMITID_SHORT));
 		ex.initCause(cause);
 		return ex;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
@@ -23,6 +23,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import org.jacoco.core.JaCoCo;
 import org.jacoco.core.internal.ContentTypeDetector;
 import org.jacoco.core.internal.InputStreams;
 import org.jacoco.core.internal.Pack200Streams;
@@ -158,7 +159,8 @@ public class Instrumenter {
 	private IOException instrumentError(final String name,
 			final Exception cause) {
 		final IOException ex = new IOException(
-				String.format("Error while instrumenting %s.", name));
+				String.format("Error while instrumenting %s with JaCoCo %s/%s.",
+						name, JaCoCo.VERSION, JaCoCo.COMMITID_SHORT));
 		ex.initCause(cause);
 		return ex;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/jacoco.properties
+++ b/org.jacoco.core/src/org/jacoco/core/jacoco.properties
@@ -1,3 +1,4 @@
 VERSION=${qualified.bundle.version}
+COMMITID=${buildNumber}
 HOMEURL=${jacoco.home.url}
 RUNTIMEPACKAGE=${jacoco.runtime.package.name}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -46,6 +46,9 @@
 <ul>
   <li>JaCoCo now depends on ASM 9.2
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1206">#1206</a>).</li>
+  <li>Messages of exceptions occurring during analysis or instrumentation now include
+      JaCoCo version
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1217">#1217</a>).</li>
 </ul>
 
 <h2>Release 0.8.7 (2021/05/04)</h2>


### PR DESCRIPTION
This should help in situations where users cannot see which version is actually used, like in AGP builds.