### PR TITLE
KotlinWhenStringFilter: remove filtering for Scala classes

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilter.java
@@ -29,9 +29,17 @@ import org.objectweb.asm.tree.VarInsnNode;
  * expressions with a <code>String</code>.
  */
 public final class KotlinWhenStringFilter implements IFilter {
+	private static boolean isScalaClass(final IFilterContext context) {
+		return context.getClassAttributes().contains("ScalaSig")
+				|| context.getClassAttributes().contains("Scala");
+	}
 
 	public void filter(final MethodNode methodNode,
 			final IFilterContext context, final IFilterOutput output) {
+		if (isScalaClass(context)) {
+			return;
+		}
+
 		final Matcher matcher = new Matcher();
 		for (final AbstractInsnNode i : methodNode.instructions) {
 			matcher.match(i, output);


### PR DESCRIPTION
This removes a Jacoco bug for some Scala 2.13 classes.

Bug report in https://github.com/bazelbuild/rules_scala/issues/1291.