### PR TITLE
Fix misleading FAQ

### DIFF
--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -65,7 +65,7 @@
   into the control flow at certain positions. Code is considered as executed
   when a subsequent probe has been executed. In case of exceptions such a
   sequence of instructions is aborted somewhere in the middle and the
-  corresponding line of source code is not marked as covered.
+  corresponding lines of source code are not marked as covered.
 </p>
 
 <h3>Why does the coverage report not show line coverage figures?</h3>


### PR DESCRIPTION
A sequence of instructions between two probes may correspond to several lines.

In that case, as identified in #1223, an exception may "hide" the executed status of several lines, and not just one.