### PR TITLE
Use Maven 3.8.3 in Azure Pipelines

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
   - bash: |
       set -e
       mkdir .maven
-      curl -L "https://downloads.apache.org/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz" -o .maven/maven.tar.gz
+      curl -L "https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz" -o .maven/maven.tar.gz
       tar -xzf .maven/maven.tar.gz -C .maven --strip-components 1
     displayName: Setup Maven
   - bash: |

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -551,7 +551,8 @@
                   <version>1.8</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>3.3.9</version>
+                  <!-- Maven 3.8.2 contains bug - see https://github.com/jacoco/jacoco/issues/1218 -->
+                  <version>[3.3.9,3.8.2),(3.8.2,)</version>
                 </requireMavenVersion>
                 <requireNoRepositories>
                   <message>The rules for repo1.maven.org are that pom.xml files should not include repository definitions.</message>


### PR DESCRIPTION
Maven 3.8.1 disappeared from https://downloads.apache.org/maven/maven-3/ which causes our builds in Azure Pipelines to fail - see for example [build](https://dev.azure.com/jacoco-org/JaCoCo/_build/results?buildId=531&view=results) after merge of #1226

Instead we should be downloading from https://archive.apache.org/dist/maven/maven-3/ that contains all released versions.

Also seems that recently released Maven 3.8.3 solves the issue that we encountered with 3.8.2

Unfortunately Azure Pipelines images was not yet updated and still come with preinstalled Maven 3.8.2

Fixes #1218