### PR TITLE
Filter branches in `for until` loop starting from Kotlin 1.5

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinControlStructuresTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinControlStructuresTarget.kt
@@ -72,7 +72,7 @@ object KotlinControlStructuresTarget {
 
     private fun missedForBlock() {
 
-        for (j in i2()..i1()) { // assertPartlyCovered(3, 1)
+        for (j in i2()..i1()) { // assertPartlyCovered(2,0)
             nop() // assertNotCovered()
         }
 
@@ -80,7 +80,16 @@ object KotlinControlStructuresTarget {
 
     private fun executedForBlock() {
 
-        for (j in i1()..i2()) { // assertFullyCovered(1, 3)
+        for (j in i1()..i2()) { // assertFullyCovered(0, 2)
+            nop() // assertFullyCovered()
+        }
+
+        val limit = 10 // assertFullyCovered()
+        for (j in i1() until limit) { // assertFullyCovered(0,2)
+            nop() // assertFullyCovered()
+        }
+
+        for (j in limit downTo i1()) { // assertFullyCovered(0,2)
             nop() // assertFullyCovered()
         }
 

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinControlStructuresTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinControlStructuresTarget.kt
@@ -72,7 +72,7 @@ object KotlinControlStructuresTarget {
 
     private fun missedForBlock() {
 
-        for (j in i2()..i1()) { // assertPartlyCovered(2,0)
+        for (j in i2()..i1()) { // assertPartlyCovered()
             nop() // assertNotCovered()
         }
 
@@ -80,19 +80,30 @@ object KotlinControlStructuresTarget {
 
     private fun executedForBlock() {
 
-        for (j in i1()..i2()) { // assertFullyCovered(0, 2)
+        for (j in i1()..i2()) { // assertFullyCovered()
             nop() // assertFullyCovered()
         }
 
         val limit = 10 // assertFullyCovered()
-        for (j in i1() until limit) { // assertFullyCovered(0,2)
+        for (j in i1() until limit) { // assertFullyCovered()
             nop() // assertFullyCovered()
         }
 
-        for (j in limit downTo i1()) { // assertFullyCovered(0,2)
+        for (j in limit downTo i1()) { // assertFullyCovered()
             nop() // assertFullyCovered()
         }
 
+        for (i in 0 until i1()) { // assertFullyCovered()
+            nop() // assertFullyCovered()
+        }
+
+        for (i in 0 until i2()) { //  assertFullyCovered()
+            nop() // assertFullyCovered()
+        }
+
+        for (i in i1() downTo 0) { // assertFullyCovered()
+            nop() // assertFullyCovered()
+        }
     }
 
     private fun missedForEachBlock() {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinForLoopFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinForLoopFilterTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2021 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Fabian Mastenbroek - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import org.jacoco.core.internal.instr.InstrSupport;
+import org.junit.Test;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+/**
+ * Unit tests for {@link KotlinForLoopFilter}.
+ */
+public class KotlinForLoopFilterTest extends FilterTestBase {
+
+	private final KotlinForLoopFilter filter = new KotlinForLoopFilter();
+
+	/**
+	 * <pre>
+	 * class Example {
+	 *   fun example() {
+	 *     for (j in 0 until i1()) {}
+	 *   }
+	 *   private fun i1() = 1
+	 * }
+	 * </pre>
+	 */
+	@Test
+	public void should_filter_Kotlin_1_5_until() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"example", "()V", null, null);
+		final Label label1 = new Label();
+		final Label label2 = new Label();
+
+		m.visitInsn(Opcodes.ICONST_0);
+		m.visitVarInsn(Opcodes.ISTORE, 0);
+		m.visitMethodInsn(Opcodes.INVOKESTATIC, "ExampleKt", "i1", "()I",
+				false);
+		m.visitVarInsn(Opcodes.ISTORE, 1);
+		m.visitVarInsn(Opcodes.ILOAD, 0);
+		m.visitVarInsn(Opcodes.ILOAD, 1);
+		m.visitJumpInsn(Opcodes.IF_ICMPGE, label1);
+		final AbstractInsnNode ignored1 = m.instructions.getLast();
+		m.visitVarInsn(Opcodes.ILOAD, 0);
+		m.visitVarInsn(Opcodes.ISTORE, 2);
+		m.visitInsn(Opcodes.IINC);
+		m.visitVarInsn(Opcodes.ILOAD, 0);
+		m.visitVarInsn(Opcodes.ILOAD, 1);
+		m.visitJumpInsn(Opcodes.IF_ICMPLT, label2);
+		final AbstractInsnNode ignored2 = m.instructions.getLast();
+		m.visitLabel(label1);
+		m.visitInsn(Opcodes.RETURN);
+
+		filter.filter(m, context, output);
+		assertIgnored(new Range(ignored1, ignored1),
+				new Range(ignored2, ignored2));
+	}
+
+	/**
+	 * <pre>
+	 * class Example {
+	 *   fun example() {
+	 *     for (i in i1() downTo 0) {}
+	 *   }
+	 *   private fun i1() = 1
+	 * }
+	 * </pre>
+	 */
+	@Test
+	public void should_filter_Kotlin_1_5_downTo() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"example", "()V", null, null);
+		final Label label1 = new Label();
+		final Label label2 = new Label();
+
+		m.visitMethodInsn(Opcodes.INVOKESTATIC, "ExampleKt", "i1", "()I",
+				false);
+		m.visitVarInsn(Opcodes.ISTORE, 0);
+		m.visitInsn(Opcodes.ICONST_0);
+		m.visitVarInsn(Opcodes.ISTORE, 1);
+		m.visitVarInsn(Opcodes.ILOAD, 1);
+		m.visitJumpInsn(Opcodes.IF_ICMPGT, label1);
+		final AbstractInsnNode ignored1 = m.instructions.getLast();
+		m.visitVarInsn(Opcodes.ILOAD, 0);
+		m.visitVarInsn(Opcodes.ISTORE, 2);
+		m.visitInsn(Opcodes.IINC);
+		m.visitInsn(Opcodes.ICONST_0);
+		m.visitVarInsn(Opcodes.ILOAD, 1);
+		m.visitJumpInsn(Opcodes.IF_ICMPLE, label2);
+		final AbstractInsnNode ignored2 = m.instructions.getLast();
+		m.visitLabel(label1);
+		m.visitInsn(Opcodes.RETURN);
+
+		filter.filter(m, context, output);
+		assertIgnored(new Range(ignored1, ignored1),
+				new Range(ignored2, ignored2));
+	}
+
+	/**
+	 * <pre>
+	 * class Example {
+	 *   fun example() {
+	 *     val limit = 10
+	 *     for (j in limit downTo i1()) {}
+	 *   }
+	 *   private fun i1() = 1
+	 * }
+	 * </pre>
+	 */
+	@Test
+	public void should_filter_Kotlin_1_5_downTo_val() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
+				"example", "()V", null, null);
+		final Label label1 = new Label();
+		final Label label2 = new Label();
+
+		m.visitVarInsn(Opcodes.BIPUSH, 10);
+		m.visitVarInsn(Opcodes.ISTORE, 0);
+		m.visitVarInsn(Opcodes.ILOAD, 0);
+		m.visitVarInsn(Opcodes.ISTORE, 1);
+		m.visitMethodInsn(Opcodes.INVOKESTATIC, "ExampleKt", "i1", "()I",
+				false);
+		m.visitVarInsn(Opcodes.ISTORE, 2);
+		m.visitVarInsn(Opcodes.ILOAD, 2);
+		m.visitVarInsn(Opcodes.ILOAD, 1);
+		m.visitJumpInsn(Opcodes.IF_ICMPGT, label1);
+		final AbstractInsnNode ignored1 = m.instructions.getLast();
+		m.visitVarInsn(Opcodes.ILOAD, 1);
+		m.visitVarInsn(Opcodes.ISTORE, 3);
+		m.visitInsn(Opcodes.IINC);
+		m.visitVarInsn(Opcodes.ILOAD, 3);
+		m.visitVarInsn(Opcodes.ILOAD, 2);
+		m.visitJumpInsn(Opcodes.IF_ICMPNE, label2);
+		final AbstractInsnNode ignored2 = m.instructions.getLast();
+		m.visitLabel(label1);
+		m.visitInsn(Opcodes.RETURN);
+
+		filter.filter(m, context, output);
+		assertIgnored(new Range(ignored1, ignored1),
+				new Range(ignored2, ignored2));
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/Filters.java
@@ -42,7 +42,7 @@ public final class Filters implements IFilter {
 				new EnumEmptyConstructorFilter(), new RecordsFilter(),
 				new AnnotationGeneratedFilter(), new KotlinGeneratedFilter(),
 				new KotlinLateinitFilter(), new KotlinWhenFilter(),
-				new KotlinWhenStringFilter(),
+				new KotlinWhenStringFilter(), new KotlinForLoopFilter(),
 				new KotlinUnsafeCastOperatorFilter(),
 				new KotlinNotNullOperatorFilter(),
 				new KotlinDefaultArgumentsFilter(), new KotlinInlineFilter(),

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinForLoopFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinForLoopFilter.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2021 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Fabian Mastenbroek - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodNode;
+
+public class KotlinForLoopFilter implements IFilter {
+
+	public void filter(final MethodNode methodNode,
+			final IFilterContext context, final IFilterOutput output) {
+		final Matcher matcher = new Matcher();
+		for (final AbstractInsnNode node : methodNode.instructions) {
+			matcher.match(node, output);
+		}
+	}
+
+	private static class Matcher extends AbstractMatcher {
+
+		public void match(final AbstractInsnNode start, IFilterOutput output) {
+			if (start.getOpcode() != Opcodes.IF_ICMPGE
+					&& start.getOpcode() != Opcodes.IF_ICMPGT) {
+				return;
+			}
+			cursor = start;
+			LabelNode jumpTarget = ((JumpInsnNode) cursor).label;
+			if (isLoop(jumpTarget)) {
+				output.ignore(start, start);
+			}
+		}
+
+		private boolean isLoop(LabelNode jumpTarget) {
+			nextIs(Opcodes.ILOAD);
+			nextIs(Opcodes.ISTORE);
+			nextIs(Opcodes.IINC);
+			// follow the jump node
+			for (AbstractInsnNode j = cursor; j != null; j = j.getNext()) {
+				if (j == jumpTarget) {
+					// if the node prior to the jump target matches
+					// we can be sure that this is the loop we are looking for
+					return j.getPrevious().getOpcode() == Opcodes.IF_ICMPLT
+							|| j.getPrevious().getOpcode() == Opcodes.IF_ICMPNE;
+				}
+			}
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
## Context
For such `for` loops, the Kotlin compiler generates two comparisons that are almost impossible to fully cover in most scenarios. The only way to get full coverage on them would require full access to the loop boundaries. 

## Examples
### Example 1
```
class Example {
  fun example() {
    for (j in 0 until i1()) {}
  }
  private fun i1() = 1
}
```
``` 
0: iconst_0
1: istore_0
2: invokestatic  #10                 // Method i1:()I
5: istore_1
6: iload_0
7: iload_1
8: if_icmpge     21
11: iload_0
12: istore_2
13: iinc          0, 1
16: iload_0
17: iload_1
18: if_icmplt     11
21: return
```

### Example 2
```
class Example {
  fun example() {
    for (j in 0 until i1()) {}
  }
  private fun i1() = 1
}
```
```
 0: invokestatic  #10                 // Method i1:()I
 3: istore_0
 4: iconst_0
 5: iload_0
 6: if_icmpgt     19
 9: iload_0
10: istore_1
11: iinc          0, -1
14: iconst_0
15: iload_0
16: if_icmple     9
19: return
```

### Example 2
```
class Example {                       
  fun example() {                     
    val limit = 10                    
    for (j in limit downTo i1()) {}   
  }                                   
  private fun i1() = 1                
}                                     
```
```
0: bipush        10
2: istore_0
3: iload_0
4: istore_1
5: invokestatic  #10                 // Method i1:()I
8: istore_2
9: iload_2
10: iload_1
11: if_icmpgt     24
14: iload_1
15: istore_3
16: iinc          1, -1
19: iload_3
20: iload_2
21: if_icmpne     14
24: return
```

This PR addresses this issue by searching for `IF_ICMPGT` or `IF_ICMPGE` then following the jump and and checking the previous node. If this node matches one of `IF_ICMPLT`, `IF_ICMPNE` or `IF_ICMPLE` that means that we found or loop and both nodes are going to be ignored. 

IMO these branches can be safely ignored as jacoco would just check coverage on compiler generated code. As long as the loop body is checked for coverage we are good. 