### PR TITLE
Improve report-aggregate documentation and behaviour

### DIFF
--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -111,7 +111,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>4500000</maxsize>
+                  <maxsize>5500000</maxsize>
                   <minsize>3400000</minsize>
                   <files>
                     <file>${project.build.directory}/jacoco-${qualified.bundle.version}.zip</file>


### PR DESCRIPTION
Fix #974

This patch is based on the work of @bmaehr .

With this, I can perform the Sonar analysis on a multi-module maven project with the following command:
```
mvn clean org.jacoco:jacoco-maven-plugin:0.8.8-SNAPSHOT:prepare-agent verify org.jacoco:jacoco-maven-plugin:0.8.8-SNAPSHOT:report-aggregate sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths=$(pwd)/target/site/jacoco-aggregate/jacoco.xml
```

No need to add a decidated jacoco module.