### PR TITLE
Agent support report coverage continuously

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
@@ -130,6 +130,19 @@ public class Agent implements IAgent {
 			if (options.getJmx()) {
 				jmxRegistration = new JmxRegistration(this);
 			}
+			if (options.isDumpContinuously()) {
+				Timer timer = new Timer();
+				timer.schedule(new TimerTask() {
+					@Override
+					public void run() {
+						try {
+							output.writeExecutionData(false);
+						} catch (final Exception e) {
+							logger.logExeption(e);
+						}
+					}
+				}, options.getDumpWaitTime(), options.getDumpInterval());
+			}
 		} catch (final Exception e) {
 			logger.logExeption(e);
 			throw e;

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
@@ -15,6 +15,8 @@ package org.jacoco.agent.rt.internal;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.Callable;
 
 import org.jacoco.agent.rt.IAgent;

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -106,6 +106,23 @@ public final class AgentOptions {
 	public static final String DUMPONEXIT = "dumponexit";
 
 	/**
+	 * Specifies whether the agent will dump coverage data continuously. Default
+	 * is <code>false</code>.
+	 */
+	public static final String DUMPCONTINUOUSLY = "dumpcontinuously";
+
+	/**
+	 * Specifies after agent startup, how many milliseconds to wait to dump
+	 * coverage data.
+	 */
+	public static final String DUMPWAITTIME = "dumpwaittime";
+
+	/**
+	 * Specifies How many milliseconds between dump coverage data.
+	 */
+	public static final String DUMPINTERVAL = "dumpinterval";
+
+	/**
 	 * Specifies the output mode. Default is {@link OutputMode#file}.
 	 *
 	 * @see OutputMode#file
@@ -650,6 +667,33 @@ public final class AgentOptions {
 			}
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Returns whether the agent need to report Continuously.
+	 *
+	 * @return <code>true</code>, when DUMPCONTINUOUSLY is enabled
+	 */
+	public boolean isDumpContinuously() {
+		return getOption(DUMPCONTINUOUSLY, false);
+	}
+
+	/**
+	 * Returns dump wait time.
+	 *
+	 * @return dump wait time, default value is 0 milliseconds.
+	 */
+	public int getDumpWaitTime() {
+		return getOption(DUMPWAITTIME, 0);
+	}
+
+	/**
+	 * Returns dump interval.
+	 *
+	 * @return dump interval, default value is 1 minute.
+	 */
+	public int getDumpInterval() {
+		return getOption(DUMPINTERVAL, 60000);
 	}
 
 }


### PR DESCRIPTION
In some scenarios, such as using coverage for traffic screening, it is necessary to continuously collect coverage data without stopping the service. Therefore, the above changes are made to support the agent to continuously report coverage data