### PR TITLE
Upgrade maven-reporting-api to 3.1.0

### DIFF
--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
   <description>The JaCoCo Maven Plugin provides the JaCoCo runtime agent to your tests and allows basic report creation.</description>
 
   <prerequisites>
-    <maven>3.0</maven>
+    <maven>3.1.0</maven>
   </prerequisites>
 
   <dependencies>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -154,7 +154,7 @@ public abstract class AbstractReportMojo extends AbstractMojo
 	abstract File getOutputDirectory();
 
 	public void generate(
-			@SuppressWarnings("deprecation") final org.codehaus.doxia.sink.Sink sink,
+			@SuppressWarnings("deprecation") final org.apache.maven.doxia.sink.Sink sink,
 			final Locale locale) throws MavenReportException {
 		generate(sink, null, locale);
 	}


### PR DESCRIPTION
Currently JaCoCo failed to build in Fedora due to `maven-reporting-api` update to 3.1.0. [1]
Also you can see the build log in detail here [2].

[1] https://koschei.fedoraproject.org/package/jacoco?
[2] https://kojipkgs.fedoraproject.org/work/tasks/9190/82549190/build.log