### PR TITLE
Provide compatibility with JDK 9 and later via manifest header

### DIFF
--- a/org.jacoco.agent.rt/pom.xml
+++ b/org.jacoco.agent.rt/pom.xml
@@ -85,6 +85,7 @@
                     <Implementation-Title>${project.description}</Implementation-Title>
                     <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                     <Implementation-Version>${project.version}</Implementation-Version>
+                    <Add-Opens>java.base/java.lang</Add-Opens>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/PreMain.java
@@ -49,67 +49,12 @@ public final class PreMain {
 
 		final Agent agent = Agent.getInstance(agentOptions);
 
-		final IRuntime runtime = createRuntime(inst);
+		final IRuntime runtime = ModifiedSystemClassRuntime.createFor(inst,
+				"java/lang/UnknownError");
+
 		runtime.startup(agent.getData());
 		inst.addTransformer(new CoverageTransformer(runtime, agentOptions,
 				IExceptionLogger.SYSTEM_ERR));
-	}
-
-	private static IRuntime createRuntime(final Instrumentation inst)
-			throws Exception {
-
-		if (redefineJavaBaseModule(inst)) {
-			return new InjectedClassRuntime(Object.class, "$JaCoCo");
-		}
-
-		return ModifiedSystemClassRuntime.createFor(inst,
-				"java/lang/UnknownError");
-	}
-
-	/**
-	 * Opens {@code java.base} module for {@link InjectedClassRuntime} when
-	 * executed on Java 9 JREs or higher.
-	 *
-	 * @return <code>true</code> when running on Java 9 or higher,
-	 *         <code>false</code> otherwise
-	 * @throws Exception
-	 *             if unable to open
-	 */
-	private static boolean redefineJavaBaseModule(
-			final Instrumentation instrumentation) throws Exception {
-		try {
-			Class.forName("java.lang.Module");
-		} catch (final ClassNotFoundException e) {
-			return false;
-		}
-
-		Instrumentation.class.getMethod("redefineModule", //
-				Class.forName("java.lang.Module"), //
-				Set.class, //
-				Map.class, //
-				Map.class, //
-				Set.class, //
-				Map.class //
-		).invoke(instrumentation, // instance
-				getModule(Object.class), // module
-				Collections.emptySet(), // extraReads
-				Collections.emptyMap(), // extraExports
-				Collections.singletonMap("java.lang",
-						Collections.singleton(
-								getModule(InjectedClassRuntime.class))), // extraOpens
-				Collections.emptySet(), // extraUses
-				Collections.emptyMap() // extraProvides
-		);
-		return true;
-	}
-
-	/**
-	 * @return {@code cls.getModule()}
-	 */
-	private static Object getModule(final Class<?> cls) throws Exception {
-		return Class.class //
-				.getMethod("getModule") //
-				.invoke(cls);
 	}
 
 }


### PR DESCRIPTION
Address issue #1328 by using the manifest for`Add-Opens`. This avoids opening `java.base/java.lang` to the entire unnamed module which can cause tests to miss illegal access issues at test time.

Verified locally with:
```
mvn clean verify -Djdk.version=17 -Dbytecode.version=17
```

And by ensuring my example was no longer affected:
```
java -javaagent:/Users/dannyt/Projects/github/jacoco/jacoco/org.jacoco.agent.rt/target/org.jacoco.agent.rt-0.8.9-SNAPSHOT-all.jar IllegalAccess
Exception in thread "main" java.lang.reflect.InaccessibleObjectException: Unable to make final void java.lang.Throwable.setCause(java.lang.Throwable) accessible: module java.base does not "opens java.lang" to unnamed module @238e0d81
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at IllegalAccess.main(IllegalAccess.java:5)
```

I'm having trouble verifying this is even required/working. If I remove the `PreMain` code and don't add a header, all the tests pass even without `InjectedClassRuntime` so I'm not sure there's enough coverage to verify.