### PR TITLE
Upgrade maven-surefire-plugin to 2.19.1

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -416,7 +416,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.9</version>
+          <!--  latest version which runs with Java 5 -->
+          <version>2.19.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Starting from version 2.11 maven-surefire-plugin does not ignore
a failure to start forked JVM and causes build failure,
e.g. if there is an exception during JaCoCo agent startup
(https://issues.apache.org/jira/browse/SUREFIRE-780)

While implementing #1334 I was tricked multiple times by the absence of build failure.

Fixes #828