### PR TITLE
Upgrade maven-compiler-plugin to 3.10.1

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -78,10 +78,6 @@ jobs:
           verify -Djdk.version=$JDK_VERSION \
           deploy:deploy -DdeployAtEnd \
           --toolchains=toolchains.xml --settings=.azure-pipelines/maven-settings.xml
-      elif [[ "$JDK_VERSION" == "5" ]]; then
-        .maven/bin/mvn -V -B -e \
-          verify -Djdk.version=$JDK_VERSION -Dbytecode.version=$JDK_VERSION \
-          --toolchains=toolchains.xml
       elif [[ "$BUILD_SOURCEBRANCH" == "refs/heads/master" && "$JDK_VERSION" == "11" ]]; then
         .maven/bin/mvn -V -B -e -f org.jacoco.build \
           verify -Djdk.version=$JDK_VERSION -Dbytecode.version=$JDK_VERSION \

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
           --toolchains=toolchains.xml --settings=.azure-pipelines/maven-settings.xml
       elif [[ "$JDK_VERSION" == "5" ]]; then
         .maven/bin/mvn -V -B -e \
-          verify -Djdk.version=$JDK_VERSION \
+          verify -Djdk.version=$JDK_VERSION -Dbytecode.version=$JDK_VERSION \
           --toolchains=toolchains.xml
       elif [[ "$BUILD_SOURCEBRANCH" == "refs/heads/master" && "$JDK_VERSION" == "11" ]]; then
         .maven/bin/mvn -V -B -e -f org.jacoco.build \

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -312,7 +312,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.10.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In my opinion convenient to refer to Java `1.5` as `5`, but unfortunately `maven-compiler-plugin` version `3.7.0` doesn't agree and execution of JaCoCo build as

```
mvn package -Dbytecode.version=5
```

leads to

```
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project org.jacoco.core: Compilation failure
javac: invalid flag: -s
```