### PR TITLE
Exclude internal packages from published JavaDoc

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -360,6 +360,7 @@
           <configuration>
             <quiet>true</quiet>
             <detectOfflineLinks>false</detectOfflineLinks>
+            <excludePackageNames>*.internal</excludePackageNames>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
While we already exclude internal packages for our all-in-one Javadoc we still publish them for the individual Maven modules. See for example: https://javadoc.io/doc/org.jacoco/org.jacoco.core/0.8.8/index.html

