### PR TITLE
fix(sec): upgrade org.scala-lang:scala-library to 2.13.9

### DIFF
--- a/org.jacoco.core.test.validation.scala/pom.xml
+++ b/org.jacoco.core.test.validation.scala/pom.xml
@@ -9,8 +9,7 @@
 
    Contributors:
       Evgeny Mandrikov - initial API and implementation
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,7 +24,7 @@
   <name>JaCoCo :: Test :: Core :: Validation Scala</name>
 
   <properties>
-    <scala.version>2.13.4</scala.version>
+    <scala.version>2.13.9</scala.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.scala-lang:scala-library 2.13.4
- [CVE-2022-36944](https://www.oscs1024.com/hd/CVE-2022-36944)


### What did I do？
Upgrade org.scala-lang:scala-library from 2.13.4 to 2.13.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS