### PR TITLE
Document `includeCurrentProject` available as of 0.8.9

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -85,6 +85,8 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	/**
 	 * Include this project in the report. If true then this projects class and
 	 * source files as well as JaCoCo execution data files will be collected.
+	 *
+	 * @since 0.8.9
 	 */
 	@Parameter(defaultValue = "false")
 	private boolean includeCurrentProject;


### PR DESCRIPTION
Follow-up to https://github.com/jacoco/jacoco/pull/1007. The new `includeCurrentProject` that has yet to be released is listed in the documentation as available since release 0.7.7.