### PR TITLE
Support targeting JDK 5 when using JDK >= 9 for Maven

### DIFF
--- a/jacoco-maven-plugin.test/it/setup-parent/pom.xml
+++ b/jacoco-maven-plugin.test/it/setup-parent/pom.xml
@@ -40,10 +40,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.3.2</version>
-          <configuration>
-            <source>@maven.compiler.source@</source>
-            <target>@maven.compiler.target@</target>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/jacoco-maven-plugin.test/pom.xml
+++ b/jacoco-maven-plugin.test/pom.xml
@@ -55,6 +55,14 @@
           <extraArtifacts>
             <extraArtifact>org.jacoco:org.jacoco.agent:${project.version}:jar:runtime</extraArtifact>
           </extraArtifacts>
+          <properties>
+            <!--
+            maven-invoker-plugin for forked Maven invocations uses the same JDK that is used for Maven,
+            so can not use source level lower than 8 with modern JDKs
+            -->
+            <maven.compiler.source>8</maven.compiler.source>
+            <maven.compiler.target>8</maven.compiler.target>
+          </properties>
         </configuration>
         <executions>
           <execution>

--- a/org.jacoco.examples.test/pom.xml
+++ b/org.jacoco.examples.test/pom.xml
@@ -124,8 +124,12 @@
         <configuration>
           <projectsDirectory>${project.build.directory}/build/examples</projectsDirectory>
           <properties>
-            <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-            <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+            <!--
+            maven-invoker-plugin for forked Maven invocations uses the same JDK that is used for Maven,
+            so can not use source level lower than 8 with modern JDKs
+            -->
+            <maven.compiler.source>8</maven.compiler.source>
+            <maven.compiler.target>8</maven.compiler.target>
           </properties>
         </configuration>
       </plugin>


### PR DESCRIPTION
`org.jacoco.examples.test` and `jacoco-maven-plugin.test` use `maven-invoker-plugin`,
[which by default for forked Maven invocations uses the same JDK that is used for Maven](https://maven.apache.org/plugins/maven-invoker-plugin/run-mojo.html#javaHome).

So the execution of the build with JDK >= 9 for Maven and JDK 5 for compilation

```
mvn clean verify -Djdk.version=5 -Dbytecode.version=5
```

currently leads to failure

```
[INFO] --- maven-invoker-plugin:2.0.0:run (test-pom) @ org.jacoco.examples.test ---
[INFO] Building: build/pom.xml
[INFO] ..FAILED (1.4 s)
[INFO]   The build exited with code 1. See /Users/godin/projects/jacoco/jacoco/org.jacoco.examples.test/target/it/build/build.log for details.
```

`org.jacoco.examples.test/target/it/build/build.log`

```
[ERROR] COMPILATION ERROR :
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
```

because of https://bugs.openjdk.org/browse/JDK-8011044

Execution of the build with JDK >= 12 for Maven and JDK <= 6 for compilation
fails similarly because of https://bugs.openjdk.org/browse/JDK-8028563

Since we require at least JDK 8 for Maven,
all JDKs >= 8 as of today support compilation into bytecode version 8,
and these tests are about integration with Maven
and not about bytecode analysis,
I propose to simply use bytecode version 8 in them.