### PR TITLE
Use Ubuntu 20.04 in AzurePipelines

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
       JDK 21:
         JDK_VERSION: 21
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
   steps:
   - bash: |
       set -e


### PR DESCRIPTION
AzurePipelines currently shows the following warning

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

[Ubuntu 18.04 in AzurePipelines by default uses Java 8](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md#java), whereas [Ubuntu 20.04 uses Java 11](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#java), so this requires https://github.com/jacoco/jacoco/pull/1398 in order to not switch away from the default.