### PR TITLE
Upgrade ECJ from 3.12.1 to 3.32.0

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -10,15 +10,15 @@ jobs:
         JDK_VERSION: 7
       JDK 8:
         JDK_VERSION: 8
-      JDK 8 with ECJ:
-        JDK_VERSION: 8
-        ECJ: true
       JDK 9:
         JDK_VERSION: 9
       JDK 10:
         JDK_VERSION: 10
       JDK 11:
         JDK_VERSION: 11
+      JDK 11 with ECJ:
+        JDK_VERSION: 11
+        ECJ: true
       JDK 12:
         JDK_VERSION: 12
       JDK 13:
@@ -31,10 +31,16 @@ jobs:
         JDK_VERSION: 16
       JDK 17:
         JDK_VERSION: 17
+      JDK 17 with ECJ:
+        JDK_VERSION: 17
+        ECJ: true
       JDK 18:
         JDK_VERSION: 18
       JDK 19:
         JDK_VERSION: 19
+      JDK 19 with ECJ:
+        JDK_VERSION: 19
+        ECJ: true
       JDK 20:
         JDK_VERSION: 20
       JDK 21:

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -934,19 +934,17 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
               <compilerId>eclipse</compilerId>
-              <source>1.8</source>
-              <target>1.8</target>
             </configuration>
             <dependencies>
               <dependency>
-                <groupId>org.eclipse.jdt.core.compiler</groupId>
+                <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>4.6.1</version>
+                <version>3.32.0</version>
               </dependency>
               <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-compiler-eclipse</artifactId>
-                <version>2.8.1</version>
+                <version>2.8.5</version>
               </dependency>
             </dependencies>
           </plugin>

--- a/org.jacoco.core.test.validation.java14/src/org/jacoco/core/test/validation/java14/SwitchExpressionsTest.java
+++ b/org.jacoco.core.test.validation.java14/src/org/jacoco/core/test/validation/java14/SwitchExpressionsTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation.java14;
 
+import org.jacoco.core.test.validation.Source.Line;
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.java14.targets.SwitchExpressionsTarget;
 
@@ -22,6 +23,22 @@ public class SwitchExpressionsTest extends ValidationTestBase {
 
 	public SwitchExpressionsTest() {
 		super(SwitchExpressionsTarget.class);
+	}
+
+	public void assertExhaustiveSwitchExpression(Line line) {
+		if (isJDKCompiler) {
+			assertPartlyCovered(line, 1, 3);
+		} else {
+			assertFullyCovered(line, 1, 3);
+		}
+	}
+
+	public void assertExhaustiveSwitchExpressionLastCase(Line line) {
+		if (isJDKCompiler) {
+			assertFullyCovered(line);
+		} else {
+			assertPartlyCovered(line);
+		}
 	}
 
 }

--- a/org.jacoco.core.test.validation.java14/src/org/jacoco/core/test/validation/java14/targets/SwitchExpressionsTarget.java
+++ b/org.jacoco.core.test.validation.java14/src/org/jacoco/core/test/validation/java14/targets/SwitchExpressionsTarget.java
@@ -12,13 +12,11 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation.java14.targets;
 
-import static org.jacoco.core.test.validation.targets.Stubs.Enum.A;
-import static org.jacoco.core.test.validation.targets.Stubs.Enum.B;
-import static org.jacoco.core.test.validation.targets.Stubs.Enum.C;
-import static org.jacoco.core.test.validation.targets.Stubs.enumA;
 import static org.jacoco.core.test.validation.targets.Stubs.i1;
 import static org.jacoco.core.test.validation.targets.Stubs.i2;
 import static org.jacoco.core.test.validation.targets.Stubs.nop;
+
+import org.jacoco.core.test.validation.targets.Stubs;
 
 /**
  * This target exercises switch expressions.
@@ -31,7 +29,10 @@ public class SwitchExpressionsTarget {
 		multiValueSwitchExpressionWithArrows();
 		switchExpressionWithArrowsAndYield();
 		switchExpressionWithYield();
-		exhaustiveSwitchExpression();
+
+		exhaustiveSwitchExpression(Stubs.Enum.A);
+		exhaustiveSwitchExpression(Stubs.Enum.B);
+		exhaustiveSwitchExpression(Stubs.Enum.C);
 
 	}
 
@@ -98,13 +99,13 @@ public class SwitchExpressionsTarget {
 
 	}
 
-	private static void exhaustiveSwitchExpression() {
+	private static void exhaustiveSwitchExpression(Stubs.Enum e) {
 
-		nop(switch (enumA()) { // assertPartlyCovered(3, 1)
+		nop(switch (e) { // assertExhaustiveSwitchExpression()
 		case A -> i1(); // assertFullyCovered()
-		case B -> i1(); // assertNotCovered()
-		case C -> i1(); // assertNotCovered()
-		});
+		case B -> i1(); // assertFullyCovered()
+		case C -> i1(); // assertExhaustiveSwitchExpressionLastCase()
+		}); // assertEmpty()
 
 	}
 }

--- a/org.jacoco.core.test.validation.java16/src/org/jacoco/core/test/validation/java16/InstanceofTest.java
+++ b/org.jacoco.core.test.validation.java16/src/org/jacoco/core/test/validation/java16/InstanceofTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation.java16;
 
+import org.jacoco.core.test.validation.Source.Line;
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.java16.targets.InstanceofTarget;
 
@@ -22,6 +23,17 @@ public class InstanceofTest extends ValidationTestBase {
 
 	public InstanceofTest() {
 		super(InstanceofTarget.class);
+	}
+
+	public void assertInstanceof(Line line) {
+		if (isJDKCompiler) {
+			assertFullyCovered(line, 0, 2);
+		} else {
+			// Upgrade to ECJ version with
+			// https://github.com/eclipse-jdt/eclipse.jdt.core/commit/3b4c932227240d090904e141a485ba9181a79b67
+			// will lead to the absence of missed branches
+			assertFullyCovered(line, 1, 3);
+		}
 	}
 
 }

--- a/org.jacoco.core.test.validation.java16/src/org/jacoco/core/test/validation/java16/targets/InstanceofTarget.java
+++ b/org.jacoco.core.test.validation.java16/src/org/jacoco/core/test/validation/java16/targets/InstanceofTarget.java
@@ -21,7 +21,7 @@ import static org.jacoco.core.test.validation.targets.Stubs.nop;
 public class InstanceofTarget {
 
 	private static void ifInstanceof(Object e) {
-		if (e instanceof String s) { // assertFullyCovered(0, 2)
+		if (e instanceof String s) { // assertInstanceof()
 			nop(s);
 		}
 	}

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -267,18 +267,22 @@
   <li><code>mvn clean verify -Djdk.version=6 -Dbytecode.version=6</code></li>
   <li><code>mvn clean verify -Djdk.version=7 -Dbytecode.version=7</code></li>
   <li><code>mvn clean verify -Djdk.version=8 -Dbytecode.version=8</code></li>
-  <li><code>mvn clean verify -Djdk.version=8 -Dbytecode.version=8 -Decj</code></li>
   <li><code>mvn clean verify -Djdk.version=9 -Dbytecode.version=9</code></li>
   <li><code>mvn clean verify -Djdk.version=10 -Dbytecode.version=10</code></li>
   <li><code>mvn clean verify -Djdk.version=11 -Dbytecode.version=11</code></li>
+  <li><code>mvn clean verify -Djdk.version=11 -Dbytecode.version=11 -Decj</code></li>
   <li><code>mvn clean verify -Djdk.version=12 -Dbytecode.version=12</code></li>
   <li><code>mvn clean verify -Djdk.version=13 -Dbytecode.version=13</code></li>
   <li><code>mvn clean verify -Djdk.version=14 -Dbytecode.version=14</code></li>
   <li><code>mvn clean verify -Djdk.version=15 -Dbytecode.version=15</code></li>
   <li><code>mvn clean verify -Djdk.version=16 -Dbytecode.version=16</code></li>
   <li><code>mvn clean verify -Djdk.version=17 -Dbytecode.version=17</code></li>
+  <li><code>mvn clean verify -Djdk.version=17 -Dbytecode.version=17 -Decj</code></li>
   <li><code>mvn clean verify -Djdk.version=18 -Dbytecode.version=18</code></li>
   <li><code>mvn clean verify -Djdk.version=19 -Dbytecode.version=19</code></li>
+  <li><code>mvn clean verify -Djdk.version=19 -Dbytecode.version=19 -Decj</code></li>
+  <li><code>mvn clean verify -Djdk.version=20 -Dbytecode.version=20</code></li>
+  <li><code>mvn clean verify -Djdk.version=21 -Dbytecode.version=21</code></li>
 </ul>
 
 


### PR DESCRIPTION
Version `4.6.1` of previously used artifact `org.eclipse.jdt:ecj` was actually version of Eclipse IDE.

This version supports source/target from Java 1.1 up to 19.

Also note that starting from version `3.27.0` ECJ requires Java 11 for execution.