### PR TITLE
Fix validation test for Java 21

### DIFF
--- a/org.jacoco.core.test.validation.java20/src/org/jacoco/core/test/validation/java20/RecordPatternsTest.java
+++ b/org.jacoco.core.test.validation.java20/src/org/jacoco/core/test/validation/java20/RecordPatternsTest.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation.java20;
 
+import org.jacoco.core.test.validation.JavaVersion;
+import org.jacoco.core.test.validation.Source.Line;
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.java20.targets.RecordPatternsTarget;
 
@@ -22,6 +24,24 @@ public class RecordPatternsTest extends ValidationTestBase {
 
 	public RecordPatternsTest() {
 		super(RecordPatternsTarget.class);
+	}
+
+	public void assertSwitchStatementCase(Line line) {
+		if (JavaVersion.current().isBefore("21")) {
+			assertFullyCovered(line);
+		} else {
+			// https://github.com/openjdk/jdk/commit/138cdc9283ae8f3367e51f0fe7e27833118dd7cb
+			assertPartlyCovered(line);
+		}
+	}
+
+	public void assertSwitchStatementDefault(Line line) {
+		if (JavaVersion.current().isBefore("21")) {
+			assertPartlyCovered(line);
+		} else {
+			// https://github.com/openjdk/jdk/commit/138cdc9283ae8f3367e51f0fe7e27833118dd7cb
+			assertFullyCovered(line);
+		}
 	}
 
 }

--- a/org.jacoco.core.test.validation.java20/src/org/jacoco/core/test/validation/java20/targets/RecordPatternsTarget.java
+++ b/org.jacoco.core.test.validation.java20/src/org/jacoco/core/test/validation/java20/targets/RecordPatternsTarget.java
@@ -31,8 +31,8 @@ public class RecordPatternsTarget {
 
 	private static void switchStatement(Object p) {
 		switch (p) { // assertFullyCovered(0, 2)
-		case Point(int x, int y) -> nop(x + y); // assertFullyCovered()
-		default -> nop(); // assertPartlyCovered()
+		case Point(int x, int y) -> nop(x + y); // assertSwitchStatementCase()
+		default -> nop(); // assertSwitchStatementDefault()
 		} // assertEmpty()
 	}
 


### PR DESCRIPTION
OpenJDK 21 EA b15 and b16 produce different class files for `RecordPatternsTarget.java` because of
https://github.com/openjdk/jdk/commit/138cdc9283ae8f3367e51f0fe7e27833118dd7cb

Here is diff between outputs of `javap -v -p RecordPatternsTarget.class`:

```diff
          line 34: 57
          line 35: 72
+         line 34: 78
          line 37: 92
```

Bytecode instructions at offset 78 correspond to the following exception handler generated for the `case` at line 34:

```
        78: astore_1
        79: new           #24                 // class java/lang/MatchException
        82: dup
        83: aload_1
        84: invokevirtual #26                 // Method java/lang/Throwable.toString:()Ljava/lang/String;
        87: aload_1
        88: invokespecial #30                 // Method java/lang/MatchException."<init>":(Ljava/lang/String;Ljava/lang/Throwable;)V
        91: athrow
```