### PR TITLE
AgentModule should set ProtectionDomain when defining classes

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/AgentModuleTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/AgentModuleTest.java
@@ -41,6 +41,8 @@ public class AgentModuleTest {
 
 		assertNotSame(this.getClass().getClassLoader(),
 				t.getClass().getClassLoader());
+		assertSame(AgentModule.class.getProtectionDomain(),
+				t.getClass().getProtectionDomain());
 		assertSame(t.getClass().getClassLoader(),
 				t.getInnerClassInstance().getClass().getClassLoader());
 		assertNotSame(this.getClass().getClassLoader(),

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/AgentModule.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/AgentModule.java
@@ -75,7 +75,8 @@ public class AgentModule {
 				} catch (final IOException e) {
 					throw new RuntimeException(e);
 				}
-				return defineClass(name, bytes, 0, bytes.length);
+				return defineClass(name, bytes, 0, bytes.length,
+						AgentModule.class.getProtectionDomain());
 			}
 		};
 	}

--- a/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.xml
@@ -166,4 +166,19 @@
 		</jacoco:coverage>
 	</target>
 
+	<target name="testSecurityManager">
+		<jacoco:coverage destfile="${exec.file}">
+			<java classname="org.jacoco.ant.TestTarget" fork="true" failonerror="true">
+				<classpath path="${org.jacoco.ant.coverageTaskTest.classes.dir}"/>
+				<jvmarg value="-Djacoco.agent=${_jacoco.agentFile}"/>
+				<jvmarg value="-Djava.security.manager"/>
+				<!-- Note that the use of two equal signs (==) below is not a typo -->
+				<jvmarg value="-Djava.security.policy==${basedir}/data/policy.txt"/>
+			</java>
+		</jacoco:coverage>
+
+		<au:assertFileExists file="${exec.file}"/>
+		<au:assertLogContains text="Target executed"/>
+	</target>
+
 </project>

--- a/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.xml
@@ -171,6 +171,7 @@
 			<java classname="org.jacoco.ant.TestTarget" fork="true" failonerror="true">
 				<classpath path="${org.jacoco.ant.coverageTaskTest.classes.dir}"/>
 				<jvmarg value="-Djacoco.agent=${_jacoco.agentFile}"/>
+				<jvmarg value="-Djacoco.exec=${exec.file}"/>
 				<jvmarg value="-Djava.security.manager"/>
 				<!-- Note that the use of two equal signs (==) below is not a typo -->
 				<jvmarg value="-Djava.security.policy==${basedir}/data/policy.txt"/>

--- a/org.jacoco.ant.test/src/org/jacoco/ant/data/policy.txt
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/data/policy.txt
@@ -1,3 +1,9 @@
 grant codeBase "file:${jacoco.agent}" {
-    permission java.security.AllPermission;
+    permission java.io.FilePermission "${jacoco.exec}/..", "read";
+    permission java.io.FilePermission "${jacoco.exec}", "write";
+    permission java.lang.RuntimePermission "shutdownHooks";
+    permission java.lang.RuntimePermission "createClassLoader";
+    permission java.lang.RuntimePermission "getProtectionDomain";
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+    permission java.lang.RuntimePermission "defineClass";
 };

--- a/org.jacoco.ant.test/src/org/jacoco/ant/data/policy.txt
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/data/policy.txt
@@ -1,0 +1,3 @@
+grant codeBase "file:${jacoco.agent}" {
+    permission java.security.AllPermission;
+};

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -20,6 +20,13 @@
 
 <h2>Snapshot Build @qualified.bundle.version@ (@build.date@)</h2>
 
+<h3>Fixed bugs</h3>
+<ul>
+  <li>Agent should not require configuration of permissions for
+      <code>SecurityManager</code> outside of its <code>codeBase</code>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1425">#1425</a>).</li>
+</ul>
+
 <h2>Release 0.8.9 (2023/03/31)</h2>
 
 <h3>New Features</h3>


### PR DESCRIPTION
Execution of

```
java \
    -Djava.security.manager -Djava.security.policy==policy.txt -Djava.security.debug=access,failure \
    -javaagent:jacocoagent.jar=output=none \
    -version
```

using the following `policy.txt`

```
grant codeBase "file:${user.dir}/jacocoagent.jar" {
    permission java.security.AllPermission;
};
```

and JaCoCo agent version `0.8.8` leads to

```
openjdk version "11.0.6" 2020-01-14
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.6+10)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.6+10, mixed mode)
```

Whereas using JaCoCo agent version `0.8.9` leads to

```
access: access denied ("java.io.FilePermission" "/private/tmp/jacoco/jacocoagent.jar" "read")
java.lang.Exception: Stack trace
        at java.base/java.lang.Thread.dumpStack(Thread.java:1387)
        at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:462)
        at java.base/java.security.AccessController.checkPermission(AccessController.java:897)
        at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
        at java.base/java.lang.SecurityManager.checkRead(SecurityManager.java:661)
        at java.base/jdk.internal.loader.URLClassPath.check(URLClassPath.java:555)
        at java.base/jdk.internal.loader.URLClassPath.checkURL(URLClassPath.java:529)
        at java.base/jdk.internal.loader.BuiltinClassLoader.checkURL(BuiltinClassLoader.java:1018)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findResource(BuiltinClassLoader.java:303)
        at java.base/java.lang.ClassLoader.getResource(ClassLoader.java:1400)
        at java.base/java.lang.ClassLoader.getResource(ClassLoader.java:1395)
        at java.base/java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:1736)
        at org.jacoco.agent.rt.internal_e5ed502.AgentModule$1.loadClass(AgentModule.java:70)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        at org.jacoco.agent.rt.internal_e5ed502.core.runtime.InjectedClassRuntime.startup(InjectedClassRuntime.java:55)
        at org.jacoco.agent.rt.internal_e5ed502.PreMain.premain(PreMain.java:50)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
access: access allowed ("java.security.SecurityPermission" "getPolicy")
access: domain that failed ProtectionDomain  (null <no signer certificates>)
 org.jacoco.agent.rt.internal_e5ed502.AgentModule$1@5c3bd550
 <no principals>
 java.security.Permissions@27c20538 (
 ("java.util.PropertyPermission" "java.specification.version" "read")
 ("java.util.PropertyPermission" "java.vm.vendor" "read")
 ("java.util.PropertyPermission" "path.separator" "read")
 ("java.util.PropertyPermission" "os.version" "read")
 ("java.util.PropertyPermission" "java.vendor.url" "read")
 ("java.util.PropertyPermission" "java.vm.name" "read")
 ("java.util.PropertyPermission" "java.vm.specification.version" "read")
 ("java.util.PropertyPermission" "os.name" "read")
 ("java.util.PropertyPermission" "java.version" "read")
 ("java.util.PropertyPermission" "os.arch" "read")
 ("java.util.PropertyPermission" "java.specification.vendor" "read")
 ("java.util.PropertyPermission" "java.vm.specification.name" "read")
 ("java.util.PropertyPermission" "file.separator" "read")
 ("java.util.PropertyPermission" "line.separator" "read")
 ("java.util.PropertyPermission" "java.vm.specification.vendor" "read")
 ("java.util.PropertyPermission" "java.specification.name" "read")
 ("java.util.PropertyPermission" "java.vendor" "read")
 ("java.util.PropertyPermission" "java.vm.version" "read")
 ("java.util.PropertyPermission" "java.class.version" "read")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.beans.*")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.apple.*")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.java.swing.plaf.*")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.beans")
 ("java.net.SocketPermission" "localhost:0" "listen,resolve")
)


Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
Caused by: java.lang.NullPointerException
        at org.jacoco.agent.rt.internal_e5ed502.core.internal.InputStreams.readFully(InputStreams.java:41)
        at org.jacoco.agent.rt.internal_e5ed502.AgentModule$1.loadClass(AgentModule.java:74)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        at org.jacoco.agent.rt.internal_e5ed502.core.runtime.InjectedClassRuntime.startup(InjectedClassRuntime.java:55)
        at org.jacoco.agent.rt.internal_e5ed502.PreMain.premain(PreMain.java:50)
        ... 6 more
```

And even for the following `policy.txt`

```
grant codeBase "file:${user.dir}/jacocoagent.jar" {
    permission java.security.AllPermission;
};

grant {
    permission java.io.FilePermission "${user.dir}/jacocoagent.jar", "read";
};
```

leads to

```
access: access denied ("java.lang.reflect.ReflectPermission" "suppressAccessChecks")
java.lang.Exception: Stack trace
        at java.base/java.lang.Thread.dumpStack(Thread.java:1387)
        at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:462)
        at java.base/java.security.AccessController.checkPermission(AccessController.java:897)
        at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
        at java.base/java.lang.invoke.MethodHandles.privateLookupIn(MethodHandles.java:189)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.jacoco.agent.rt.internal_e5ed502.core.runtime.InjectedClassRuntime$Lookup.privateLookupIn(InjectedClassRuntime.java:123)
        at org.jacoco.agent.rt.internal_e5ed502.core.runtime.InjectedClassRuntime.startup(InjectedClassRuntime.java:55)
        at org.jacoco.agent.rt.internal_e5ed502.PreMain.premain(PreMain.java:50)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
access: access allowed ("java.security.SecurityPermission" "getPolicy")
access: domain that failed ProtectionDomain  (null <no signer certificates>)
 org.jacoco.agent.rt.internal_e5ed502.AgentModule$1@5c3bd550
 <no principals>
 java.security.Permissions@63753b6d (
 ("java.util.PropertyPermission" "java.specification.version" "read")
 ("java.util.PropertyPermission" "java.vm.vendor" "read")
 ("java.util.PropertyPermission" "path.separator" "read")
 ("java.util.PropertyPermission" "os.version" "read")
 ("java.util.PropertyPermission" "java.vendor.url" "read")
 ("java.util.PropertyPermission" "java.vm.name" "read")
 ("java.util.PropertyPermission" "java.vm.specification.version" "read")
 ("java.util.PropertyPermission" "os.name" "read")
 ("java.util.PropertyPermission" "java.version" "read")
 ("java.util.PropertyPermission" "os.arch" "read")
 ("java.util.PropertyPermission" "java.specification.vendor" "read")
 ("java.util.PropertyPermission" "java.vm.specification.name" "read")
 ("java.util.PropertyPermission" "file.separator" "read")
 ("java.util.PropertyPermission" "line.separator" "read")
 ("java.util.PropertyPermission" "java.vm.specification.vendor" "read")
 ("java.util.PropertyPermission" "java.specification.name" "read")
 ("java.util.PropertyPermission" "java.vendor" "read")
 ("java.util.PropertyPermission" "java.vm.version" "read")
 ("java.util.PropertyPermission" "java.class.version" "read")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.beans.*")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.apple.*")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.java.swing.plaf.*")
 ("java.lang.RuntimePermission" "accessClassInPackage.com.sun.beans")
 ("java.net.SocketPermission" "localhost:0" "listen,resolve")
 ("java.io.FilePermission" "/private/tmp/jacoco/jacocoagent.jar#plus" "read")
)


Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
Caused by: java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.jacoco.agent.rt.internal_e5ed502.core.runtime.InjectedClassRuntime$Lookup.privateLookupIn(InjectedClassRuntime.java:123)
        at org.jacoco.agent.rt.internal_e5ed502.core.runtime.InjectedClassRuntime.startup(InjectedClassRuntime.java:55)
        at org.jacoco.agent.rt.internal_e5ed502.PreMain.premain(PreMain.java:50)
        ... 6 more
Caused by: java.security.AccessControlException: access denied ("java.lang.reflect.ReflectPermission" "suppressAccessChecks")
        at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:472)
        at java.base/java.security.AccessController.checkPermission(AccessController.java:897)
        at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
        at java.base/java.lang.invoke.MethodHandles.privateLookupIn(MethodHandles.java:189)
        ... 13 more
```

i.e. `AgentModule` introduced in #1334 creates `ClassLoader` which defines classes with `null` instead of `ProtectionDomain` of JaCoCo agent.

So requires the following `policy.txt`

```
grant codeBase "file:${user.dir}/jacocoagent.jar" {
    permission java.security.AllPermission;
};

grant {
    permission java.io.FilePermission "${user.dir}/jacocoagent.jar", "read";
    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
    permission java.lang.RuntimePermission "defineClass";
};
```
