### PR TITLE
Fix execution of tests in IntelliJ IDEA

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -128,6 +128,7 @@
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
 
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
+    <build.commitId>0000000</build.commitId>
     <jacoco.home.url>http://www.jacoco.org/jacoco</jacoco.home.url>
     <copyright.years>${project.inceptionYear}, 2023</copyright.years>
 
@@ -668,6 +669,7 @@
           <doUpdate>false</doUpdate>
           <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
           <revisionOnScmFailure>0000000</revisionOnScmFailure>
+          <buildNumberPropertyName>build.commitId</buildNumberPropertyName>
         </configuration>
       </plugin>
 
@@ -699,8 +701,8 @@
                 buildDate = qualifier.substring(0, 4) + "/" + qualifier.substring(4, 6) + "/" + qualifier.substring(6, 8);
                 project.getProperties().setProperty("build.date", buildDate);
 
-                buildNumber = project.getProperties().get("buildNumber");
-                pkgName = buildNumber.substring(buildNumber.length() - 7, buildNumber.length());
+                commitId = project.getProperties().get("build.commitId");
+                pkgName = commitId.substring(commitId.length() - 7, commitId.length());
                 project.getProperties().setProperty("jacoco.runtime.package.name", "org.jacoco.agent.rt.internal_" + pkgName);
 
                 void loadLicense(String libraryId) {
@@ -737,7 +739,7 @@
               org.objectweb.asm.*;version="${range;[===,=+);${asm.version}}"
             </Import-Package>
             <Bundle-RequiredExecutionEnvironment>J2SE-1.5</Bundle-RequiredExecutionEnvironment>
-            <Eclipse-SourceReferences>scm:git:git://github.com/jacoco/jacoco.git;path="${project.artifactId}";commitId=${buildNumber}</Eclipse-SourceReferences>
+            <Eclipse-SourceReferences>scm:git:git://github.com/jacoco/jacoco.git;path="${project.artifactId}";commitId=${build.commitId}</Eclipse-SourceReferences>
           </instructions>
         </configuration>
       </plugin>
@@ -1108,7 +1110,7 @@
                   <rules>
                     <requireReleaseVersion/>
                     <requireProperty>
-                      <property>buildNumber</property>
+                      <property>build.commitId</property>
                       <regex>[0-9a-f]{40}</regex>
                     </requireProperty>
                   </rules>

--- a/org.jacoco.core/src/org/jacoco/core/jacoco.properties
+++ b/org.jacoco.core/src/org/jacoco/core/jacoco.properties
@@ -1,4 +1,4 @@
 VERSION=${qualified.bundle.version}
-COMMITID=${buildNumber}
+COMMITID=${build.commitId}
 HOMEURL=${jacoco.home.url}
 RUNTIMEPACKAGE=${jacoco.runtime.package.name}

--- a/org.jacoco.doc/docroot/index.html
+++ b/org.jacoco.doc/docroot/index.html
@@ -25,7 +25,7 @@
 <p>
   This is the distribution of version ${qualified.bundle.version} created on
   ${build.date} based on commit
-  <a href="https://github.com/jacoco/jacoco/tree/${buildNumber}">${buildNumber}</a>.
+  <a href="https://github.com/jacoco/jacoco/tree/${build.commitId}">${build.commitId}</a>.
 </p>
 
 <h2>Contents</h2>


### PR DESCRIPTION
Prior to this change execution of some tests in IntelliJ IDEA 2022.3.3 fails with `ExceptionInInitializerError`

```
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: 7
    at java.lang.String.substring(String.java:1963)
    at org.jacoco.core.JaCoCo.<clinit>(JaCoCo.java:44)
```

because build of the project in IntelliJ IDEA produces following `org.jacoco.core/target/classes/org/jacoco/core/jacoco.properties`

```
VERSION=${qualified.bundle.version}
COMMITID=
HOMEURL=http://www.jacoco.org/jacoco
RUNTIMEPACKAGE=${jacoco.runtime.package.name}
```

after this change produces

```
VERSION=${qualified.bundle.version}
COMMITID=0000000
HOMEURL=http://www.jacoco.org/jacoco
RUNTIMEPACKAGE=${jacoco.runtime.package.name}
```

and tests pass.