### PR TITLE
Upgrade exec-maven-plugin to 3.1.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -454,8 +454,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <!--  latest version which runs with Java 5 -->
-          <version>1.5.0</version>
+          <version>3.1.0</version>
         </plugin>
         <!-- Third-party plugins -->
         <plugin>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2

```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:00 min
[INFO] Finished at: 2023-05-15T10:26:59+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 24 plugin(s)
[WARNING]
[WARNING]  * org.apache.felix:maven-bundle-plugin:3.5.1
[WARNING]  * org.apache.maven.plugins:maven-dependency-plugin:2.2
[WARNING]  * net.alchim31.maven:scala-maven-plugin:4.4.0
[WARNING]  * org.apache.maven.plugins:maven-clean-plugin:2.4.1
[WARNING]  * org.apache.maven.plugins:maven-invoker-plugin:2.0.0
[WARNING]  * org.apache.maven.plugins:maven-javadoc-plugin:3.0.1
[WARNING]  * org.codehaus.mojo:buildnumber-maven-plugin:1.2
[WARNING]  * org.codehaus.mojo:xml-maven-plugin:1.0
[WARNING]  * org.apache.maven.plugins:maven-resources-plugin:2.5
[WARNING]  * org.apache.maven.plugins:maven-antrun-plugin:1.6
[WARNING]  * org.apache.maven.plugins:maven-source-plugin:2.1.2
[WARNING]  * org.apache.maven.plugins:maven-plugin-plugin:3.6.0
[WARNING]  * org.apache.maven.plugins:maven-compiler-plugin:3.10.1
[WARNING]  * org.jacoco:jacoco-maven-plugin:0.8.11-SNAPSHOT
[WARNING]  * com.github.genthaler:beanshell-maven-plugin:1.4
[WARNING]  * org.apache.maven.plugins:maven-shade-plugin:3.2.1
[WARNING]  * org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2
[WARNING]  * org.apache.maven.plugins:maven-jar-plugin:2.3.1
[WARNING]  * org.apache.maven.plugins:maven-surefire-plugin:2.19.1
[WARNING]  * org.apache.maven.plugins:maven-assembly-plugin:2.2.1
[WARNING]  * org.jetbrains.kotlin:kotlin-maven-plugin:1.5.0
[WARNING]  * org.codehaus.mojo:build-helper-maven-plugin:1.5
[WARNING]  * org.codehaus.mojo:exec-maven-plugin:1.5.0
[WARNING]  * org.codehaus.gmavenplus:gmavenplus-plugin:1.13.0
[WARNING]
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING]
```