### PR TITLE
Fix computation of `build.commitId`

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -667,7 +667,7 @@
         <configuration>
           <doCheck>false</doCheck>
           <doUpdate>false</doUpdate>
-          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+          <getRevisionOnlyOnce>false</getRevisionOnlyOnce>
           <revisionOnScmFailure>0000000</revisionOnScmFailure>
           <buildNumberPropertyName>build.commitId</buildNumberPropertyName>
         </configuration>


### PR DESCRIPTION
Unfortunately #1437 broke build from terminal.

After 4dc8b3855c82c868d7756944519c90d4326913da build from terminal and in CI produces following
`org.jacoco.core/target/classes/org/jacoco/core/jacoco.properties`

```
VERSION=0.8.11.202305151209
COMMITID=0000000
HOMEURL=http://www.jacoco.org/jacoco
RUNTIMEPACKAGE=org.jacoco.agent.rt.internal_0000000
```

https://www.jacoco.org/jacoco/trunk/index.html currently shows

> This is the distribution of version 0.8.11.202305120500 created on 2023/05/12 based on commit 0000000.

Fortunately we have a check that activates at release time and is able to detect this - `mvn clean verify -Prelease` fails as following

```
[WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireProperty failed with message:
Property "build.commitId" evaluates to "0000000".  This does not match the regular expression "[0-9a-f]{40}"
```
