### PR TITLE
Upgrade maven-jar-plugin to 3.3.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -347,7 +347,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.3.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.035 s
[INFO] Finished at: 2023-05-17T00:15:23+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 18 plugin(s)
...
[WARNING]  * org.apache.maven.plugins:maven-jar-plugin:2.3.1
...
```

Note that the new version produces slightly different `jar` files - `below is an example of org.jacoco.agent-0.8.11-SNAPSHOT.jar`, others in the same way:

`META-INF/MANIFEST.MF`
```diff
 Manifest-Version: 1.0
-Archiver-Version: Plexus Archiver
 Created-By: Apache Maven Bundle Plugin
-Built-By: godin
-Build-Jdk: 11.0.17
+Build-Jdk-Spec: 11
 Automatic-Module-Name: org.jacoco.agent
-Bnd-LastModified: 1684446448995
+Bnd-LastModified: 1684447060925
+Build-Jdk: 11.0.17
+Built-By: godin
 Bundle-Description: JaCoCo Agent
 Bundle-License: https://www.eclipse.org/legal/epl-2.0/
 Bundle-ManifestVersion: 2
 Bundle-Name: JaCoCo Agent
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-SymbolicName: org.jacoco.agent
 Bundle-Vendor: Mountainminds GmbH & Co. KG
-Bundle-Version: 0.8.11.202305180947
-Eclipse-SourceReferences: scm:git:git://github.com/jacoco/jacoco.git;p
- ath="org.jacoco.agent";commitId=0304aa7b4354b47a205b7aa0aa98291d52aad
- 8e5
+Bundle-Version: 0.8.11.202305180957
+Eclipse-SourceReferences: scm:git:git://github.com/jacoco/jacoco.git;pat
+ h="org.jacoco.agent";commitId=f4a0996822d3096b31e8f4e52eb9fab354bad8b0
 Export-Package: org.jacoco.agent;version="0.8.11"
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.5))"
 Tool: Bnd-3.5.0.201709291849
```

`META-INF/maven/org.jacoco/org.jacoco.agent/pom.properties`
```diff
-#Generated by Maven
-#Thu May 18 23:47:29 CEST 2023
-groupId=org.jacoco
 artifactId=org.jacoco.agent
+groupId=org.jacoco
 version=0.8.11-SNAPSHOT
```