### PR TITLE
Upgrade maven-dependency-plugin to 3.5.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -317,7 +317,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.2</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.035 s
[INFO] Finished at: 2023-05-17T00:15:23+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 17 plugin(s)
...
[WARNING]  * org.apache.maven.plugins:maven-dependency-plugin:2.2
...
```
