### PR TITLE
Upgrade maven-assembly-plugin to 3.6.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -302,7 +302,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  42.077 s
[INFO] Finished at: 2023-05-22T11:42:01+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 18 plugin(s)
[WARNING]
[WARNING]  * org.apache.felix:maven-bundle-plugin:3.5.1
[WARNING]  * org.apache.maven.plugins:maven-plugin-plugin:3.6.0
[WARNING]  * org.jacoco:jacoco-maven-plugin:0.8.11-SNAPSHOT
[WARNING]  * com.github.genthaler:beanshell-maven-plugin:1.4
[WARNING]  * net.alchim31.maven:scala-maven-plugin:4.4.0
[WARNING]  * org.apache.maven.plugins:maven-shade-plugin:3.2.1
[WARNING]  * org.apache.maven.plugins:maven-invoker-plugin:2.0.0
[WARNING]  * org.apache.maven.plugins:maven-javadoc-plugin:3.0.1
[WARNING]  * org.apache.maven.plugins:maven-source-plugin:3.2.1
[WARNING]  * org.apache.maven.plugins:maven-assembly-plugin:2.2.1
[WARNING]  * org.apache.maven.plugins:maven-dependency-plugin:3.5.0
[WARNING]  * org.apache.maven.plugins:maven-surefire-plugin:2.19.1
[WARNING]  * org.jetbrains.kotlin:kotlin-maven-plugin:1.5.0
[WARNING]  * org.codehaus.mojo:buildnumber-maven-plugin:1.2
[WARNING]  * org.codehaus.gmavenplus:gmavenplus-plugin:1.13.0
[WARNING]  * org.codehaus.mojo:xml-maven-plugin:1.0
[WARNING]  * org.apache.maven.plugins:maven-resources-plugin:2.5
[WARNING]  * org.apache.maven.plugins:maven-antrun-plugin:1.6
[WARNING]
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING]
...
```
