### PR TITLE
Upgrade maven-source-plugin to 3.2.1

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -412,7 +412,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.1.2</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change on 41dbbb01f659f14860cbd5bd6e5c3dbcdf95f0dc:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.035 s
[INFO] Finished at: 2023-05-17T00:15:23+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 19 plugin(s)
...
[WARNING]  * org.apache.maven.plugins:maven-source-plugin:2.1.2
...
```

Note that the new version produces slightly different `source.jar` files - below is an example of `org.jacoco.core-0.8.11-SNAPSHOT-sources.jar`, others in the same way:

adds entries `META-INF/maven/org.jacoco/org.jacoco.core/pom.xml`
and `META-INF/maven/org.jacoco/org.jacoco.core/pom.properties`
which corresponds to the following note from https://maven.apache.org/plugins/maven-source-plugin/jar-no-fork-mojo.html

> Note: Since 3.0.0 the resulting archives contain a maven descriptor. If you need to suppress the generation of the maven descriptor you can simply achieve this by using the [archiver configuration](http://maven.apache.org/shared/maven-archiver/index.html#archive).

and modifies entry `META-INF/MANIFEST.MF`

```diff
 Manifest-Version: 1.0
-Archiver-Version: Plexus Archiver
-Created-By: Apache Maven
-Built-By: godin
-Build-Jdk: 11.0.17
+Created-By: Maven Source Plugin 3.2.1
```
