### PR TITLE
Fix generation of `Eclipse-SourceReference` entry in `MANIFEST.MF`

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -128,7 +128,6 @@
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
 
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
-    <build.commitId>0000000</build.commitId>
     <jacoco.home.url>http://www.jacoco.org/jacoco</jacoco.home.url>
     <copyright.years>${project.inceptionYear}, 2023</copyright.years>
 
@@ -666,7 +665,7 @@
         <configuration>
           <doCheck>false</doCheck>
           <doUpdate>false</doUpdate>
-          <getRevisionOnlyOnce>false</getRevisionOnlyOnce>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
           <revisionOnScmFailure>0000000</revisionOnScmFailure>
           <buildNumberPropertyName>build.commitId</buildNumberPropertyName>
         </configuration>

--- a/org.jacoco.core/src/org/jacoco/core/jacoco.properties
+++ b/org.jacoco.core/src/org/jacoco/core/jacoco.properties
@@ -1,4 +1,4 @@
 VERSION=${qualified.bundle.version}
-COMMITID=${build.commitId}
+COMMITID=@build.commitId@
 HOMEURL=${jacoco.home.url}
 RUNTIMEPACKAGE=${jacoco.runtime.package.name}


### PR DESCRIPTION
During the comparison of JAR files while doing #1444 I realized that unfortunately https://github.com/jacoco/jacoco/pull/1437 broke build from terminal and unfortunately https://github.com/jacoco/jacoco/pull/1443 did not fully fix it.

After https://github.com/jacoco/jacoco/commit/4dc8b3855c82c868d7756944519c90d4326913da and https://github.com/jacoco/jacoco/commit/740c51fd74934ea7549383984f21e8ffe3dc2910 build from terminal and in CI produces following `Eclipse-SourceReference` entry in `META-INF/MANIFEST.MF`

```
Eclipse-SourceReferences: scm:git:git://github.com/jacoco/jacoco.git;p
 ath="org.jacoco.core";commitId=0000000
```
