### PR TITLE
Upgrade maven-invoker-plugin to 3.8.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
     ignore:
       # It is known that upgrade from current version requires additional changes:
       - dependency-name: "org.apache.maven.plugins:maven-plugin-plugin"
-      - dependency-name: "org.apache.maven.plugins:maven-invoker-plugin"
       # Because of
       # https://github.com/apache/maven-compiler-plugin/blob/maven-compiler-plugin-3.13.0/pom.xml#L71
       # https://github.com/codehaus-plexus/plexus-compiler/blob/plexus-compiler-2.15.0/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java#L149-L163

--- a/jacoco-maven-plugin.test/pom.xml
+++ b/jacoco-maven-plugin.test/pom.xml
@@ -32,6 +32,15 @@
     <jacoco.includes>org.jacoco.maven.*</jacoco.includes>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>${project.version}</version>
+      <type>maven-plugin</type>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -52,9 +61,6 @@
             <goal>install</goal>
           </goals>
           <settingsFile>it/settings.xml</settingsFile>
-          <extraArtifacts>
-            <extraArtifact>org.jacoco:org.jacoco.agent:${project.version}:jar:runtime</extraArtifact>
-          </extraArtifacts>
           <properties>
             <!--
             maven-invoker-plugin for forked Maven invocations uses the same JDK that is used for Maven,

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -338,7 +338,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>2.0.0</version>
+          <version>3.8.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/org.jacoco.examples.test/pom.xml
+++ b/org.jacoco.examples.test/pom.xml
@@ -42,6 +42,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>${project.version}</version>
+      <type>maven-plugin</type>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Without this change execution of

```
mvn verify -Dmaven.plugin.validation=verbose
```

produces

```
[WARNING]  * org.apache.maven.plugins:maven-invoker-plugin:2.0.0
[WARNING]   Plugin EXTERNAL issue(s):
[WARNING]    * Plugin is a Maven 2.x plugin, which will be not supported in Maven 4.x
```
