### PR TITLE
Upgrade maven-antrun-plugin to 3.1.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -297,7 +297,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.6</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  42.077 s
[INFO] Finished at: 2023-05-22T11:42:01+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 16 plugin(s)
...
[WARNING]  * org.apache.maven.plugins:maven-antrun-plugin:1.6
...
```
