### PR TITLE
Upgrade maven-bundle-plugin to 6.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       - dependency-name: "org.apache.maven.plugins:*"
       - dependency-name: "org.codehaus.mojo:*"
       - dependency-name: "com.diffplug.spotless:*"
+      - dependency-name: "org.apache.felix:*"
       - dependency-name: "org.sonarsource.scanner.maven:*"
     ignore:
       # It is known that upgrade from current version requires additional changes:

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -445,7 +445,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>6.0.0</version>
         </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
Nothing suspicious in diffs - here is example for `org.jacoco.core`:

```diff
--- 1/before/jacoco-0.8.13.202412210239/lib/org.jacoco.core-0.8.13.202412210239/META-INF/MANIFEST.MF
+++ 2/after/jacoco-0.8.13.202412210238/lib/org.jacoco.core-0.8.13.202412210238/META-INF/MANIFEST.MF
@@ -1,10 +1,8 @@
 Manifest-Version: 1.0
-Created-By: Apache Maven Bundle Plugin
+Created-By: Apache Maven Bundle Plugin 6.0.0
 Build-Jdk-Spec: 21
 Automatic-Module-Name: org.jacoco.core
-Bnd-LastModified: 1734748801910
-Build-Jdk: 21.0.1
-Built-By: godin
+Bnd-LastModified: 1734748691882^M
 Bundle-Description: JaCoCo Core
 Bundle-License: https://www.eclipse.org/legal/epl-2.0/
 Bundle-ManifestVersion: 2
@@ -12,9 +10,9 @@ Bundle-Name: JaCoCo Core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-SymbolicName: org.jacoco.core
 Bundle-Vendor: Mountainminds GmbH & Co. KG
-Bundle-Version: 0.8.13.202412210239
+Bundle-Version: 0.8.13.202412210238
 Eclipse-SourceReferences: scm:git:git://github.com/jacoco/jacoco.git;pat
- h="org.jacoco.core";commitId=e21a0b13a9da4aecb4b3c60faeacf45a5b11b9db
+ h="org.jacoco.core";commitId=a7e30821a228770eb0109277d6e2df8743eec1a4^M
 Export-Package: org.jacoco.core.internal;x-internal:=true;version="0.8.1
  3",org.jacoco.core.internal.analysis;x-internal:=true;version="0.8.13";
  uses:="org.jacoco.core.analysis,org.jacoco.core.internal.analysis.filte
@@ -44,5 +42,5 @@ Import-Package: org.jacoco.core;version="[0.8.13,0.8.14)",org.jacoco.cor
  m;version="[9.7.1,9.8)",org.objectweb.asm.commons;version="[9.7.1,9.8)"
  ,org.objectweb.asm.tree;version="[9.7.1,9.8)"
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-Tool: Bnd-3.5.0.201709291849
+Tool: Bnd-7.0.0.202310060912
```
