### PR TITLE
Upgrade buildnumber-maven-plugin to 3.1.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -443,7 +443,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>1.2</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -534,7 +534,7 @@
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <!-- Maven 3.8.2 contains bug - see https://github.com/jacoco/jacoco/issues/1218 -->
-                  <version>[3.3.9,3.8.2),(3.8.2,)</version>
+                  <version>[3.5.4,3.8.2),(3.8.2,)</version>
                 </requireMavenVersion>
                 <requireNoRepositories>
                   <message>The rules for repo1.maven.org are that pom.xml files should not include repository definitions.</message>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -24,7 +24,7 @@
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a> and
   can be locally executed on every machine with a proper
   <a href="environment.html">environment setup</a>. In particular you need at
-  least <a href="http://maven.apache.org/">Maven 3.3.9</a> and JDK 11
+  least <a href="http://maven.apache.org/">Maven 3.5.4</a> and JDK 11
   installations. Developers are encouraged to run the build before every commit
   to ensure consistency of the source tree.
 </p>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -28,6 +28,12 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/893">#893</a>).</li>
 </ul>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>JaCoCo build now requires at least Maven 3.5.4
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1467">#1467</a>).</li>
+</ul>
+
 <h2>Release 0.8.10 (2023/04/24)</h2>
 
 <h3>Fixed bugs</h3>

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -76,7 +76,7 @@
 
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a>
-  and requires at least Maven 3.3.9 and JDK 11.
+  and requires at least Maven 3.5.4 and JDK 11.
   See the <a href="build.html">build description</a> for details.
 </p>
 


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  42.077 s
[INFO] Finished at: 2023-05-23T12:18:40+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 15 plugin(s)
...
[WARNING]  * org.codehaus.mojo:buildnumber-maven-plugin:1.2
...
```

Note that [`buildnumber-maven-plugin` starting from version `3.1.0` requires Maven `3.5.4`](https://github.com/mojohaus/buildnumber-maven-plugin/commit/d50551b6889b78a6901aeb4d419f3f0a17b8ff34) and thus transitively our build should require it too.