### PR TITLE
Upgrade gmavenplus-plugin to 3.0.0

### DIFF
--- a/org.jacoco.core.test.validation.groovy/pom.xml
+++ b/org.jacoco.core.test.validation.groovy/pom.xml
@@ -26,7 +26,7 @@
   <name>JaCoCo :: Test :: Core :: Validation Groovy</name>
 
   <properties>
-    <gmaven.version>1.13.0</gmaven.version>
+    <gmaven.version>3.0.0</gmaven.version>
     <groovy.version>3.0.15</groovy.version>
   </properties>
 


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:20 min
[INFO] Finished at: 2023-05-24T23:38:33+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 12 plugin(s)
...
[WARNING]  * org.codehaus.gmavenplus:gmavenplus-plugin:1.13.0
...
```
