### PR TITLE
Upgrade ECJ to 3.34.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,11 +2,16 @@ cache:
   - C:\Users\appveyor\.m2 -> **\pom.xml
 
 install:
-  - SET JAVA_HOME=C:\Program Files\Java\jdk11
+  - mkdir .jdk
+  - curl -L "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/binary/?jdk_version=17&ext=zip&os=windows&arch=x86&hw_bitness=64&javafx=false&bundle_type=jdk" -o .jdk/jdk.zip
+  - unzip -d .jdk .jdk/jdk.zip
+  - mv .jdk/*/* .jdk
+  - .jdk\bin\java -version
+  - SET JAVA_HOME=%CD%\.jdk
 
 build_script:
   # generation of Javadocs requires Java <= 6 (https://github.com/jacoco/jacoco/issues/110)
-  - mvn -V -B -e verify -Djdk.version=6 --toolchains=.travis\appveyor-toolchains.xml
+  - mvn -V -B -e verify -Djdk.version=6 -Dbytecode.version=5 --toolchains=.travis\appveyor-toolchains.xml
 
 artifacts:
   - path: jacoco\target\*.zip

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -38,11 +38,11 @@ jobs:
         JDK_VERSION: 18
       JDK 19:
         JDK_VERSION: 19
-      JDK 19 with ECJ:
-        JDK_VERSION: 19
-        ECJ: true
       JDK 20:
         JDK_VERSION: 20
+      JDK 20 with ECJ:
+        JDK_VERSION: 20
+        ECJ: true
       JDK 21:
         JDK_VERSION: 21
       JDK 22:
@@ -80,8 +80,10 @@ jobs:
       tar -xzf .maven/maven.tar.gz -C .maven --strip-components 1
     displayName: Setup Maven
   - bash: |
-      if [[ "$JDK_VERSION" -ge "11" ]]; then
+      if [[ "$JDK_VERSION" -ge "17" ]]; then
         export JAVA_HOME=$PWD/.jdk
+      else
+        export JAVA_HOME=$JAVA_HOME_17_X64
       fi
       if [[ "$BUILD_SOURCEBRANCH" == "refs/heads/master" && "$JDK_VERSION" == "5" ]]; then
         .maven/bin/mvn -V -B -e -f org.jacoco.build \

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -523,7 +523,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>11</version>
+                  <version>17</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <!-- Maven 3.8.2 contains bug - see https://github.com/jacoco/jacoco/issues/1218 -->
@@ -945,7 +945,7 @@
               <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>3.33.0</version>
+                <version>3.34.0</version>
               </dependency>
               <dependency>
                 <groupId>org.codehaus.plexus</groupId>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -24,7 +24,7 @@
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a> and
   can be locally executed on every machine with a proper
   <a href="environment.html">environment setup</a>. In particular you need at
-  least <a href="http://maven.apache.org/">Maven 3.5.4</a> and JDK 11
+  least <a href="http://maven.apache.org/">Maven 3.5.4</a> and JDK 17
   installations. Developers are encouraged to run the build before every commit
   to ensure consistency of the source tree.
 </p>
@@ -280,8 +280,8 @@
   <li><code>mvn clean verify -Djdk.version=17 -Dbytecode.version=17 -Decj</code></li>
   <li><code>mvn clean verify -Djdk.version=18 -Dbytecode.version=18</code></li>
   <li><code>mvn clean verify -Djdk.version=19 -Dbytecode.version=19</code></li>
-  <li><code>mvn clean verify -Djdk.version=19 -Dbytecode.version=19 -Decj</code></li>
   <li><code>mvn clean verify -Djdk.version=20 -Dbytecode.version=20</code></li>
+  <li><code>mvn clean verify -Djdk.version=20 -Dbytecode.version=20 -Decj</code></li>
   <li><code>mvn clean verify -Djdk.version=21 -Dbytecode.version=21</code></li>
 </ul>
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -49,6 +49,8 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1467">#1467</a>).</li>
   <li>Maven 3.9.2 should not produce warnings for jacoco-maven-plugin
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1468">#1468</a>).</li>
+  <li>JaCoCo build now requires JDK 17
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1482">#1482</a>).</li>
 </ul>
 
 <h2>Release 0.8.10 (2023/04/24)</h2>

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -76,7 +76,7 @@
 
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a>
-  and requires at least Maven 3.5.4 and JDK 11.
+  and requires at least Maven 3.5.4 and JDK 17.
   See the <a href="build.html">build description</a> for details.
 </p>
 


### PR DESCRIPTION
It requires Java 17 and thus transitively our build should require it too.