### PR TITLE
Upgrade xml-maven-plugin to 1.1.0

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -440,7 +440,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This reduces number of warnings produced by Maven 3.9.2 - prior to this change:

```
...
[WARNING] Plugin validation issues were detected in 9 plugin(s)
...
[WARNING]  * org.codehaus.mojo:xml-maven-plugin:1.0
...
```
