### PR TITLE
Restore exec file compatibility after upgrade of ASM to version 9.5

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.analysis.IMethodCoverage;
+import org.jacoco.core.data.ExecutionDataWriter;
 import org.jacoco.core.internal.analysis.filter.FilterContextMock;
 import org.jacoco.core.internal.analysis.filter.Filters;
 import org.jacoco.core.internal.analysis.filter.IFilter;
@@ -134,6 +135,62 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		assertEquals(1002, result.getLastLine());
 
 		assertLine(1001, 0, 0, 0, 0);
+		assertLine(1002, 0, 1, 0, 0);
+	}
+
+	// === Scenario: method invocation after zero line number
+
+	/**
+	 * @see org.jacoco.core.internal.flow.LabelFlowAnalyzer#visitLineNumber(int,
+	 *      Label)
+	 * @see org.jacoco.core.internal.instr.ZeroLineNumberTest
+	 */
+	private void createZeroLineNumber() {
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
+		method.visitInsn(Opcodes.NOP);
+		final Label l1 = new Label();
+		method.visitLabel(l1);
+		method.visitLineNumber(0, l1);
+		method.visitMethodInsn(Opcodes.INVOKESTATIC, "Foo", "foo", "()V",
+				false);
+		method.visitInsn(Opcodes.NOP);
+		final Label l2 = new Label();
+		method.visitLabel(l2);
+		method.visitLineNumber(1002, l2);
+		method.visitInsn(Opcodes.RETURN);
+	}
+
+	@Test
+	public void zero_line_number_should_create_1_probe() {
+		createZeroLineNumber();
+		runMethodAnalzer();
+		assertEquals(1, nextProbeId);
+
+		// workaround for zero line number can be removed if needed
+		// during change of exec file version
+		assertEquals(0x1007, ExecutionDataWriter.FORMAT_VERSION);
+	}
+
+	@Test
+	public void zero_line_number_should_show_missed_when_no_probes_are_executed() {
+		createZeroLineNumber();
+		runMethodAnalzer();
+
+		assertLine(1001, 1, 0, 0, 0);
+		assertLine(0, 2, 0, 0, 0);
+		assertLine(1002, 1, 0, 0, 0);
+	}
+
+	@Test
+	public void zero_line_number_should_show_covered_when_probe_is_executed() {
+		createZeroLineNumber();
+		probes[0] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 1, 0, 0);
+		assertLine(0, 0, 2, 0, 0);
 		assertLine(1002, 0, 1, 0, 0);
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
@@ -12,12 +12,14 @@
  *******************************************************************************/
 package org.jacoco.core.internal.flow;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.objectweb.asm.Opcodes.*;
 
+import org.jacoco.core.data.ExecutionDataWriter;
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.asm.Label;
@@ -302,6 +304,20 @@ public class LabelFlowAnalyzerTest {
 	public void testLineNumber() {
 		analyzer.visitLineNumber(42, label);
 		assertSame(label, analyzer.lineStart);
+	}
+
+	/**
+	 * @see org.jacoco.core.internal.analysis.MethodAnalyzerTest#zero_line_number_should_create_1_probe()
+	 * @see org.jacoco.core.internal.instr.ZeroLineNumberTest
+	 */
+	@Test
+	public void visitLineNumber_should_skip_zero() {
+		analyzer.visitLineNumber(0, label);
+		assertNull(analyzer.lineStart);
+
+		// workaround for zero line number can be removed if needed
+		// during change of exec file version
+		assertEquals(0x1007, ExecutionDataWriter.FORMAT_VERSION);
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ZeroLineNumberTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ZeroLineNumberTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2023 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.instr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.data.CRC64;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.RuntimeData;
+import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.jacoco.core.test.TargetLoader;
+import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * @see org.jacoco.core.internal.flow.LabelFlowAnalyzer#visitLineNumber(int,
+ *      Label)
+ * @see org.jacoco.core.internal.analysis.MethodAnalyzerTest#zero_line_number_should_create_1_probe()
+ */
+public class ZeroLineNumberTest {
+
+	@Test
+	public void zero_line_numbers_should_be_preserved_during_instrumentation_and_should_not_cause_insertion_of_additional_probes()
+			throws Exception {
+		final IRuntime runtime = new SystemPropertiesRuntime();
+		final RuntimeData data = new RuntimeData();
+		runtime.startup(data);
+
+		final byte[] original = createClass();
+		final byte[] instrumented = new Instrumenter(runtime)
+				.instrument(original, "Sample");
+
+		final Class<?> cls = new TargetLoader().add("Sample", instrumented);
+		try {
+			cls.newInstance();
+			fail("Exception expected");
+		} catch (final Exception e) {
+			assertEquals(0, e.getStackTrace()[1].getLineNumber());
+		}
+
+		data.getExecutionData(CRC64.classId(original), "Sample", 2);
+	}
+
+	private static byte[] createClass() {
+		final ClassWriter cv = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+		cv.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC, "Sample", null,
+				"java/lang/Object", null);
+		cv.visitSource("Sample.java", null);
+
+		MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V",
+				null, null);
+		mv.visitCode();
+		final Label label1 = new Label();
+		mv.visitLabel(label1);
+		mv.visitLineNumber(1, label1);
+		mv.visitVarInsn(Opcodes.ALOAD, 0);
+		mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>",
+				"()V", false);
+		final Label label2 = new Label();
+		mv.visitLabel(label2);
+		mv.visitLineNumber(0, label2);
+		mv.visitMethodInsn(Opcodes.INVOKESTATIC, "Sample", "throw", "()V",
+				false);
+		mv.visitInsn(Opcodes.RETURN);
+		mv.visitMaxs(0, 0);
+		mv.visitEnd();
+
+		mv = cv.visitMethod(Opcodes.ACC_STATIC, "throw", "()V", null, null);
+		mv.visitCode();
+		mv.visitTypeInsn(Opcodes.NEW, "java/lang/RuntimeException");
+		mv.visitInsn(Opcodes.DUP);
+		mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/RuntimeException",
+				"<init>", "()V", false);
+		mv.visitInsn(Opcodes.ATHROW);
+		mv.visitMaxs(0, 0);
+		mv.visitEnd();
+
+		cv.visitEnd();
+		return cv.toByteArray();
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelFlowAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelFlowAnalyzer.java
@@ -101,6 +101,12 @@ public final class LabelFlowAnalyzer extends MethodVisitor {
 
 	@Override
 	public void visitLineNumber(final int line, final Label start) {
+		if (line == 0) {
+			// ASM versions prior to 9.5 were ignoring zero line numbers
+			// (https://gitlab.ow2.org/asm/asm/-/issues/317989)
+			// so we ignore them here to preserve exec file compatibility
+			return;
+		}
 		lineStart = start;
 	}
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -40,6 +40,9 @@
       local variable of method parameters is overridden in the method body to
       store a value of type long or double
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/893">#893</a>).</li>
+  <li>Restore exec file compatibility with versions from 0.7.5 to 0.8.8
+      in case of class files with zero line numbers
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1492">#1492</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>


### PR DESCRIPTION
JaCoCo version `0.8.8`  was removing from `LineNumberTable` entries with zero line numbers (see stacktrace of `RuntimeException` and `classinfo` output below) due to a bug in ASM  (https://gitlab.ow2.org/asm/asm/-/issues/317989), this was fixed by an upgrade of ASM to `9.5` in JaCoCo version `0.8.9` (https://github.com/jacoco/jacoco/pull/1416), which unfortunately also lead to the insertion of more probes (see `execinfo` output below) and so broke exec-file compatibility (see `ArrayIndexOutOfBoundsException` and `IllegalStateException` below).

----

Using the following `Generator.java` which generates class file with zero line number for a method invocation instruction

```java
import org.objectweb.asm.ClassWriter;
import org.objectweb.asm.Label;
import org.objectweb.asm.MethodVisitor;
import org.objectweb.asm.Opcodes;

import java.io.FileOutputStream;
import java.io.IOException;

public class Generator {
        public static void main(String[] args) throws IOException {
                ClassWriter c = new ClassWriter(ClassWriter.COMPUTE_MAXS);
                c.visit(Opcodes.V1_5, 0, "Example", null, "java/lang/Object", null);

                c.visitSource("Example.java", null);

                MethodVisitor m = c.visitMethod(
                                Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "main",
                                "([Ljava/lang/String;)V", null, null);
                m.visitCode();
                m.visitInsn(Opcodes.NOP);
                Label label1 = new Label();
                m.visitLabel(label1);
                m.visitLineNumber(0, label1);
                m.visitMethodInsn(Opcodes.INVOKESTATIC, "Example", "throw", "()V", false);
                Label label2 = new Label();
                m.visitLabel(label2);
                m.visitLineNumber(1, label2);
                m.visitInsn(Opcodes.RETURN);
                m.visitMaxs(0, 0);
                m.visitEnd();

                m = c.visitMethod(Opcodes.ACC_STATIC, "throw", "()V", null, null);
                m.visitCode();
                m.visitTypeInsn(Opcodes.NEW, "java/lang/RuntimeException");
                m.visitInsn(Opcodes.DUP);
                m.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/RuntimeException",
                                "<init>", "()V", false);
                m.visitInsn(Opcodes.ATHROW);
                m.visitMaxs(0, 0);
                m.visitEnd();

                c.visitEnd();

                FileOutputStream fos = new FileOutputStream("Example.class");
                fos.write(cw.toByteArray());
                fos.close();
        }
}
```

execution of

```
java -cp ~/.m2/repository/org/ow2/asm/asm/9.5/asm-9.5.jar Generator.java

java -cp . Example
```

produces

```
Exception in thread "main" java.lang.RuntimeException
        at Example.main(Example.java:0)
```

----

### Before this change

Usage of JaCoCo version `0.8.8` for instrumentation and versions `0.8.9` or `0.8.10` for analysis

```
java -javaagent:jacoco-0.8.8/lib/jacocoagent.jar=append=false -cp . Example

java -jar jacoco-0.8.8/lib/jacococli.jar classinfo Example.class --verbose

java -jar jacoco-0.8.9/lib/jacococli.jar classinfo Example.class --verbose

java -jar jacoco-0.8.9/lib/jacococli.jar report jacoco.exec --classfiles Example.class
```

leads to `ArrayIndexOutOfBoundsException`:

```
Exception in thread "main" java.lang.RuntimeException
        at Example.throw(Example.java)
        at Example.main(Example.java)

  INST   BRAN   LINE   METH   CXTY   ELEMENT
     7      0      1      2      2   class 0x37a683e967bd1949 Example
     3      0      1      1      1   +- method main([Ljava/lang/String;)V
     1      0                        |  +- line 1
     4      0      0      1      1   +- method throw()V

  INST   BRAN   LINE   METH   CXTY   ELEMENT
     7      0      2      2      2   class 0x37a683e967bd1949 Example
     3      0      2      1      1   +- method main([Ljava/lang/String;)V
     1      0                        |  +- line 0
     1      0                        |  +- line 1
     4      0      0      1      1   +- method throw()V

[INFO] Loading execution data file /private/tmp/jacoco.exec.
Exception in thread "main" java.io.IOException: Error while analyzing Example.class with JaCoCo 0.8.9.202303310957/c0ad781.
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzerError(Analyzer.java:163)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:135)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:158)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:195)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeAll(Analyzer.java:228)
        at org.jacoco.cli.internal.commands.Report.analyze(Report.java:110)
        at org.jacoco.cli.internal.commands.Report.execute(Report.java:84)
        at org.jacoco.cli.internal.Main.execute(Main.java:90)
        at org.jacoco.cli.internal.Main.main(Main.java:105)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
        at org.jacoco.cli.internal.core.internal.analysis.InstructionsBuilder.addProbe(InstructionsBuilder.java:149)
        at org.jacoco.cli.internal.core.internal.analysis.MethodAnalyzer.visitInsnWithProbe(MethodAnalyzer.java:169)
        at org.jacoco.cli.internal.core.internal.flow.MethodProbesAdapter.visitInsn(MethodProbesAdapter.java:107)
        at org.jacoco.cli.internal.asm.tree.InsnNode.accept(InsnNode.java:65)
        at org.jacoco.cli.internal.core.internal.analysis.MethodAnalyzer.accept(MethodAnalyzer.java:52)
        at org.jacoco.cli.internal.core.internal.analysis.ClassAnalyzer$1.accept(ClassAnalyzer.java:107)
        at org.jacoco.cli.internal.core.internal.flow.ClassProbesAdapter$2.visitEnd(ClassProbesAdapter.java:91)
        at org.jacoco.cli.internal.asm.ClassReader.readMethod(ClassReader.java:1518)
        at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:744)
        at org.jacoco.cli.internal.asm.ClassReader.accept(ClassReader.java:424)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:117)
        at org.jacoco.cli.internal.core.analysis.Analyzer.analyzeClass(Analyzer.java:133)
        ... 7 more
```

Usage of JaCoCo version `0.8.8` together with versions `0.8.9` or `0.8.10` for instrumentation

```
java -javaagent:jacoco-0.8.8/lib/jacocoagent.jar=append=false -cp . Example

java -javaagent:jacoco-0.8.9/lib/jacocoagent.jar -cp . Example

java -jar jacoco-0.8.9/lib/jacococli.jar execinfo jacoco.exec

java -jar jacoco-0.8.8/lib/jacococli.jar report jacoco.exec --classfiles Example.class

java -jar jacoco-0.8.9/lib/jacococli.jar report jacoco.exec --classfiles Example.class
```

leads to `IllegalStateException` at analysis time

```
Exception in thread "main" java.lang.RuntimeException
        at Example.throw(Example.java)
        at Example.main(Example.java)

Exception in thread "main" java.lang.RuntimeException
        at Example.throw(Example.java)
        at Example.main(Example.java:0)

[INFO] Loading exec file jacoco.exec.
CLASS ID         HITS/PROBES   CLASS NAME
Session "godins-macbook-pro.home-cefeb549": Mon Jul 10 23:03:15 CEST 2023 - Mon Jul 10 23:03:15 CEST 2023
37a683e967bd1949    1 of   2   Example
Session "godins-macbook-pro.home-e0b3d098": Mon Jul 10 23:03:15 CEST 2023 - Mon Jul 10 23:03:15 CEST 2023
37a683e967bd1949    2 of   3   Example

[INFO] Loading execution data file /private/tmp/jacoco.exec.
Exception in thread "main" java.lang.IllegalStateException: Incompatible execution data for class Example with id 37a683e967bd1949.
        at org.jacoco.cli.internal.core.data.ExecutionData.assertCompatibility(ExecutionData.java:197)
        at org.jacoco.cli.internal.core.data.ExecutionData.merge(ExecutionData.java:160)
        at org.jacoco.cli.internal.core.data.ExecutionData.merge(ExecutionData.java:133)
        at org.jacoco.cli.internal.core.data.ExecutionDataStore.put(ExecutionDataStore.java:55)
        at org.jacoco.cli.internal.core.data.ExecutionDataStore.visitClassExecution(ExecutionDataStore.java:178)
        at org.jacoco.cli.internal.core.data.ExecutionDataReader.readExecutionData(ExecutionDataReader.java:151)
        at org.jacoco.cli.internal.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:116)
        at org.jacoco.cli.internal.core.data.ExecutionDataReader.read(ExecutionDataReader.java:93)
        at org.jacoco.cli.internal.core.tools.ExecFileLoader.load(ExecFileLoader.java:60)
        at org.jacoco.cli.internal.core.tools.ExecFileLoader.load(ExecFileLoader.java:74)
        at org.jacoco.cli.internal.commands.Report.loadExecutionData(Report.java:99)
        at org.jacoco.cli.internal.commands.Report.execute(Report.java:83)
        at org.jacoco.cli.internal.Main.execute(Main.java:90)
        at org.jacoco.cli.internal.Main.main(Main.java:105)

[INFO] Loading execution data file /private/tmp/jacoco.exec.
Exception in thread "main" java.lang.IllegalStateException: Incompatible execution data for class Example with id 37a683e967bd1949.
        at org.jacoco.cli.internal.core.data.ExecutionData.assertCompatibility(ExecutionData.java:197)
        at org.jacoco.cli.internal.core.data.ExecutionData.merge(ExecutionData.java:160)
        at org.jacoco.cli.internal.core.data.ExecutionData.merge(ExecutionData.java:133)
        at org.jacoco.cli.internal.core.data.ExecutionDataStore.put(ExecutionDataStore.java:55)
        at org.jacoco.cli.internal.core.data.ExecutionDataStore.visitClassExecution(ExecutionDataStore.java:178)
        at org.jacoco.cli.internal.core.data.ExecutionDataReader.readExecutionData(ExecutionDataReader.java:151)
        at org.jacoco.cli.internal.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:116)
        at org.jacoco.cli.internal.core.data.ExecutionDataReader.read(ExecutionDataReader.java:93)
        at org.jacoco.cli.internal.core.tools.ExecFileLoader.load(ExecFileLoader.java:60)
        at org.jacoco.cli.internal.core.tools.ExecFileLoader.load(ExecFileLoader.java:74)
        at org.jacoco.cli.internal.commands.Report.loadExecutionData(Report.java:99)
        at org.jacoco.cli.internal.commands.Report.execute(Report.java:83)
        at org.jacoco.cli.internal.Main.execute(Main.java:90)
        at org.jacoco.cli.internal.Main.main(Main.java:105)
```

Usage of JaCoCo versions `0.8.9` or `0.8.10` for instrumentation and analysis

```
java -javaagent:jacoco-0.8.9/lib/jacocoagent.jar=append=false -cp . Example

java -jar jacoco-0.8.9/lib/jacococli.jar report jacoco.exec --classfiles Example.class --html report
```

produces

<img width="816" alt="Screenshot 2023-07-11 at 00 02 01" src="https://github.com/jacoco/jacoco/assets/138671/7f2c04a5-3b22-43ae-9465-0a19a6401161">

whereas usage of JaCoCo versions `0.8.9` or `0.8.10` for instrumentation and version `0.8.8` for analysis

```
java -javaagent:jacoco-0.8.9/lib/jacocoagent.jar=append=false -cp . Example

java -jar jacoco-0.8.8/lib/jacococli.jar report jacoco.exec --classfiles Example.class --html report
```

leads to a misleading report

<img width="816" alt="Screenshot 2023-07-10 at 22 49 40" src="https://github.com/jacoco/jacoco/assets/138671/bc0ab7b8-776c-4d2a-8481-603372f88fcd">

----

### After this change

Usage of JaCoCo version `0.8.8` for instrumentation and version with this change for analysis

```
java -javaagent:jacoco-0.8.8/lib/jacocoagent.jar=append=false -cp . Example

java -javaagent:jacoco-snapshot/lib/jacocoagent.jar -cp . Example

java -jar jacoco-snapshot/lib/jacococli.jar classinfo Example.class --verbose

java -jar jacoco-snapshot/lib/jacococli.jar execinfo jacoco.exec

java -jar jacoco-snapshot/lib/jacococli.jar report jacoco.exec --classfiles Example.class
```

does not lead to `ArrayIndexOutOfBoundsException`:

```
Exception in thread "main" java.lang.RuntimeException
        at Example.throw(Example.java)
        at Example.main(Example.java)

Exception in thread "main" java.lang.RuntimeException
        at Example.throw(Example.java)
        at Example.main(Example.java:0)

  INST   BRAN   LINE   METH   CXTY   ELEMENT
     7      0      2      2      2   class 0x37a683e967bd1949 Example
     3      0      2      1      1   +- method main([Ljava/lang/String;)V
     1      0                        |  +- line 0
     1      0                        |  +- line 1
     4      0      0      1      1   +- method throw()V

[INFO] Loading exec file jacoco.exec.
CLASS ID         HITS/PROBES   CLASS NAME
Session "godins-macbook-pro.home-c5f6be3c": Mon Jul 10 23:08:04 CEST 2023 - Mon Jul 10 23:08:04 CEST 2023
37a683e967bd1949    1 of   2   Example
Session "godins-macbook-pro.home-f3138653": Mon Jul 10 23:08:04 CEST 2023 - Mon Jul 10 23:08:04 CEST 2023
37a683e967bd1949    1 of   2   Example

[INFO] Loading execution data file /private/tmp/jacoco.exec.
[INFO] Analyzing 1 classes.
```

however

usage of JaCoCo versions `0.8.9` or `0.8.10` for instrumentation and version with this change for analysis
will still lead to a misleading report

and usage of JaCoCo version with this change together with versions `0.8.9` or `0.8.10` for instrumentation
will still lead to `IllegalStateException` at analysis time. 

----

Fixes #1471 
