### PR TITLE
`Opcodes.RET` should be processed by `visitVarInsn` instead of `visitInsn`

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
@@ -264,11 +264,6 @@ public class LabelFlowAnalyzerTest {
 		assertFalse(analyzer.first);
 	}
 
-	@Test(expected = AssertionError.class)
-	public void testVisitInsnNegative() {
-		analyzer.visitInsn(RET);
-	}
-
 	@Test
 	public void testIntInsn() {
 		analyzer.visitIntInsn(BIPUSH, 0);
@@ -281,6 +276,11 @@ public class LabelFlowAnalyzerTest {
 		analyzer.visitVarInsn(ILOAD, 0);
 		assertTrue(analyzer.successor);
 		assertFalse(analyzer.first);
+	}
+
+	@Test(expected = AssertionError.class)
+	public void testVisitVarInsnNegative() {
+		analyzer.visitVarInsn(RET, 0);
 	}
 
 	@Test

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelFlowAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/LabelFlowAnalyzer.java
@@ -137,8 +137,6 @@ public final class LabelFlowAnalyzer extends MethodVisitor {
 	@Override
 	public void visitInsn(final int opcode) {
 		switch (opcode) {
-		case Opcodes.RET:
-			throw new AssertionError("Subroutines not supported.");
 		case Opcodes.IRETURN:
 		case Opcodes.LRETURN:
 		case Opcodes.FRETURN:
@@ -163,6 +161,9 @@ public final class LabelFlowAnalyzer extends MethodVisitor {
 
 	@Override
 	public void visitVarInsn(final int opcode, final int var) {
+		if (Opcodes.RET == opcode) {
+			throw new AssertionError("Subroutines not supported.");
+		}
 		successor = true;
 		first = false;
 	}


### PR DESCRIPTION
See
* https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-6.html#jvms-6.5.ret
* https://asm.ow2.io/javadoc/org/objectweb/asm/MethodVisitor.html#visitVarInsn(int,int)
* https://gitlab.ow2.org/asm/asm/-/blob/ASM_9_5/asm/src/main/java/org/objectweb/asm/ClassReader.java?ref_type=tags#L2408-2409