### PR TITLE
Fix misleading outdated javadoc

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesVisitor.java
@@ -47,10 +47,8 @@ public abstract class ClassProbesVisitor extends ClassVisitor {
 			String desc, String signature, String[] exceptions);
 
 	/**
-	 * Reports the total number of encountered probes. For classes this method
-	 * is called just before {@link ClassVisitor#visitEnd()}. For interfaces
-	 * this method is called before the first method (the static initializer) is
-	 * emitted.
+	 * Reports the total number of encountered probes. This method is called
+	 * just before {@link #visitEnd()}
 	 *
 	 * @param count
 	 *            total number of probes


### PR DESCRIPTION
Outdated since commit 72793f84314a393b86c5dc344499888b7113d20b in JaCoCo version 0.7.1