### PR TITLE
Use SPDX identifier for license declaration in pom.xml

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -27,7 +27,7 @@
   </organization>
   <licenses>
     <license>
-      <name>Eclipse Public License 2.0</name>
+      <name>EPL-2.0</name>
       <url>https://www.eclipse.org/legal/epl-2.0/</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
As recommended by https://maven.apache.org/pom.html#Licenses