### PR TITLE
Fix misleading outdated javadoc

### DIFF
--- a/org.jacoco.ant.test/src/org/jacoco/ant/TestTarget.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/TestTarget.java
@@ -21,8 +21,7 @@ import org.junit.Test;
 
 /**
  * Simple test target for Java applications ant JUnit4 tests. To assert
- * execution it creates an empty file <code>target.txt</code> in the working
- * directory.
+ * execution it prints "Target executed".
  */
 public class TestTarget {
 


### PR DESCRIPTION
Outdated since created in commit 88802a1de70be3fbf7675316f0f66b10f5ff34b4 in JaCoCo version 0.3.3