### PR TITLE
Added reference to the JaCoCo extension for bld

### DIFF
--- a/org.jacoco.doc/docroot/doc/integrations.html
+++ b/org.jacoco.doc/docroot/doc/integrations.html
@@ -85,6 +85,10 @@
       <td>Cloud-powered collaboration tools by Microsoft, see <a href="https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-code-coverage-results">documentation</a></td>
     </tr>
     <tr>
+      <td><a href="https://rife2.com/bld">bld</a></td>
+      <td>Pure Java build System with JaCoCo extension, see <a href="https://github.com/rife2/bld-jacoco-report">documentation</a></td>
+    </tr>
+    <tr>
       <td><a href="https://www.codacy.com/">Codacy</a></td>
       <td>Platform to track code coverage and code quality, see <a href="https://support.codacy.com/hc/en-us/articles/207279819-Coverage">documentation</a></td>
     </tr>


### PR DESCRIPTION
Added a reference to the [JaCoCo extension for bld](https://github.com/rife2/bld-jacoco-report) to the `Integration Matrix` table 