### PR TITLE
Fix warnings reported by maven-shade-plugin

### DIFF
--- a/org.jacoco.agent.rt/pom.xml
+++ b/org.jacoco.agent.rt/pom.xml
@@ -71,6 +71,18 @@
               </relocations>
               <filters>
                 <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jacoco:org.jacoco.core</artifact>
+                  <excludes>
+                    <exclude>about.html</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>org.ow2.asm:*</artifact>
                   <excludes>
                     <exclude>module-info.class</exclude>

--- a/org.jacoco.ant/pom.xml
+++ b/org.jacoco.ant/pom.xml
@@ -70,6 +70,30 @@
               </relocations>
               <filters>
                 <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jacoco:org.jacoco.core</artifact>
+                  <excludes>
+                    <exclude>about.html</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jacoco:org.jacoco.report</artifact>
+                  <excludes>
+                    <exclude>about.html</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jacoco:org.jacoco.agent</artifact>
+                  <excludes>
+                    <exclude>about.html</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>org.ow2.asm:*</artifact>
                   <excludes>
                     <exclude>module-info.class</exclude>

--- a/org.jacoco.cli/pom.xml
+++ b/org.jacoco.cli/pom.xml
@@ -108,6 +108,24 @@
               </transformers>
               <filters>
                 <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jacoco:org.jacoco.core</artifact>
+                  <excludes>
+                    <exclude>about.html</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.jacoco:org.jacoco.report</artifact>
+                  <excludes>
+                    <exclude>about.html</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>args4j:args4j</artifact>
                   <excludes>
                     <exclude>**/Messages_*.properties</exclude>


### PR DESCRIPTION
Without this change

```
...
[INFO] --- shade:3.5.0:shade (default) @ org.jacoco.agent.rt ---
[INFO] Including org.jacoco:org.jacoco.core:jar:0.8.12-SNAPSHOT in the shaded jar.
[INFO] Including org.ow2.asm:asm:jar:9.6 in the shaded jar.
[INFO] Including org.ow2.asm:asm-commons:jar:9.6 in the shaded jar.
[INFO] Including org.ow2.asm:asm-tree:jar:9.6 in the shaded jar.
[INFO] Minimizing jar org.jacoco:org.jacoco.agent.rt:jar:0.8.12-SNAPSHOT
[WARNING] org.jacoco.agent.rt-0.8.12-SNAPSHOT.jar, org.jacoco.core-0.8.12-SNAPSHOT.jar define 1 overlapping resource:
[WARNING]   - about.html
[WARNING] asm-9.6.jar, asm-commons-9.6.jar, asm-tree-9.6.jar, org.jacoco.agent.rt-0.8.12-SNAPSHOT.jar, org.jacoco.core-0.8.12-SNAPSHOT.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Minimized 310 -> 179 (57%)
[INFO] Attaching shaded artifact.
...
[INFO] --- shade:3.5.0:shade (default) @ org.jacoco.ant ---
[INFO] Including org.jacoco:org.jacoco.core:jar:0.8.12-SNAPSHOT in the shaded jar.
[INFO] Including org.ow2.asm:asm:jar:9.6 in the shaded jar.
[INFO] Including org.ow2.asm:asm-commons:jar:9.6 in the shaded jar.
[INFO] Including org.ow2.asm:asm-tree:jar:9.6 in the shaded jar.
[INFO] Including org.jacoco:org.jacoco.report:jar:0.8.12-SNAPSHOT in the shaded jar.
[INFO] Including org.jacoco:org.jacoco.agent:jar:0.8.12-SNAPSHOT in the shaded jar.
[INFO] Minimizing jar org.jacoco:org.jacoco.ant:jar:0.8.12-SNAPSHOT
[WARNING] asm-9.6.jar, asm-commons-9.6.jar, asm-tree-9.6.jar, org.jacoco.agent-0.8.12-SNAPSHOT.jar, org.jacoco.ant-0.8.12-SNAPSHOT.jar, org.jacoco.core-0.8.12-SNAPSHOT.jar, org.jacoco.report-0.8.12-SNAPSHOT.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] org.jacoco.agent-0.8.12-SNAPSHOT.jar, org.jacoco.ant-0.8.12-SNAPSHOT.jar, org.jacoco.core-0.8.12-SNAPSHOT.jar, org.jacoco.report-0.8.12-SNAPSHOT.jar define 1 overlapping resource:
[WARNING]   - about.html
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Minimized 420 -> 373 (88%)
[INFO] Attaching shaded artifact.
...
[INFO] --- shade:3.5.0:shade (default) @ org.jacoco.cli ---
[INFO] Including org.jacoco:org.jacoco.core:jar:0.8.12-SNAPSHOT in the shaded jar.
[INFO] Including org.ow2.asm:asm:jar:9.6 in the shaded jar.
[INFO] Including org.ow2.asm:asm-commons:jar:9.6 in the shaded jar.
[INFO] Including org.ow2.asm:asm-tree:jar:9.6 in the shaded jar.
[INFO] Including org.jacoco:org.jacoco.report:jar:0.8.12-SNAPSHOT in the shaded jar.
[INFO] Including args4j:args4j:jar:2.0.28 in the shaded jar.
[INFO] Minimizing jar org.jacoco:org.jacoco.cli:jar:0.8.12-SNAPSHOT
[WARNING] org.jacoco.cli-0.8.12-SNAPSHOT.jar, org.jacoco.core-0.8.12-SNAPSHOT.jar, org.jacoco.report-0.8.12-SNAPSHOT.jar define 1 overlapping resource:
[WARNING]   - about.html
[WARNING] args4j-2.0.28.jar, asm-9.6.jar, asm-commons-9.6.jar, asm-tree-9.6.jar, org.jacoco.cli-0.8.12-SNAPSHOT.jar, org.jacoco.core-0.8.12-SNAPSHOT.jar, org.jacoco.report-0.8.12-SNAPSHOT.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Minimized 484 -> 405 (83%)
[INFO] Attaching shaded artifact.
...
```

and no such warnings after this change.
Also I checked that this change doesn't affect the content of JAR files.