### PR TITLE
Add configuration for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - jdk: 8
+          - jdk: 11
+          - jdk: 17
+          - jdk: 21
+    name: JDK ${{ matrix.jdk }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
+        with:
+          distribution: 'zulu'
+          java-version: |
+            ${{ matrix.jdk }}
+            17
+      - name: 'Generate toolchains.xml'
+        env:
+          JDK_VERSION: ${{ matrix.jdk }}
+          JDK_HOME_VARIABLE_NAME: JAVA_HOME_${{ matrix.jdk }}_X64
+        run: |
+          echo "
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <id>$JDK_VERSION</id>
+                <version>$JDK_VERSION</version>
+              </provides>
+              <configuration>
+                <jdkHome>${!JDK_HOME_VARIABLE_NAME}</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          " > toolchains.xml
+      - name: 'Build'
+        run: |
+          mvn -V -B -e \
+            verify -Djdk.version=${{ matrix.jdk }} -Dbytecode.version=${{ matrix.jdk }} \
+            --toolchains=toolchains.xml

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -87,6 +87,7 @@
 </p>
 
 <ul>
+  <li><a href="https://github.com/jacoco/jacoco/actions">GitHub Actions</a></li>
   <li><a href="https://dev.azure.com/JaCoCo-org/JaCoCo/_build">Azure Pipelines</a></li>
   <li><a href="https://ci.appveyor.com/project/JaCoCo/jacoco">AppVeyor</a></li>
 </ul>


### PR DESCRIPTION
One of the advantages of GitHub Actions - they are easy to enable in forks on GitHub, which allows testing without publishing a branch in our repo and without opening PR.

So I propose to take a baby step and as a starter add this basic configuration for GitHub Actions. And later on will look at fully replacing AppVeyor and AzurePipelines.