### PR TITLE
Add configuration for Dependabot to simplify updates of ASM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "org.ow2.asm:*"


### PR DESCRIPTION
There were no announcements in ASM mailing list for the past two releases, so instead of wasting the time of @merks on this (see https://github.com/jacoco/jacoco/pull/1600#issuecomment-2017578336), I propose to use Dependabot.