### PR TITLE
Configure labels that Dependabot assigns to PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "component: build"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "component: core"
     allow:
       - dependency-name: "org.ow2.asm:*"


### PR DESCRIPTION
According to https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels

> By default, Dependabot raises all pull requests with the `dependencies` label. If more than one package manager is defined, Dependabot includes an additional label on each pull request. This indicates which language or ecosystem the pull request will update, for example: `java`

This was overlooked in https://github.com/jacoco/jacoco/pull/1601