### PR TITLE
Fix build with JDK >= 20 when option `-Dbytecode.version` is not provided

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -744,10 +744,37 @@
     <profile>
       <id>maven-jdk12</id>
       <activation>
-        <jdk>[12,)</jdk>
+        <jdk>[12,20)</jdk>
       </activation>
       <properties>
         <bytecode.version>7</bytecode.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- https://bugs.openjdk.org/browse/JDK-8173605 -->
+      <id>maven-jdk20</id>
+      <activation>
+        <jdk>[20,)</jdk>
+      </activation>
+      <properties>
+        <bytecode.version>8</bytecode.version>
+      </properties>
+    </profile>
+
+    <!--
+    Following profile is automatically activated in IntelliJ IDEA
+    and used to set the correct Java language level in it
+    -->
+    <profile>
+      <id>intellij</id>
+      <activation>
+        <property>
+          <name>idea.maven.embedder.version</name>
+        </property>
+      </activation>
+      <properties>
+        <bytecode.version>5</bytecode.version>
       </properties>
     </profile>
 

--- a/org.jacoco.core.test.validation.java7/pom.xml
+++ b/org.jacoco.core.test.validation.java7/pom.xml
@@ -24,14 +24,24 @@
 
   <name>JaCoCo :: Test :: Core :: Validation Java 7</name>
 
-  <properties>
-    <bytecode.version>7</bytecode.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>org.jacoco.core.test</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>intellij</id>
+      <activation>
+        <property>
+          <name>idea.maven.embedder.version</name>
+        </property>
+      </activation>
+      <properties>
+        <bytecode.version>7</bytecode.version>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -287,9 +287,9 @@
     <td>7</td>
     <td>7</td>
     <td>7</td>
-    <td>7</td>
-    <td>7</td>
-    <td>7</td>
+    <td>8</td>
+    <td>8</td>
+    <td>8</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Due to https://bugs.openjdk.org/browse/JDK-8173605 currently the execution of build with JDK 20 and higher requires specification of `-Dbytecode.version`, ie execution of `mvn clean package -Dbytecode.version=8` succeeds, whereas execution of `mvn clean package` fails

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project org.jacoco.core: Compilation failure: Compilation failure:
[ERROR] Source option 7 is no longer supported. Use 8 or later.
[ERROR] Target option 7 is no longer supported. Use 8 or later.
```
