### PR TITLE
Fix build of JaCoCo with JDK 23 EA after JDK-8324774

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -762,6 +762,27 @@
       </properties>
     </profile>
 
+    <profile>
+      <id>maven-jdk23</id>
+      <activation>
+        <jdk>[23,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalOptions>
+                <!-- https://bugs.openjdk.org/browse/JDK-8324774 -->
+                <option>--no-fonts</option>
+              </additionalOptions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!--
     Following profile is automatically activated in IntelliJ IDEA
     and used to set the correct Java language level in it
@@ -1033,6 +1054,30 @@
       <properties>
         <bytecode.version>7</bytecode.version>
       </properties>
+    </profile>
+
+    <profile>
+      <id>jdk23</id>
+      <activation>
+        <property>
+          <name>jdk.version</name>
+          <value>23</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalOptions>
+                <!-- https://bugs.openjdk.org/browse/JDK-8324774 -->
+                <option>--no-fonts</option>
+              </additionalOptions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <!-- This profile enables generation of JARs with sources and javadocs -->


### PR DESCRIPTION
Prior to this change execution of

```
mvn clean verify -Djdk.version=23
```

using JDK 23 EA >= b16 fails with

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.3.0:enforce (enforce-distribution-size) on project jacoco:
[ERROR] Rule 0: org.apache.maven.enforcer.rules.files.RequireFilesSize failed with message:
[ERROR] /Users/evgeny.mandrikov/projects/jacoco/jacoco/jacoco/target/jacoco-0.8.13.202405130824.zip size (8253189) too large. Max. is 4600000/Users/evgeny.mandrikov/projects/jacoco/jacoco/jacoco/target/jacoco-0.8.13.202405130824.zip
```

due to https://bugs.openjdk.org/browse/JDK-8324774

After this change it will pass for JDK 23 EA >= b16, but unfortunately will fail for < b16 with

```
error: invalid flag: --no-fonts
```
