### PR TITLE
`mvn -Decj=false` should not activate the use of ECJ

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -953,6 +953,7 @@
       <activation>
         <property>
           <name>ecj</name>
+          <value>true</value>
         </property>
       </activation>
       <build>


### PR DESCRIPTION
Without this change execution of

```
mvn clean verify -Decj=false
```

causes the use of ECJ, which is IMO counterintuitive.

Only `-Decj=true` or `-Decj` or `-Pecj` should activate ECJ, but not `-Decj=false` nor `-Decj=foo`.

This was discovered while working on a migration from AzurePipelines to GitHub Actions.
In AzurePipelines we use `-Decj=true` to activate ECJ and `-Decj=` otherwise

https://github.com/jacoco/jacoco/blob/7589f79f3a7329b77c605a11a6825aed8b812f0f/.azure-pipelines/azure-pipelines.yml#L104

And interpretation of `-Decj=` is the same before and after this change.

Activation of profiles can be tested using

```
mvn -f org.jacoco.build --non-recursive help:active-profiles
```

See also https://maven.apache.org/guides/introduction/introduction-to-profiles.html#property