### PR TITLE
Add missing `Test` annotation to method in `FileOutputTest`

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/FileOutputTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/FileOutputTest.java
@@ -108,6 +108,7 @@ public class FileOutputTest {
 		}
 	}
 
+	@Test
 	public void startup_should_throw_InterruptedIOException_when_execfile_is_locked_and_thread_is_interrupted()
 			throws Exception {
 		if (JavaVersion.current().isBefore("1.6")) {


### PR DESCRIPTION
This was overlooked in aa16a7c25cfc119ba3486bb114d3d54dc1bcca6c