### PR TITLE
NormalizedFileNames should add prefix instead of suffix

### DIFF
--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -42,6 +42,9 @@
 <ul>
   <li>Fixed interpretation of Kotlin SMAP
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1525">#1525</a>).</li>
+  <li>File extensions are preserved in HTML report in case of clashes of normalized
+      file names
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1660">#1660</a>).</li>
 </ul>
 
 <h3>Non-functional Changes</h3>

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/NormalizedFileNamesTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/NormalizedFileNamesTest.java
@@ -52,26 +52,26 @@ public class NormalizedFileNamesTest {
 
 	@Test
 	public void testReplaceIllegalCharactersNonUnique() {
-		assertEquals("F__", nfn.getFileName("F__"));
-		assertEquals("F__~1", nfn.getFileName("F**"));
-		assertEquals("F__~2", nfn.getFileName("F??"));
+		assertEquals("F__.html", nfn.getFileName("F__.html"));
+		assertEquals("1~F__.html", nfn.getFileName("F**.html"));
+		assertEquals("2~F__.html", nfn.getFileName("F??.html"));
 
 		// Mapping must be reproducible
-		assertEquals("F__", nfn.getFileName("F__"));
-		assertEquals("F__~1", nfn.getFileName("F**"));
-		assertEquals("F__~2", nfn.getFileName("F??"));
+		assertEquals("F__.html", nfn.getFileName("F__.html"));
+		assertEquals("1~F__.html", nfn.getFileName("F**.html"));
+		assertEquals("2~F__.html", nfn.getFileName("F??.html"));
 	}
 
 	@Test
 	public void testCaseAware() {
-		assertEquals("Hello", nfn.getFileName("Hello"));
-		assertEquals("HELLO~1", nfn.getFileName("HELLO"));
-		assertEquals("HeLLo~2", nfn.getFileName("HeLLo"));
+		assertEquals("Hello.html", nfn.getFileName("Hello.html"));
+		assertEquals("1~HELLO.html", nfn.getFileName("HELLO.html"));
+		assertEquals("2~HeLLo.html", nfn.getFileName("HeLLo.html"));
 
 		// Mapping must be reproducible
-		assertEquals("Hello", nfn.getFileName("Hello"));
-		assertEquals("HELLO~1", nfn.getFileName("HELLO"));
-		assertEquals("HeLLo~2", nfn.getFileName("HeLLo"));
+		assertEquals("Hello.html", nfn.getFileName("Hello.html"));
+		assertEquals("1~HELLO.html", nfn.getFileName("HELLO.html"));
+		assertEquals("2~HeLLo.html", nfn.getFileName("HeLLo.html"));
 	}
 
 }

--- a/org.jacoco.report/src/org/jacoco/report/internal/NormalizedFileNames.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/NormalizedFileNames.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * <li>File names are case aware, i.e. the same file name but with different
  * upper/lower case characters is not possible.</li>
  * <li>If unique filenames can't directly created from the ids, additional
- * suffixes are appended.</li>
+ * prefixes are prepended.</li>
  * </ul>
  */
 class NormalizedFileNames {
@@ -81,7 +81,7 @@ class NormalizedFileNames {
 		String lower = unique.toLowerCase(Locale.ENGLISH);
 		int idx = 1;
 		while (usedNames.contains(lower)) {
-			unique = s + '~' + idx++;
+			unique = (idx++) + "~" + s;
 			lower = unique.toLowerCase(Locale.ENGLISH);
 		}
 		usedNames.add(lower);


### PR DESCRIPTION
Otherwise it changes file extensions.

Fixes #1656

Alternatives are
* change it to handle extensions separately/explicitly
* or change its consumers to append extension after it
