### PR TITLE
Fix javadoc

### DIFF
--- a/org.jacoco.report/src/org/jacoco/report/internal/ReportOutputFolder.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/ReportOutputFolder.java
@@ -83,8 +83,8 @@ public class ReportOutputFolder {
 	 * Creates a new file in this folder with the given local name.
 	 *
 	 * @param name
-	 *            name of the sub-folder
-	 * @return handle for output into the sub-folder
+	 *            name of the file
+	 * @return stream for output into the file
 	 * @throws IOException
 	 *             if the file creation fails
 	 */


### PR DESCRIPTION
Incorrect since creation in commit 2f5a2fc86a1148674bd1d661111c621cfa912a6b in JaCoCo version 0.1.0