### PR TITLE
Extract SMAP parser from KotlinInlineFilter

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSMAPTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSMAPTest.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link KotlinSMAP}.
+ */
+public class KotlinSMAPTest {
+
+	/**
+	 * <pre>
+	 * // A.kt
+	 * package a
+	 * inline fun f() {} // line 3
+	 * </pre>
+	 *
+	 * <pre>
+	 * // B.kt
+	 * package b
+	 * fun callsite() = f() // line 3
+	 * </pre>
+	 */
+	@Test
+	public void should_parse() {
+		final KotlinSMAP smap = new KotlinSMAP("B.kt", "SMAP\n" //
+				+ "B.kt\n" // OutputFileName=B.kt
+				+ "Kotlin\n" // DefaultStratumId=Kotlin
+				+ "*S Kotlin\n" // StratumID=Kotlin
+				+ "*F\n" // FileSection
+				+ "+ 1 B.kt\n" // FileID=1,FileName=B.kt
+				+ "b/BKt\n" // ClassName=b/BKt
+				+ "+ 2 A.kt\n" // FileID=2,FileName=A.kt
+				+ "a/AKt\n" // ClassName=a/AKt
+				+ "*L\n" // LineSection
+				+ "1#1,4:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=4,OutputStartLine=1
+				+ "3#2:5\n" // InputStartLine=3,LineFileID=2,RepeatCount=,OutputStartLine=5
+				+ "*E\n"); // EndSection
+		assertEquals(2, smap.mappings().size());
+		KotlinSMAP.Mapping mapping = smap.mappings().get(0);
+		assertEquals("b/BKt", mapping.inputClassName());
+		assertEquals(1, mapping.inputStartLine());
+		assertEquals(4, mapping.repeatCount());
+		assertEquals(1, mapping.outputStartLine());
+		mapping = smap.mappings().get(1);
+		assertEquals("a/AKt", mapping.inputClassName());
+		assertEquals(3, mapping.inputStartLine());
+		assertEquals(1, mapping.repeatCount());
+		assertEquals(5, mapping.outputStartLine());
+	}
+
+	/**
+	 * See <a href="https://youtrack.jetbrains.com/issue/KT-37704">KT-37704</a>
+	 *
+	 * <pre>
+	 * inline fun f() {}
+	 * fun g() = f()
+	 * </pre>
+	 */
+	@Test
+	public void should_stop_parsing_at_KotlinDebug_stratum() {
+		final KotlinSMAP smap = new KotlinSMAP("Example.kt", "SMAP\n" //
+				+ "Example.kt\n" // OutputFileName=Example.kt
+				+ "Kotlin\n" // DefaultStratumId=Kotlin
+				+ "*S Kotlin\n" // StratumID=Kotlin
+				+ "*F\n" // FileSection
+				+ "+ 1 Example.kt\n" // FileID=1,FileName=Example.kt
+				+ "ExampleKt\n" //
+				+ "*L\n" // LineSection
+				+ "1#1,3:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=3,OutputStartLine=1
+				+ "1#1:4\n" // InputStartLine=1,LineFileID=1,OutputStartLine=4
+				+ "*S KotlinDebug\n" // StratumID=KotlinDebug
+				+ "xxx");
+		assertEquals(2, smap.mappings().size());
+		KotlinSMAP.Mapping mapping = smap.mappings().get(0);
+		assertEquals("ExampleKt", mapping.inputClassName());
+		assertEquals(1, mapping.inputStartLine());
+		assertEquals(3, mapping.repeatCount());
+		assertEquals(1, mapping.outputStartLine());
+		mapping = smap.mappings().get(1);
+		assertEquals("ExampleKt", mapping.inputClassName());
+		assertEquals(1, mapping.inputStartLine());
+		assertEquals(1, mapping.repeatCount());
+		assertEquals(4, mapping.outputStartLine());
+	}
+
+	@Test
+	public void should_throw_exception_when_not_an_SMAP_Header() {
+		try {
+			new KotlinSMAP("", "xxx");
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: xxx", e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_OutputFileName_does_not_match_SourceFileName() {
+		try {
+			new KotlinSMAP("", "SMAP\n" //
+					+ "Example.kt\n");
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: Example.kt", e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_DefaultStratumId_is_not_Kotlin() {
+		try {
+			new KotlinSMAP("Servlet.java", "SMAP\n" //
+					+ "Servlet.java\n" // OutputFileName=Servlet.java
+					+ "JSP\n"); // DefaultStratumId=JSP
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: JSP", e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_first_StratumId_is_not_Kotlin() {
+		try {
+			new KotlinSMAP("Example.kt", "SMAP\n" //
+					+ "Example.kt\n" // OutputFileName=Example.kt
+					+ "Kotlin\n" // DefaultStratumId=Kotlin
+					+ "*S KotlinDebug\n"); // StratumID=KotlinDebug
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: *S KotlinDebug",
+					e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_StratumSection_does_not_start_with_FileSection() {
+		try {
+			new KotlinSMAP("Example.kt", "SMAP\n" //
+					+ "Example.kt\n" //
+					+ "Kotlin\n" //
+					+ "*S Kotlin\n" //
+					+ "xxx"); //
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: xxx", e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_FileSection_contains_unexpected_FileInfo() {
+		try {
+			new KotlinSMAP("Example.kt", "SMAP\n" //
+					+ "Example.kt\n" //
+					+ "Kotlin\n" //
+					+ "*S Kotlin\n" //
+					+ "*F\n" //
+					+ "xxx"); //
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: xxx", e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_LineSection_contains_unexpected_LineInfo() {
+		try {
+			new KotlinSMAP("Example.kt", "SMAP\n" //
+					+ "Example.kt\n" //
+					+ "Kotlin\n" //
+					+ "*S Kotlin\n" //
+					+ "*F\n" //
+					+ "*L\n" //
+					+ "xxx"); //
+			fail("exception expected");
+		} catch (final IllegalStateException e) {
+			assertEquals("Unexpected SMAP line: xxx", e.getMessage());
+		}
+	}
+
+	@Test
+	public void should_throw_exception_when_LineInfo_does_not_have_FileID() {
+		try {
+			new KotlinSMAP("Example.kt", "SMAP\n" //
+					+ "Example.kt\n" //
+					+ "Kotlin\n" //
+					+ "*S Kotlin\n" //
+					+ "*F\n" //
+					+ "*L\n" //
+					+ "1:1\n"); // InputStartLine=1,OutputStartLine=1
+			fail("exception expected");
+		} catch (final NullPointerException e) {
+			// expected
+		}
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilter.java
@@ -12,13 +12,6 @@
  *******************************************************************************/
 package org.jacoco.core.internal.analysis.filter;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.BitSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.LineNumberNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -57,85 +50,18 @@ public final class KotlinInlineFilter implements IFilter {
 		}
 	}
 
-	private static int getFirstGeneratedLineNumber(
-			final String currentClassName, final String sourceFileName,
-			final String smap) {
-		try {
-			final BufferedReader br = new BufferedReader(
-					new StringReader(smap));
-			expectLine(br, "SMAP");
-			// OutputFileName
-			expectLine(br, sourceFileName);
-			// DefaultStratumId
-			expectLine(br, "Kotlin");
-			// StratumSection
-			expectLine(br, "*S Kotlin");
-			// FileSection
-			expectLine(br, "*F");
-			final BitSet sourceFileIds = new BitSet();
-			String line;
-			while (!"*L".equals(line = br.readLine())) {
-				final Matcher m = FILE_INFO_PATTERN.matcher(line);
-				if (!m.matches()) {
-					throw new IllegalStateException(
-							"Unexpected SMAP line: " + line);
-				}
-				// See
-				// https://github.com/JetBrains/kotlin/blob/2.0.0/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt#L120-L121
-				// https://github.com/JetBrains/kotlin/blob/2.0.0/compiler/backend/src/org/jetbrains/kotlin/codegen/SourceInfo.kt#L38-L41
-				final String className = br.readLine();
-				if (currentClassName.equals(className)) {
-					sourceFileIds.set(Integer.parseInt(m.group(1)));
-				}
+	private static int getFirstGeneratedLineNumber(final String className,
+			final String sourceFileName, final String smap) {
+		int min = Integer.MAX_VALUE;
+		for (KotlinSMAP.Mapping mapping : new KotlinSMAP(sourceFileName, smap)
+				.mappings()) {
+			if (className.equals(mapping.inputClassName())
+					&& mapping.inputStartLine() == mapping.outputStartLine()) {
+				continue;
 			}
-			// LineSection
-			int min = Integer.MAX_VALUE;
-			while (true) {
-				line = br.readLine();
-				if (line.equals("*E") || line.equals("*S KotlinDebug")) {
-					break;
-				}
-				final Matcher m = LINE_INFO_PATTERN.matcher(line);
-				if (!m.matches()) {
-					throw new IllegalStateException(
-							"Unexpected SMAP line: " + line);
-				}
-				final int inputStartLine = Integer.parseInt(m.group(1));
-				final int lineFileID = Integer
-						.parseInt(m.group(2).substring(1));
-				final int outputStartLine = Integer.parseInt(m.group(4));
-				if (sourceFileIds.get(lineFileID)
-						&& inputStartLine == outputStartLine) {
-					continue;
-				}
-				min = Math.min(outputStartLine, min);
-			}
-			return min;
-		} catch (final IOException e) {
-			// Must not happen with StringReader
-			throw new AssertionError(e);
+			min = Math.min(mapping.outputStartLine(), min);
 		}
+		return min;
 	}
-
-	private static void expectLine(final BufferedReader br,
-			final String expected) throws IOException {
-		final String line = br.readLine();
-		if (!expected.equals(line)) {
-			throw new IllegalStateException("Unexpected SMAP line: " + line);
-		}
-	}
-
-	private static final Pattern LINE_INFO_PATTERN = Pattern.compile("" //
-			+ "([0-9]++)" // InputStartLine
-			+ "(#[0-9]++)?+" // LineFileID
-			+ "(,[0-9]++)?+" // RepeatCount
-			+ ":([0-9]++)" // OutputStartLine
-			+ "(,[0-9]++)?+" // OutputLineIncrement
-	);
-
-	private static final Pattern FILE_INFO_PATTERN = Pattern.compile("" //
-			+ "\\+ ([0-9]++)" // FileID
-			+ " (.++)" // FileName
-	);
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinSMAP.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinSMAP.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis.filter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parsed representation of SourceDebugExtension attribute.
+ */
+final class KotlinSMAP {
+
+	public static final class Mapping {
+		private final String inputClassName;
+		private final int inputStartLine;
+		private final int repeatCount;
+		private final int outputStartLine;
+
+		/**
+		 * Creates a new mapping.
+		 *
+		 * @param inputClassName
+		 *            name of input class
+		 * @param inputStartLine
+		 *            starting line in input
+		 * @param repeatCount
+		 *            number of mapped lines
+		 * @param outputStartLine
+		 *            starting line in output
+		 */
+		Mapping(final String inputClassName, final int inputStartLine,
+				final int repeatCount, final int outputStartLine) {
+			this.inputClassName = inputClassName;
+			this.inputStartLine = inputStartLine;
+			this.repeatCount = repeatCount;
+			this.outputStartLine = outputStartLine;
+		}
+
+		/**
+		 * @return name of input class
+		 */
+		public String inputClassName() {
+			return inputClassName;
+		}
+
+		/**
+		 * @return starting line in input
+		 */
+		public int inputStartLine() {
+			return inputStartLine;
+		}
+
+		/**
+		 * @return number of mapped lines
+		 */
+		public int repeatCount() {
+			return repeatCount;
+		}
+
+		/**
+		 * @return starting line in output
+		 */
+		public int outputStartLine() {
+			return outputStartLine;
+		}
+	}
+
+	private final ArrayList<Mapping> mappings = new ArrayList<Mapping>();
+
+	/**
+	 * Returns list of mappings.
+	 *
+	 * @return list of mappings
+	 */
+	public List<Mapping> mappings() {
+		return mappings;
+	}
+
+	/**
+	 * Creates parsed representation of provided SourceDebugExtension attribute.
+	 *
+	 * @param sourceFileName
+	 *            the name of the source file from which the class with SMAP was
+	 *            compiled
+	 * @param smap
+	 *            value of SourceDebugExtension attribute to parse
+	 */
+	public KotlinSMAP(final String sourceFileName, final String smap) {
+		try {
+			final BufferedReader br = new BufferedReader(
+					new StringReader(smap));
+			// Header
+			expectLine(br, "SMAP");
+			// OutputFileName
+			expectLine(br, sourceFileName);
+			// DefaultStratumId
+			expectLine(br, "Kotlin");
+			// StratumSection
+			expectLine(br, "*S Kotlin");
+			// FileSection
+			expectLine(br, "*F");
+			final HashMap<Integer, String> inputClassNames = new HashMap<Integer, String>();
+			String line;
+			while (!"*L".equals(line = br.readLine())) {
+				final Matcher m = FILE_INFO_PATTERN.matcher(line);
+				if (!m.matches()) {
+					throw new IllegalStateException(
+							"Unexpected SMAP line: " + line);
+				}
+				final int id = Integer.parseInt(m.group(1));
+				// See
+				// https://github.com/JetBrains/kotlin/blob/2.0.0/compiler/backend/src/org/jetbrains/kotlin/codegen/inline/SMAP.kt#L120-L121
+				// https://github.com/JetBrains/kotlin/blob/2.0.0/compiler/backend/src/org/jetbrains/kotlin/codegen/SourceInfo.kt#L38-L41
+				final String className = br.readLine();
+				inputClassNames.put(id, className);
+			}
+			// LineSection
+			while (true) {
+				line = br.readLine();
+				if (line.equals("*E") || line.equals("*S KotlinDebug")) {
+					break;
+				}
+				final Matcher m = LINE_INFO_PATTERN.matcher(line);
+				if (!m.matches()) {
+					throw new IllegalStateException(
+							"Unexpected SMAP line: " + line);
+				}
+				final int inputStartLine = Integer.parseInt(m.group(1));
+				final int lineFileID = Integer
+						.parseInt(m.group(2).substring(1));
+				final String repeatCountOptional = m.group(3);
+				final int repeatCount = repeatCountOptional != null
+						? Integer.parseInt(repeatCountOptional.substring(1))
+						: 1;
+				final int outputStartLine = Integer.parseInt(m.group(4));
+				mappings.add(new Mapping(inputClassNames.get(lineFileID),
+						inputStartLine, repeatCount, outputStartLine));
+			}
+		} catch (final IOException e) {
+			// Must not happen with StringReader
+			throw new AssertionError(e);
+		}
+	}
+
+	private static void expectLine(final BufferedReader br,
+			final String expected) throws IOException {
+		final String line = br.readLine();
+		if (!expected.equals(line)) {
+			throw new IllegalStateException("Unexpected SMAP line: " + line);
+		}
+	}
+
+	private static final Pattern LINE_INFO_PATTERN = Pattern.compile("" //
+			+ "([0-9]++)" // InputStartLine
+			+ "(#[0-9]++)?+" // LineFileID
+			+ "(,[0-9]++)?+" // RepeatCount
+			+ ":([0-9]++)" // OutputStartLine
+			+ "(,[0-9]++)?+" // OutputLineIncrement
+	);
+
+	private static final Pattern FILE_INFO_PATTERN = Pattern.compile("" //
+			+ "\\+ ([0-9]++)" // FileID
+			+ " (.++)" // FileName
+	);
+
+}


### PR DESCRIPTION
This decouples filtering logic from parsing, which is IMO good on its own.
And allows using parser for resolution of #654.
