### PR TITLE
Require at least Maven 3.6.3 for build

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -520,7 +520,7 @@
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <!-- Maven 3.8.2 contains bug - see https://github.com/jacoco/jacoco/issues/1218 -->
-                  <version>[3.5.4,3.8.2),(3.8.2,)</version>
+                  <version>[3.6.3,3.8.2),(3.8.2,)</version>
                 </requireMavenVersion>
                 <requireNoRepositories>
                   <message>The rules for repo1.maven.org are that pom.xml files should not include repository definitions.</message>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -24,7 +24,7 @@
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a> and
   can be locally executed on every machine with a proper
   <a href="environment.html">environment setup</a>. In particular you need at
-  least <a href="http://maven.apache.org/">Maven 3.5.4</a> and JDK 17
+  least <a href="http://maven.apache.org/">Maven 3.6.3</a> and JDK 17
   installations. Developers are encouraged to run the build before every commit
   to ensure consistency of the source tree.
 </p>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -44,6 +44,12 @@
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1525">#1525</a>).</li>
 </ul>
 
+<h3>Non-functional Changes</h3>
+<ul>
+  <li>JaCoCo build now requires at least Maven 3.6.3
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1681">#1681</a>).</li>
+</ul>
+
 <h2>Release 0.8.12 (2024/03/31)</h2>
 
 <h3>New Features</h3>

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -76,7 +76,7 @@
 
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a>
-  and requires at least Maven 3.5.4 and JDK 17.
+  and requires at least Maven 3.6.3 and JDK 17.
   See the <a href="build.html">build description</a> for details.
 </p>
 


### PR DESCRIPTION
Quoting https://maven.apache.org/docs/history.html

> Currently, plugins provide Maven API compatibility down to 3.2.5. New plugin releases will require Maven 3.6.3 or later.

And execution of

```
mvn versions:display-plugin-updates
```

shows

```
INFO] Require Maven 3.6.3 to use the following plugin updates:
[INFO]   maven-assembly-plugin .............................. 3.6.0 -> 3.7.1
[INFO]   maven-clean-plugin ................................. 3.2.0 -> 3.4.0
[INFO]   maven-compiler-plugin ............................ 3.11.0 -> 3.13.0
[INFO]   maven-dependency-plugin ............................ 3.6.0 -> 3.7.1
[INFO]   maven-deploy-plugin ................................ 3.1.1 -> 3.1.2
[INFO]   maven-enforcer-plugin .............................. 3.3.0 -> 3.5.0
[INFO]   maven-install-plugin ............................... 3.1.1 -> 3.1.2
[INFO]   maven-invoker-plugin ............................... 2.0.0 -> 3.7.0
[INFO]   maven-jar-plugin ................................... 3.3.0 -> 3.4.2
[INFO]   maven-javadoc-plugin ............................... 3.6.3 -> 3.8.0
[INFO]   maven-plugin-plugin ......................... 3.6.4 -> 4.0.0-beta-1
[INFO]   maven-release-plugin ................................. 2.1 -> 3.1.1
[INFO]   maven-shade-plugin ................................. 3.5.0 -> 3.6.0
[INFO]   maven-site-plugin ............................. 3.12.1 -> 4.0.0-M16
[INFO]   maven-surefire-plugin ............................. 2.19.1 -> 3.3.1
[INFO]   maven-toolchains-plugin ............................ 3.1.0 -> 3.2.0
[INFO]   org.codehaus.mojo:animal-sniffer-maven-plugin ........ 1.23 -> 1.24
[INFO]   org.codehaus.mojo:build-helper-maven-plugin ........ 3.4.0 -> 3.6.0
[INFO]   org.codehaus.mojo:exec-maven-plugin ................ 3.1.0 -> 3.4.0
```
