### PR TITLE
Generate HTML reports for validation tests

### DIFF
--- a/org.jacoco.core.test/pom.xml
+++ b/org.jacoco.core.test/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>org.jacoco.core</artifactId>
+      <artifactId>org.jacoco.report</artifactId>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -15,22 +15,31 @@ package org.jacoco.core.test.validation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IBundleCoverage;
 import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.data.ExecutionData;
 import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.SessionInfo;
 import org.jacoco.core.internal.analysis.CounterImpl;
 import org.jacoco.core.test.InstrumentingLoader;
 import org.jacoco.core.test.TargetLoader;
 import org.jacoco.core.test.validation.Source.Line;
 import org.jacoco.core.test.validation.targets.Stubs;
+import org.jacoco.report.DirectorySourceFileLocator;
+import org.jacoco.report.FileMultiReportOutput;
+import org.jacoco.report.IReportVisitor;
+import org.jacoco.report.ISourceFileLocator;
+import org.jacoco.report.html.HTMLFormatter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.model.MultipleFailureException;
@@ -55,6 +64,8 @@ public abstract class ValidationTestBase {
 	private final Class<?> target;
 
 	private Source source;
+
+	private IBundleCoverage bundle;
 
 	private InstrumentingLoader loader;
 
@@ -86,7 +97,9 @@ public abstract class ValidationTestBase {
 		for (ExecutionData data : store.getContents()) {
 			analyze(analyzer, data);
 		}
-		source = Source.load(target, builder.getBundle("Test"));
+		final String testClassSimpleName = getClass().getSimpleName();
+		bundle = builder.getBundle(testClassSimpleName);
+		source = Source.load(target, bundle);
 	}
 
 	private void analyze(final Analyzer analyzer, final ExecutionData data)
@@ -94,6 +107,22 @@ public abstract class ValidationTestBase {
 		final byte[] bytes = TargetLoader
 				.getClassDataAsBytes(target.getClassLoader(), data.getName());
 		analyzer.analyzeClass(bytes, data.getName());
+	}
+
+	/**
+	 * Generates HTML report.
+	 */
+	@Test
+	public final void generate_html_report() throws IOException {
+		final File destination = new File("target/reports/" + bundle.getName());
+		final IReportVisitor visitor = new HTMLFormatter()
+				.createVisitor(new FileMultiReportOutput(destination));
+		visitor.visitInfo(Collections.<SessionInfo> emptyList(),
+				Collections.<ExecutionData> emptyList());
+		final ISourceFileLocator sourceFileLocator = new DirectorySourceFileLocator(
+				new File("src"), "UTF-8", 4);
+		visitor.visitBundle(bundle, sourceFileLocator);
+		visitor.visitEnd();
 	}
 
 	/**


### PR DESCRIPTION
IMO this visualization on its own and as an addition to #1565 is very handy when

* investigating failures of tests after compiler version update
* adding new tests
* updating existing tests
* and experimenting with implementations of new features such as #1670

For example execution of `org.jacoco.core.test.validation.java8.InterfaceDefaultMethodsTest` after this change generates following report in directory `org.jacoco.core.test.validation.java8/target/reports/InterfaceDefaultMethodsTest/`

<img width="1118" alt="Screenshot 2024-08-21 at 11 31 49" src="https://github.com/user-attachments/assets/08857343-1e2d-4bec-92b1-68a8b636a372">

<img width="1118" alt="Screenshot 2024-08-21 at 11 32 06" src="https://github.com/user-attachments/assets/9c5875b0-9bc5-4447-bce7-05896ffc6480">

<img width="1118" alt="Screenshot 2024-08-21 at 11 32 36" src="https://github.com/user-attachments/assets/b232bd2d-e68f-4828-8201-928c5242187d">
