### PR TITLE
Add a new Mojo ("report-aggregate-all") to aggregate projects from reactor without forking a lifecycle

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,5 +4,8 @@
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
     </JavaCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
   </code_scheme>
 </component>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
-   http://www.eclipse.org/legal/epl-2.0
+   https://www.eclipse.org/legal/epl-2.0
 
    SPDX-License-Identifier: EPL-2.0
 

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child1-test</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>jacoco</groupId>
+      <artifactId>child1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/src/test/java/package1/Example1bTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/src/test/java/package1/Example1bTest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1bTest {
+
+	@Test
+	public void test() {
+		new Example1b().b();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/src/test/java/package1/Example1bTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1-test/src/test/java/package1/Example1bTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
-   http://www.eclipse.org/legal/epl-2.0
+   https://www.eclipse.org/legal/epl-2.0
 
    SPDX-License-Identifier: EPL-2.0
 

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child1</artifactId>
+  <packaging>jar</packaging>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1a.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1a.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1a {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1a.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1a.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1b.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1b.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+public class Example1b {
+
+	public void b() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1b.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/main/java/package1/Example1b.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/test/java/package1/Example1aTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/test/java/package1/Example1aTest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package1;
+
+import org.junit.Test;
+
+public class Example1aTest {
+
+	@Test
+	public void test() {
+		new Example1a().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/test/java/package1/Example1aTest.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child1/src/test/java/package1/Example1aTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
-   http://www.eclipse.org/legal/epl-2.0
+   https://www.eclipse.org/legal/epl-2.0
 
    SPDX-License-Identifier: EPL-2.0
 

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child2</artifactId>
+  <packaging>jar</packaging>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/main/java/package2/Example2.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+public class Example2 {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/main/java/package2/Example2.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/test/java/package2/Example2Test.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+import org.junit.Test;
+
+public class Example2Test {
+
+	@Test
+	public void test() {
+		new Example2().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2/src/test/java/package2/Example2Test.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
-   http://www.eclipse.org/legal/epl-2.0
+   https://www.eclipse.org/legal/epl-2.0
 
    SPDX-License-Identifier: EPL-2.0
 

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>it-report-aggregate-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>child2</artifactId>
+  <version>2.0-SNAPSHOT</version>
+
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/main/java/package2/Example2.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+public class Example2 {
+
+	public void a() {
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/main/java/package2/Example2.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/main/java/package2/Example2.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/test/java/package2/Example2Test.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package package2;
+
+import org.junit.Test;
+
+public class Example2Test {
+
+	@Test
+	public void test() {
+		new Example2().a();
+	}
+
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/test/java/package2/Example2Test.java
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/child2v2/src/test/java/package2/Example2Test.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/invoker.properties
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean verify jacoco:report-aggregate-all

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
-   http://www.eclipse.org/legal/epl-2.0
+   https://www.eclipse.org/legal/epl-2.0
 
    SPDX-License-Identifier: EPL-2.0
 

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Marc R. Hoffmann, Jan Wloka - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-report-aggregate-all</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child1</module>
+    <module>child1-test</module>
+    <module>child2</module>
+    <module>child2v2</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/verify.bsh
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+import org.codehaus.plexus.util.*;
+import java.util.regex.*;
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+if ( !Pattern.compile( "Loading execution data file \\S*child1.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child1 was not loaded." );
+}
+
+if ( !Pattern.compile( "Loading execution data file \\S*child1-test.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child1-test was not loaded." );
+}
+
+if ( !new File( basedir, "child2/target/jacoco.exec" ).isFile()) {
+    throw new RuntimeException( "No execution data in child2." );
+}
+if ( !Pattern.compile( "Loading execution data file \\S*child2.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child2 was not loaded." );
+}
+if ( !Pattern.compile( "Loading execution data file \\S*child2v2.target.jacoco.exec").matcher( buildLog ).find() ) {
+    throw new RuntimeException( "Execution data from child2v2 was not loaded." );
+}
+
+//if ( !Pattern.compile( "Loading execution data file \\S*report.target.jacoco.exec").matcher( buildLog ).find() ) {
+//    throw new RuntimeException( "Execution data from report was not loaded." );
+//}
+
+File reportChild1 = new File( basedir, "target/site/jacoco-aggregate/child1/index.html" );
+if ( !reportChild1.isFile() ) {
+    throw new RuntimeException( "Report for child1 was not created." );
+}
+
+File reportChild1test = new File( basedir, "target/site/jacoco-aggregate/child1-test/index.html" );
+if ( !reportChild1test.isFile() ) {
+    throw new RuntimeException( "Report for child1-test was not created." );
+}
+
+File reportChild2 = new File( basedir, "target/site/jacoco-aggregate/child2/index.html" );
+if ( !reportChild2.isFile() ) {
+    throw new RuntimeException( "Report for child2 was not created." );
+}

--- a/jacoco-maven-plugin.test/it/it-report-aggregate-all/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-report-aggregate-all/verify.bsh
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
@@ -12,19 +12,12 @@
  *******************************************************************************/
 package org.jacoco.maven;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
-import org.jacoco.report.IReportGroupVisitor;
 
 /**
  * <p>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    John Oliver, Marc R. Hoffmann, Jan Wloka - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
+import org.jacoco.report.IReportGroupVisitor;
+
+/**
+ * <p>
+ * Creates a structured code coverage report (HTML, XML, and CSV) from multiple
+ * projects within reactor. The report is created from all modules this project
+ * depends on. From those projects class and source files as well as JaCoCo
+ * execution data files will be collected and aggregated. This mojo will not
+ * fork any lifecycle and so need to be added after build generating jacoco
+ * data.
+ * </p>
+ *
+ * @since 0.8.13
+ */
+@Mojo(name = "report-aggregate-all", threadSafe = true, aggregator = true)
+public class ReportAggregateAllMojo extends ReportAggregateMojo {
+
+	@Override
+	protected List<MavenProject> findDependencies(final String... scopes) {
+
+		List<MavenProject> result = reactorProjects;
+
+		// need to exclude pom projects
+		List<MavenProject> nonPomProjects = new ArrayList<>();
+		for (MavenProject mavenProject : result) {
+			if (!StringUtils.equals("pom", mavenProject.getPackaging())) {
+				nonPomProjects.add(mavenProject);
+			}
+		}
+		return nonPomProjects;
+	}
+
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
@@ -21,15 +21,15 @@ import org.codehaus.plexus.util.StringUtils;
 
 /**
  * <p>
- * Creates a structured code coverage report (HTML, XML, and CSV) from multiple
- * projects within reactor. The report is created from all modules this project
- * depends on. From those projects class and source files as well as JaCoCo
+ * Creates a structured code coverage report (HTML, XML, and CSV) from all
+ * projects within the reactor.
+ * From those projects class and source files as well as JaCoCo
  * execution data files will be collected and aggregated. This mojo will not
  * fork any lifecycle and so need to be added after build generating jacoco
  * data.
  * </p>
  *
- * @since 0.8.13
+ * @since 0.8.16
  */
 @Mojo(name = "report-aggregate-all", threadSafe = true, aggregator = true)
 public class ReportAggregateAllMojo extends ReportAggregateMojo {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateAllMojo.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 Mountainminds GmbH & Co. KG and Contributors
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
  *
@@ -22,11 +22,10 @@ import org.codehaus.plexus.util.StringUtils;
 /**
  * <p>
  * Creates a structured code coverage report (HTML, XML, and CSV) from all
- * projects within the reactor.
- * From those projects class and source files as well as JaCoCo
- * execution data files will be collected and aggregated. This mojo will not
- * fork any lifecycle and so need to be added after build generating jacoco
- * data.
+ * projects within the reactor. From those projects class and source files as
+ * well as JaCoCo execution data files will be collected and aggregated. This
+ * mojo will not fork any lifecycle and so need to be added after build
+ * generating jacoco data.
  * </p>
  *
  * @since 0.8.16

--- a/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
@@ -95,7 +95,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 	 * The projects in the reactor.
 	 */
 	@Parameter(property = "reactorProjects", readonly = true)
-	private List<MavenProject> reactorProjects;
+	protected List<MavenProject> reactorProjects;
 
 	@Override
 	boolean canGenerateReportRegardingDataFiles() {
@@ -179,7 +179,7 @@ public class ReportAggregateMojo extends AbstractReportMojo {
 		return "JaCoCo Aggregate";
 	}
 
-	private List<MavenProject> findDependencies(final String... scopes) {
+	protected List<MavenProject> findDependencies(final String... scopes) {
 		final List<MavenProject> result = new ArrayList<MavenProject>();
 		final List<String> scopeList = Arrays.asList(scopes);
 		for (final Object dependencyObject : project.getDependencies()) {

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -349,6 +349,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.10.1</version>
+          <configuration>
+            <streamLogsOnFailures>true</streamLogsOnFailures>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/org.jacoco.examples.test/pom.xml
+++ b/org.jacoco.examples.test/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>org.jacoco.agent.rt</artifactId>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>


### PR DESCRIPTION
- **Add option to aggregate automatically reports from aggregators, no need to add any dependency**

Actually having some aggregated report, need to have a module and include all dependencies of the current project.
This doesn't scale very well for large projects (Jetty can have up to more than 300 modules, we can't really add and maintain a pom with all other modules included) 
