### PR TITLE
Add validation test for synthetic accessor methods in Kotlin

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinSyntheticAccessorsTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinSyntheticAccessorsTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinSyntheticAccessorsTarget;
+import org.junit.Test;
+
+/**
+ * Test of code coverage in {@link KotlinSyntheticAccessorsTarget}.
+ */
+public class KotlinSyntheticAccessorsTest extends ValidationTestBase {
+
+	public KotlinSyntheticAccessorsTest() {
+		super(KotlinSyntheticAccessorsTarget.class);
+	}
+
+	@Test
+	public void compiler_should_generate_synthetic_accessors() {
+		final HashSet<String> names = new HashSet<String>();
+		for (final Method method : KotlinSyntheticAccessorsTarget.Outer.class
+				.getDeclaredMethods()) {
+			if (method.isSynthetic()) {
+				names.add(method.getName());
+			}
+		}
+
+		assertEquals(new HashSet<String>(
+				Arrays.asList("access$getX", "access$getX$p", "access$setX$p")),
+				names);
+	}
+
+	@Test
+	public void test_method_count() {
+		assertMethodCount(/* main + 2 in Outer + 2 in Inner */ 5);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinSyntheticAccessorsTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinSyntheticAccessorsTarget.kt
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+/**
+ * Test target with synthetic accessor methods.
+ */
+object KotlinSyntheticAccessorsTarget {
+
+    class Outer { // assertFullyCovered()
+        private var x = 42
+
+        private fun getX(): Int {
+            return x
+        }
+
+        inner class Inner { // assertFullyCovered()
+            /**
+             * Access to private field and function of outer class causes creation of synthetic methods in it.
+             * Those methods refer to the line of outer class definition.
+             */
+            @Suppress("unused")
+            fun accessOuter() {
+                x += 1 // assertNotCovered()
+                getX()
+            }
+        }
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Outer().Inner()
+    }
+
+}


### PR DESCRIPTION
We have such [test for Java](https://github.com/jacoco/jacoco/blob/v0.8.12/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/targets/SyntheticTarget.java), so I think we should add similar for Kotlin too.