### PR TITLE
Add configuration files for Java code formatting in IntelliJ IDEA

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,8 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    </JavaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/eclipseCodeFormatter.xml
+++ b/.idea/eclipseCodeFormatter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EclipseCodeFormatterProjectSettings">
+    <option name="projectSpecificProfile">
+      <ProjectSpecificProfile>
+        <option name="formatter" value="ECLIPSE" />
+        <option name="pathToConfigFileJava" value="$PROJECT_DIR$/org.jacoco.core/.settings/org.eclipse.jdt.core.prefs" />
+        <option name="selectedJavaProfile" value="valid 'org.eclipse.jdt.core.prefs' config" />
+      </ProjectSpecificProfile>
+    </option>
+  </component>
+</project>

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="EclipseCodeFormatter" />
+  </component>
+</project>


### PR DESCRIPTION
* `.idea/externalDependencies.xml` to require installation of EclipseCodeFormatter plugin into IntelliJ IDEA
* `.idea/eclipseCodeFormatter.xml` configures plugin to use the same settings as for Eclipse IDE and spotelss-maven-plugin
* `.idea/codeStyles/codeStyleConfig.xml` and `.idea/codeStyles/Project.xml` prevent use of wildcard imports

----

After import of project with this change into a fresh installation of IntelliJ IDEA 2024.2.1:

<img width="1183" alt="Screenshot 2024-09-10 at 21 56 36" src="https://github.com/user-attachments/assets/8685b6f7-1d1c-424c-abbf-8e9415c7b201">

After installation of EclipseCodeFormatter plugin:

<img width="1406" alt="Screenshot 2024-09-10 at 21 58 15" src="https://github.com/user-attachments/assets/33e9070b-0cb8-4893-bb20-8622c54663ec">
