### PR TITLE
Require at least Maven 3.9.9 for build

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.3/apache-maven-3.8.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -519,8 +519,7 @@
                   <version>17</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <!-- Maven 3.8.2 contains bug - see https://github.com/jacoco/jacoco/issues/1218 -->
-                  <version>[3.6.3,3.8.2),(3.8.2,)</version>
+                  <version>3.9.9</version>
                 </requireMavenVersion>
                 <requireNoRepositories>
                   <message>The rules for repo1.maven.org are that pom.xml files should not include repository definitions.</message>

--- a/org.jacoco.doc/docroot/doc/build.html
+++ b/org.jacoco.doc/docroot/doc/build.html
@@ -23,9 +23,8 @@
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a> and
   can be locally executed on every machine with a proper
-  <a href="environment.html">environment setup</a>. In particular you need at
-  least <a href="http://maven.apache.org/">Maven 3.6.3</a> and JDK 17
-  installations. Developers are encouraged to run the build before every commit
+  <a href="environment.html">environment setup</a>. In particular you need JDK 17
+  installation. Developers are encouraged to run the build before every commit
   to ensure consistency of the source tree.
 </p>
 
@@ -33,12 +32,13 @@
 <h2>Running the Build</h2>
 
 <p>
-  The build can be started by executing the following command with
-  <code>./org.jacoco.build/</code> as the working directory:
+  The build can be started by executing the
+  <a href="https://maven.apache.org/wrapper/">Maven Wrapper</a> using following
+  command with <code>./org.jacoco.build/</code> as the working directory:
 </p>
 
 <pre>
-  mvn clean verify
+  ../mvnw clean verify
 </pre>
 
 <p>
@@ -48,7 +48,7 @@
 </p>
 
 <pre>
-  ./jacoco/target/jacoco-<i>x.y.z.qualifier</i>.zip
+  ../jacoco/target/jacoco-<i>x.y.z.qualifier</i>.zip
 </pre>
 
 
@@ -59,7 +59,7 @@
 </p>
 
 <pre>
-  mvn clean verify -DskipTests
+  ../mvnw clean verify -DskipTests
 </pre>
 
 
@@ -305,7 +305,7 @@
 </p>
 
 <pre>
-  mvn clean verify -Djdk.version=10 -Dbytecode.version=9
+  ../mvnw clean verify -Djdk.version=10 -Dbytecode.version=9
 </pre>
 
 <p>
@@ -313,7 +313,7 @@
 </p>
 
 <pre>
-  mvn clean verify -Decj
+  ../mvnw clean verify -Decj
 </pre>
 
 <p>
@@ -321,27 +321,27 @@
 </p>
 
 <ul>
-  <li><code>mvn clean verify -Djdk.version=5 -Dbytecode.version=5</code></li>
-  <li><code>mvn clean verify -Djdk.version=6 -Dbytecode.version=6</code></li>
-  <li><code>mvn clean verify -Djdk.version=7 -Dbytecode.version=7</code></li>
-  <li><code>mvn clean verify -Djdk.version=8 -Dbytecode.version=8</code></li>
-  <li><code>mvn clean verify -Djdk.version=9 -Dbytecode.version=9</code></li>
-  <li><code>mvn clean verify -Djdk.version=10 -Dbytecode.version=10</code></li>
-  <li><code>mvn clean verify -Djdk.version=11 -Dbytecode.version=11</code></li>
-  <li><code>mvn clean verify -Djdk.version=11 -Dbytecode.version=11 -Decj</code></li>
-  <li><code>mvn clean verify -Djdk.version=12 -Dbytecode.version=12</code></li>
-  <li><code>mvn clean verify -Djdk.version=13 -Dbytecode.version=13</code></li>
-  <li><code>mvn clean verify -Djdk.version=14 -Dbytecode.version=14</code></li>
-  <li><code>mvn clean verify -Djdk.version=15 -Dbytecode.version=15</code></li>
-  <li><code>mvn clean verify -Djdk.version=16 -Dbytecode.version=16</code></li>
-  <li><code>mvn clean verify -Djdk.version=17 -Dbytecode.version=17</code></li>
-  <li><code>mvn clean verify -Djdk.version=17 -Dbytecode.version=17 -Decj</code></li>
-  <li><code>mvn clean verify -Djdk.version=18 -Dbytecode.version=18</code></li>
-  <li><code>mvn clean verify -Djdk.version=19 -Dbytecode.version=19</code></li>
-  <li><code>mvn clean verify -Djdk.version=20 -Dbytecode.version=20</code></li>
-  <li><code>mvn clean verify -Djdk.version=21 -Dbytecode.version=21</code></li>
-  <li><code>mvn clean verify -Djdk.version=21 -Dbytecode.version=21 -Decj</code></li>
-  <li><code>mvn clean verify -Djdk.version=22 -Dbytecode.version=22</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=5 -Dbytecode.version=5</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=6 -Dbytecode.version=6</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=7 -Dbytecode.version=7</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=8 -Dbytecode.version=8</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=9 -Dbytecode.version=9</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=10 -Dbytecode.version=10</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=11 -Dbytecode.version=11</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=11 -Dbytecode.version=11 -Decj</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=12 -Dbytecode.version=12</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=13 -Dbytecode.version=13</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=14 -Dbytecode.version=14</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=15 -Dbytecode.version=15</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=16 -Dbytecode.version=16</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=17 -Dbytecode.version=17</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=17 -Dbytecode.version=17 -Decj</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=18 -Dbytecode.version=18</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=19 -Dbytecode.version=19</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=20 -Dbytecode.version=20</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=21 -Dbytecode.version=21</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=21 -Dbytecode.version=21 -Decj</code></li>
+  <li><code>../mvnw clean verify -Djdk.version=22 -Dbytecode.version=22</code></li>
 </ul>
 
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -57,8 +57,10 @@
 
 <h3>Non-functional Changes</h3>
 <ul>
-  <li>JaCoCo build now requires at least Maven 3.6.3
-      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1681">#1681</a>).</li>
+  <li>JaCoCo build now uses Maven Wrapper and requires at least Maven 3.9.9
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1708">#1708</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/1707">#1707</a>,
+      <a href="https://github.com/jacoco/jacoco/issues/1681">#1681</a>).</li>
 </ul>
 
 <h2>Release 0.8.12 (2024/03/31)</h2>

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -76,7 +76,7 @@
 
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a>
-  and requires at least Maven 3.6.3 and JDK 17.
+  and requires at least Maven 3.9.9 and JDK 17.
   See the <a href="build.html">build description</a> for details.
 </p>
 


### PR DESCRIPTION
After #1707 we do not need to rely on pre-installed Maven version in CI or on a developer machine, so I don't see any reason not to require latest Maven version, which is 3.9.9 as of today. Together with #1701 this will help reduce time required to handle updates of Maven and its plugins since compatibility/requirements matrix becomes much simpler.