### PR TITLE
Fix Kotlin when boolean coverage

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenExpressionTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenExpressionTarget.kt
@@ -74,6 +74,11 @@ object KotlinWhenExpressionTarget {
         else -> 6 // assertFullyCovered()
     } // assertFullyCovered()
 
+    private fun whenBoolean(p: Boolean) = when (p) { // assertFullyCovered()
+        true -> 1 // assertFullyCovered(0, 2)
+        false -> 2 // assertFullyCovered()
+    } // assertFullyCovered()
+
     @JvmStatic
     fun main(args: Array<String>) {
         whenSealed(Sealed.Sealed1)
@@ -102,6 +107,9 @@ object KotlinWhenExpressionTarget {
         whenStringBiggestHashCodeFirst("c")
         whenStringBiggestHashCodeFirst("\u0000a")
         whenStringBiggestHashCodeFirst("\u0000b")
+
+        whenBoolean(true)
+        whenBoolean(false)
     }
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinWhenFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinWhenFilter.java
@@ -55,7 +55,7 @@ public final class KotlinWhenFilter implements IFilter {
 			nextIs(Opcodes.ATHROW);
 
 			for (AbstractInsnNode i = cursor; i != null; i = i.getPrevious()) {
-				if (i.getOpcode() == Opcodes.IFEQ
+				if ((i.getOpcode() == Opcodes.IFEQ || i.getOpcode() == Opcodes.IFNE)
 						&& ((JumpInsnNode) i).label == start) {
 					output.ignore(i, i);
 					output.ignore(start, cursor);


### PR DESCRIPTION
Fixes #1747

The bytecode for the test method
```
private final int whenBoolean(boolean);
    descriptor: (Z)I
    flags: (0x0012) ACC_PRIVATE, ACC_FINAL
    Code:
      stack=2, locals=3, args_size=2
         0: iload_1
         1: istore_2
         2: iload_2
         3: iconst_1
         4: if_icmpne     11
         7: iconst_1
         8: goto          27
        11: iload_2
        12: ifne          19 // IFNE instead of IFQE HERE
        15: iconst_2
        16: goto          27
        19: new           #18                 // class kotlin/NoWhenBranchMatchedException
        22: dup
        23: invokespecial #19                 // Method kotlin/NoWhenBranchMatchedException."<init>":()V
        26: athrow
        27: ireturn
```