### PR TITLE
Fix warning "'reportOutputDirectory' is unknown for plugin 'maven-javadoc-plugin:3.11.1:jar (attach-javadocs)'"

### DIFF
--- a/org.jacoco.doc/pom.xml
+++ b/org.jacoco.doc/pom.xml
@@ -198,7 +198,6 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <reportOutputDirectory>${project.build.directory}/apidocs</reportOutputDirectory>
               <includeDependencySources>true</includeDependencySources>
               <excludePackageNames>*.internal.*,*.internal,org.jacoco.ant,org.jacoco.maven,org.jacoco.examples</excludePackageNames>
               <dependencySourceIncludes>


### PR DESCRIPTION
`reportOutputDirectory` parameter was removed in maven-javadoc-plugin
version 3.10.0 by
https://github.com/apache/maven-javadoc-plugin/commit/9638a6a76c6db53c3bf8ffbd5cec7318b0e25303
(https://issues.apache.org/jira/browse/MJAVADOC-785).

This was overlooked in commit 435579f27cb8259ba14c1a868245a843e053211f.

`outputDirectory` parameter can be used to restore prior behavior,
but this customization seems unnecessary.
