### PR TITLE
Split KotlinWhenExpressionTarget

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenEnumTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenEnumTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenEnumTarget;
+
+/**
+ * Test of code coverage in {@link KotlinWhenEnumTarget}.
+ */
+public class KotlinWhenEnumTest extends ValidationTestBase {
+
+	public KotlinWhenEnumTest() {
+		super(KotlinWhenEnumTarget.class);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenSealedTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenSealedTest.java
@@ -13,15 +13,15 @@
 package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
-import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenExpressionTarget;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenSealedTarget;
 
 /**
- * Test of <code>when</code> expressions.
+ * Test of code coverage in {@link KotlinWhenSealedTarget}.
  */
-public class KotlinWhenExpressionTest extends ValidationTestBase {
+public class KotlinWhenSealedTest extends ValidationTestBase {
 
-	public KotlinWhenExpressionTest() {
-		super(KotlinWhenExpressionTarget.class);
+	public KotlinWhenSealedTest() {
+		super(KotlinWhenSealedTarget.class);
 	}
 
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenStringTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenStringTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenStringTarget;
+
+/**
+ * Test of code coverage in {@link KotlinWhenStringTarget}.
+ */
+public class KotlinWhenStringTest extends ValidationTestBase {
+
+	public KotlinWhenStringTest() {
+		super(KotlinWhenStringTarget.class);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenEnumTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenEnumTarget.kt
@@ -13,26 +13,9 @@
 package org.jacoco.core.test.validation.kotlin.targets
 
 /**
- * This test target is `when` expression.
+ * Test target with `when` expressions with subject of type `enum class`.
  */
-object KotlinWhenExpressionTarget {
-
-    private sealed class Sealed {
-        object Sealed1 : Sealed()
-        object Sealed2 : Sealed()
-    }
-
-    private fun whenSealed(p: Sealed): Int = when (p) { // assertFullyCovered()
-        is Sealed.Sealed1 -> 1 // assertFullyCovered(0, 2)
-        is Sealed.Sealed2 -> 2 // assertFullyCovered()
-    } // assertFullyCovered()
-
-    @Suppress("REDUNDANT_ELSE_IN_WHEN")
-    private fun whenSealedRedundantElse(p: Sealed): Int = when (p) { // assertFullyCovered()
-        is Sealed.Sealed1 -> 1 // assertFullyCovered(0, 2)
-        is Sealed.Sealed2 -> 2 // assertFullyCovered(0, 0)
-        else -> throw NoWhenBranchMatchedException() // assertEmpty()
-    } // assertFullyCovered()
+object KotlinWhenEnumTarget {
 
     private enum class Enum {
         A, B
@@ -71,38 +54,8 @@ object KotlinWhenExpressionTarget {
             else -> "else" // assertFullyCovered()
         } // assertFullyCovered()
 
-    private fun whenString(p: String): Int = when (p) { // assertFullyCovered(0, 7)
-        "a" -> 1 // assertFullyCovered()
-        "b" -> 2 // assertFullyCovered()
-        "c" -> 3 // assertFullyCovered()
-        "\u0000a" -> 4 // assertFullyCovered()
-        "\u0000b" -> 5 // assertFullyCovered()
-        "\u0000c" -> 6 // assertFullyCovered()
-        else -> 7 // assertFullyCovered()
-    } // assertFullyCovered()
-
-    /**
-     * Unlike [whenString]
-     * in this example first case is the only case with biggest hashCode value.
-     * FIXME https://github.com/jacoco/jacoco/issues/1295
-     */
-    private fun whenStringBiggestHashCodeFirst(p: String): Int = when (p) { // assertPartlyCovered(3, 11)
-        "c" -> 1 // assertFullyCovered()
-        "b" -> 2 // assertFullyCovered()
-        "\u0000b" -> 3 // assertFullyCovered()
-        "a" -> 4 // assertFullyCovered()
-        "\u0000a" -> 5 // assertFullyCovered()
-        else -> 6 // assertFullyCovered()
-    } // assertFullyCovered()
-
     @JvmStatic
     fun main(args: Array<String>) {
-        whenSealed(Sealed.Sealed1)
-        whenSealed(Sealed.Sealed2)
-
-        whenSealedRedundantElse(Sealed.Sealed1)
-        whenSealedRedundantElse(Sealed.Sealed2)
-
         whenEnum(Enum.A)
         whenEnum(Enum.B)
 
@@ -120,21 +73,6 @@ object KotlinWhenExpressionTarget {
         whenByNullableEnumWithNullAndElseCases(Enum.A)
         whenByNullableEnumWithNullAndElseCases(Enum.B)
         whenByNullableEnumWithNullAndElseCases(null)
-
-        whenString("")
-        whenString("a")
-        whenString("b")
-        whenString("c")
-        whenString("\u0000a")
-        whenString("\u0000b")
-        whenString("\u0000c")
-
-        whenStringBiggestHashCodeFirst("")
-        whenStringBiggestHashCodeFirst("a")
-        whenStringBiggestHashCodeFirst("b")
-        whenStringBiggestHashCodeFirst("c")
-        whenStringBiggestHashCodeFirst("\u0000a")
-        whenStringBiggestHashCodeFirst("\u0000b")
     }
 
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget.kt
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+/**
+ * Test target with `when` expressions with subject of type `enum class`.
+ */
+object KotlinWhenSealedTarget {
+
+    private sealed class Sealed {
+        object Sealed1 : Sealed()
+        object Sealed2 : Sealed()
+    }
+
+    private fun whenSealed(p: Sealed): Int = when (p) { // assertFullyCovered()
+        is Sealed.Sealed1 -> 1 // assertFullyCovered(0, 2)
+        is Sealed.Sealed2 -> 2 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    @Suppress("REDUNDANT_ELSE_IN_WHEN")
+    private fun whenSealedRedundantElse(p: Sealed): Int = when (p) { // assertFullyCovered()
+        is Sealed.Sealed1 -> 1 // assertFullyCovered(0, 2)
+        is Sealed.Sealed2 -> 2 // assertFullyCovered(0, 0)
+        else -> throw NoWhenBranchMatchedException() // assertEmpty()
+    } // assertFullyCovered()
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        whenSealed(Sealed.Sealed1)
+        whenSealed(Sealed.Sealed2)
+
+        whenSealedRedundantElse(Sealed.Sealed1)
+        whenSealedRedundantElse(Sealed.Sealed2)
+    }
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenStringTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenStringTarget.kt
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2024 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+/**
+ * Test target with `when` expressions with subject of type `String`.
+ */
+object KotlinWhenStringTarget {
+
+    private fun whenString(p: String): Int = when (p) { // assertFullyCovered(0, 7)
+        "a" -> 1 // assertFullyCovered()
+        "b" -> 2 // assertFullyCovered()
+        "c" -> 3 // assertFullyCovered()
+        "\u0000a" -> 4 // assertFullyCovered()
+        "\u0000b" -> 5 // assertFullyCovered()
+        "\u0000c" -> 6 // assertFullyCovered()
+        else -> 7 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    /**
+     * Unlike [whenString]
+     * in this example first case is the only case with biggest hashCode value.
+     * FIXME https://github.com/jacoco/jacoco/issues/1295
+     */
+    private fun whenStringBiggestHashCodeFirst(p: String): Int = when (p) { // assertPartlyCovered(3, 11)
+        "c" -> 1 // assertFullyCovered()
+        "b" -> 2 // assertFullyCovered()
+        "\u0000b" -> 3 // assertFullyCovered()
+        "a" -> 4 // assertFullyCovered()
+        "\u0000a" -> 5 // assertFullyCovered()
+        else -> 6 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        whenString("")
+        whenString("a")
+        whenString("b")
+        whenString("c")
+        whenString("\u0000a")
+        whenString("\u0000b")
+        whenString("\u0000c")
+
+        whenStringBiggestHashCodeFirst("")
+        whenStringBiggestHashCodeFirst("a")
+        whenStringBiggestHashCodeFirst("b")
+        whenStringBiggestHashCodeFirst("c")
+        whenStringBiggestHashCodeFirst("\u0000a")
+        whenStringBiggestHashCodeFirst("\u0000b")
+    }
+
+}


### PR DESCRIPTION
It already contains a lot of different cases.
#1756, #1769, and #1773 will add even more.
So I propose to split it.