### PR TITLE
Fix typo: replace "a instrumented" by "an instrumented"

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/perf/ExecuteInstrumentedCodeScenario.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/perf/ExecuteInstrumentedCodeScenario.java
@@ -22,7 +22,7 @@ import org.jacoco.core.test.TargetLoader;
 
 /**
  * This scenario runs a given scenario twice and reports the execution time:
- * Once on its original version, once in a instrumented version.
+ * Once on its original version, once in an instrumented version.
  */
 public class ExecuteInstrumentedCodeScenario extends TimedScenario {
 

--- a/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
@@ -93,7 +93,7 @@ public class Instrumenter {
 	}
 
 	/**
-	 * Creates a instrumented version of the given class if possible.
+	 * Creates an instrumented version of the given class if possible.
 	 *
 	 * @param buffer
 	 *            definition of the class
@@ -113,7 +113,7 @@ public class Instrumenter {
 	}
 
 	/**
-	 * Creates a instrumented version of the given class if possible. The
+	 * Creates an instrumented version of the given class if possible. The
 	 * provided {@link InputStream} is not closed by this method.
 	 *
 	 * @param input
@@ -137,7 +137,7 @@ public class Instrumenter {
 	}
 
 	/**
-	 * Creates a instrumented version of the given class file. The provided
+	 * Creates an instrumented version of the given class file. The provided
 	 * {@link InputStream} and {@link OutputStream} instances are not closed by
 	 * this method.
 	 *
@@ -166,7 +166,7 @@ public class Instrumenter {
 	}
 
 	/**
-	 * Creates a instrumented version of the given resource depending on its
+	 * Creates an instrumented version of the given resource depending on its
 	 * type. Class files and the content of archive files are instrumented. All
 	 * other files are copied without modification. The provided
 	 * {@link InputStream} and {@link OutputStream} instances are not closed by

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassInstrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/ClassInstrumenter.java
@@ -28,7 +28,7 @@ public class ClassInstrumenter extends ClassProbesVisitor {
 	private String className;
 
 	/**
-	 * Emits a instrumented version of this class to the given class visitor.
+	 * Emits an instrumented version of this class to the given class visitor.
 	 *
 	 * @param probeArrayStrategy
 	 *            this strategy will be used to access the probe array


### PR DESCRIPTION
"an" should be used instead of "a" when the
following word starts with a vowel sound.