### PR TITLE
Build should not produce warning about generation of JUnit report

### DIFF
--- a/org.jacoco.doc/pom.xml
+++ b/org.jacoco.doc/pom.xml
@@ -157,7 +157,6 @@
             </goals>
             <configuration>
               <target>
-                <echo message="JUnit report"/>
                 <mkdir dir="${project.build.directory}/junit"/>
                 <junitreport todir="${project.build.directory}/junit">
                   <fileset dir="../org.jacoco.agent.test/target" includes="surefire-reports/**/*.xml"/>


### PR DESCRIPTION
Without this change execution of `mvn verify` produces

```
[INFO] --- antrun:3.1.0:run (prepare-reports) @ org.jacoco.doc ---
[INFO] Executing tasks
[WARNING]      [echo] JUnit report
[INFO]     [mkdir] Created dir: /Users/godin/projects/jacoco/jacoco/org.jacoco.doc/target/junit
[INFO] [junitreport] Processing /Users/godin/projects/jacoco/jacoco/org.jacoco.doc/target/junit/TESTS-TestSuites.xml to /Users/godin/projects/jacoco/jacoco/org.jacoco.doc/target/junit/junit-noframes.html
[INFO] [junitreport] Loading stylesheet /Users/godin/projects/jacoco/jacoco/org.jacoco.doc/xsl/junit-noframes.xsl
[INFO] [junitreport] Transform time: 149ms
[INFO]      [move] Moving 1 file to /Users/godin/projects/jacoco/jacoco/org.jacoco.doc/target/junit
[INFO] Executed tasks
```

According to https://ant.apache.org/manual/Tasks/echo.html for optional `level`

> default is "warning"

we can set it to "info", but this message seems unnecessary given the messages below it.