### PR TITLE
SecurityManagerTest should not depend on CoverageTaskTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
       - name: 'Build'
         run: |
           ./mvnw -V -B -e --no-transfer-progress \
-            -Dsurefire.runOrder=reversealphabetical \
             verify -Djdk.version=${{ matrix.jdk }} -Dbytecode.version=${{ matrix.jdk }} \
             ${{ matrix.ecj && '-Decj' || ''}} \
             --toolchains=toolchains.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: 'Build'
         run: |
           ./mvnw -V -B -e --no-transfer-progress \
+            -Dsurefire.runOrder=reversealphabetical \
             verify -Djdk.version=${{ matrix.jdk }} -Dbytecode.version=${{ matrix.jdk }} \
             ${{ matrix.ecj && '-Decj' || ''}} \
             --toolchains=toolchains.xml

--- a/org.jacoco.ant.test/src/org/jacoco/ant/SecurityManagerTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/SecurityManagerTest.xml
@@ -27,7 +27,7 @@
 	<target name="testJaCoCoWithSecurityManager">
 		<jacoco:coverage destfile="${exec.file}">
 			<java classname="org.jacoco.ant.TestTarget" fork="true" failonerror="true">
-				<classpath path="${org.jacoco.ant.coverageTaskTest.classes.dir}"/>
+				<classpath path="${org.jacoco.ant.securityManagerTest.classes.dir}"/>
 				<jvmarg value="-Djacoco.agent=${_jacoco.agentFile}"/>
 				<jvmarg value="-Djacoco.exec=${exec.file}"/>
 				<jvmarg value="-Djava.security.manager"/>


### PR DESCRIPTION
Unfortunately I overlooked this during review of #1780 😞
Fortunately on one of my dev machines order of tests is different than in our CI 😄 and build started to fail after merge

```
testJaCoCoWithSecurityManager:
[jacoco:coverage] Enhancing java with coverage
     [java] WARNING: A command line option has enabled the Security Manager
     [java] WARNING: The Security Manager is deprecated and will be removed in a future release
     [java] Error: Could not find or load main class org.jacoco.ant.TestTarget
     [java] Caused by: java.lang.ClassNotFoundException: org.jacoco.ant.TestTarget
```

Problem can be reproduced by executing only `SecurityManagerTest`
```
mvn verify -Dtest=SecurityManagerTest -DfailIfNoTests=false
```
or by changing order of tests
```
mvn verify -Dsurefire.runOrder=reversealphabetical
```
