### PR TITLE
Fix typo: replace "a instance" by "an instance"

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * {@link IExecutionDataVisitor} interface. If execution data is provided
  * multiple times for the same class the data is merged, i.e. a probe is marked
  * as executed if it is reported as executed at least once. This allows to merge
- * coverage date from multiple runs. A instance of this class is not thread
+ * coverage date from multiple runs. An instance of this class is not thread
  * safe.
  */
 public final class ExecutionDataStore implements IExecutionDataVisitor {

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageCalculator.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageCalculator.java
@@ -25,9 +25,9 @@ import org.jacoco.core.internal.analysis.filter.IFilterOutput;
 import org.objectweb.asm.tree.AbstractInsnNode;
 
 /**
- * Calculates the filtered coverage of a single method. A instance of this class
- * can be first used as {@link IFilterOutput} before the coverage result is
- * calculated.
+ * Calculates the filtered coverage of a single method. An instance of this
+ * class can be first used as {@link IFilterOutput} before the coverage result
+ * is calculated.
  */
 class MethodCoverageCalculator implements IFilterOutput {
 

--- a/org.jacoco.report/src/org/jacoco/report/internal/xml/XMLElement.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/xml/XMLElement.java
@@ -246,7 +246,7 @@ public class XMLElement {
 
 	/**
 	 * Creates a new child element for this element. Might be overridden in
-	 * subclasses to return a instance of the subclass.
+	 * subclasses to return an instance of the subclass.
 	 *
 	 * @param name
 	 *            name of the child element


### PR DESCRIPTION
"an" should be used instead of "a" when the
following word starts with a vowel sound.