### PR TITLE
Fix javadoc doclint warning "no @param for fragment"

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
@@ -42,6 +42,8 @@ public class SourceNodeImpl extends CoverageNodeImpl implements ISourceNode {
 	}
 
 	/**
+	 * @param fragment
+	 *            fragment to apply
 	 * @return <code>true</code> if fragment contains lines of this node
 	 */
 	public boolean applyFragment(final SourceNodeImpl fragment) {


### PR DESCRIPTION
This was overlooked in commit 831ecd609e17a3a5f8e114134fa0ce1d2071c6bd.