### PR TITLE
Fix typo: replace "an listener" by "a listener"

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java
@@ -46,7 +46,7 @@ public class ExecutionDataReader {
 	}
 
 	/**
-	 * Sets an listener for session information.
+	 * Sets a listener for session information.
 	 *
 	 * @param visitor
 	 *            visitor to retrieve session info events
@@ -56,7 +56,7 @@ public class ExecutionDataReader {
 	}
 
 	/**
-	 * Sets an listener for execution data.
+	 * Sets a listener for execution data.
 	 *
 	 * @param visitor
 	 *            visitor to retrieve execution data events

--- a/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlReader.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlReader.java
@@ -50,7 +50,7 @@ public class RemoteControlReader extends ExecutionDataReader {
 	}
 
 	/**
-	 * Sets an listener for agent commands.
+	 * Sets a listener for agent commands.
 	 *
 	 * @param visitor
 	 *            visitor to retrieve agent commands


### PR DESCRIPTION
"a" should be used instead of "an" when the
following word doesn't start with a vowel sound.