### PR TITLE
Fix typo: replace "a XML" by "an XML"

### DIFF
--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -89,7 +89,7 @@
 </p>
 
 <p class="hint">
-  Declaring a XML namespace for JaCoCo tasks is optional but always recommended
+  Declaring an XML namespace for JaCoCo tasks is optional but always recommended
   if you mix tasks from different libraries. All subsequent examples use the
   <code>jacoco</code> prefix declared above. If you don't declare a separate
   namespace the <code>jacoco</code> prefix must be removed from the following

--- a/org.jacoco.report/src/org/jacoco/report/internal/xml/ReportElement.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/xml/ReportElement.java
@@ -32,7 +32,7 @@ public class ReportElement extends XMLElement {
 	private static final String SYSTEM = "report.dtd";
 
 	/**
-	 * Creates a <code>report</code> root element for a XML report.
+	 * Creates a <code>report</code> root element for an XML report.
 	 *
 	 * @param name
 	 *            value for the name attribute

--- a/org.jacoco.report/src/org/jacoco/report/internal/xml/XMLElement.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/xml/XMLElement.java
@@ -20,8 +20,8 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 /**
- * Simple API to create well formed XML streams with minimal memory overhead. A
- * {@link XMLElement} instance represents a single element in a XML document.
+ * Simple API to create well formed XML streams with minimal memory overhead. An
+ * {@link XMLElement} instance represents a single element in an XML document.
  * {@link XMLElement} can be used directly or might be subclassed for schema
  * specific convenience methods.
  */
@@ -60,7 +60,7 @@ public class XMLElement {
 	}
 
 	/**
-	 * Creates a root element of a XML document.
+	 * Creates a root element of an XML document.
 	 *
 	 * @param name
 	 *            element name
@@ -95,7 +95,7 @@ public class XMLElement {
 	}
 
 	/**
-	 * Creates a new child element within a XML document. May only be called
+	 * Creates a new child element within an XML document. May only be called
 	 * before the parent element has been closed.
 	 *
 	 * @param name


### PR DESCRIPTION
"an" should be used instead of "a" when the
following word starts with a vowel sound.