### PR TITLE
Add validation test for Kotlin `when` statement with `sealed class` subject type

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget.kt
@@ -12,8 +12,10 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation.kotlin.targets
 
+import org.jacoco.core.test.validation.targets.Stubs.nop
+
 /**
- * Test target with `when` expressions with subject of type `enum class`.
+ * Test target with `when` expressions and statements with subject of type `sealed class`.
  */
 object KotlinWhenSealedTarget {
 
@@ -22,25 +24,70 @@ object KotlinWhenSealedTarget {
         object Sealed2 : Sealed()
     }
 
-    private fun whenSealed(p: Sealed): Int = when (p) { // assertFullyCovered()
-        is Sealed.Sealed1 -> 1 // assertFullyCovered(0, 2)
-        is Sealed.Sealed2 -> 2 // assertFullyCovered()
-    } // assertFullyCovered()
+    private fun expression(sealed: Sealed): String =
+        when (sealed) { // assertFullyCovered()
+            is Sealed.Sealed1 -> "case 1" // assertFullyCovered(0, 2)
+            is Sealed.Sealed2 -> "case 2" // assertFullyCovered()
+        } // assertFullyCovered()
 
     @Suppress("REDUNDANT_ELSE_IN_WHEN")
-    private fun whenSealedRedundantElse(p: Sealed): Int = when (p) { // assertFullyCovered()
-        is Sealed.Sealed1 -> 1 // assertFullyCovered(0, 2)
-        is Sealed.Sealed2 -> 2 // assertFullyCovered(0, 0)
-        else -> throw NoWhenBranchMatchedException() // assertEmpty()
+    private fun expressionWithRedundantElse(sealed: Sealed): String =
+        when (sealed) { // assertFullyCovered()
+            is Sealed.Sealed1 -> "case 1" // assertFullyCovered(0, 2)
+            is Sealed.Sealed2 -> "case 2" // assertFullyCovered(0, 0)
+            else -> throw NoWhenBranchMatchedException() // assertEmpty()
+        } // assertFullyCovered()
+
+    /**
+     * Since Kotlin 1.7 `when` statement with subject of type `sealed class`
+     * must be exhaustive (error otherwise, warning in 1.6), however
+     * Kotlin compiler prior to version 2.0 was generating bytecode
+     * indistinguishable from [nonSealedWhen] and [nonSealedIf]
+     * that do not have coverage for the case of [NonSealed.NonSealed3].
+     */
+    private fun statement(sealed: Sealed) { // assertEmpty()
+        when (sealed) { // assertFullyCovered()
+            is Sealed.Sealed1 -> nop("case 1") // assertFullyCovered(0, 2)
+            is Sealed.Sealed2 -> nop("case 2") // assertFullyCovered()
+        } // assertEmpty()
+    } // assertFullyCovered()
+
+    private abstract class NonSealed {
+        class NonSealed1 : NonSealed()
+        class NonSealed2 : NonSealed()
+        class NonSealed3 : NonSealed()
+    }
+
+    private fun nonSealedWhen(nonSealed: NonSealed) { // assertEmpty()
+        when (nonSealed) { // assertFullyCovered()
+            is NonSealed.NonSealed1 -> nop("case 1") // assertFullyCovered(0, 2)
+            is NonSealed.NonSealed2 -> nop("case 2") // assertFullyCovered(1, 1)
+            /* missing is NonSealed.NonSealed3 */
+        } // assertEmpty()
+    } // assertFullyCovered()
+
+    private fun nonSealedIf(nonSealed: NonSealed) { // assertEmpty()
+        if (nonSealed is NonSealed.NonSealed1) nop("case 1") // assertFullyCovered(0, 2)
+        else if (nonSealed is NonSealed.NonSealed2) nop("case 2") // assertFullyCovered(1, 1)
+        /* missing is NonSealed.NonSealed3 */
     } // assertFullyCovered()
 
     @JvmStatic
     fun main(args: Array<String>) {
-        whenSealed(Sealed.Sealed1)
-        whenSealed(Sealed.Sealed2)
+        expression(Sealed.Sealed1)
+        expression(Sealed.Sealed2)
 
-        whenSealedRedundantElse(Sealed.Sealed1)
-        whenSealedRedundantElse(Sealed.Sealed2)
+        expressionWithRedundantElse(Sealed.Sealed1)
+        expressionWithRedundantElse(Sealed.Sealed2)
+
+        statement(Sealed.Sealed1)
+        statement(Sealed.Sealed2)
+
+        nonSealedWhen(NonSealed.NonSealed1())
+        nonSealedWhen(NonSealed.NonSealed2())
+
+        nonSealedIf(NonSealed.NonSealed1())
+        nonSealedIf(NonSealed.NonSealed2())
     }
 
 }


### PR DESCRIPTION
For `Example.kt`

```Kotlin
sealed class Sealed {
    object Sealed1 : Sealed()
    object Sealed2 : Sealed()
}

fun example(sealed: Sealed) {
    when (sealed) {
        is Sealed.Sealed1 -> println("case 1")
        is Sealed.Sealed2 -> println("case 2")
    }
}

fun main() {
    example(Sealed.Sealed1)
    example(Sealed.Sealed2)
}
```

Using Kotlin compiler version `2.0.0` execution of

```
kotlin-compiler-2.0.0/bin/kotlinc Example.kt -d classes

javap -v -p classes/ExampleKt.class

java \
    -javaagent:jacoco-0.8.12/lib/jacocoagent.jar \
    -cp kotlin-compiler-2.0.0/lib/kotlin-stdlib.jar:classes \
    ExampleKt

java \
     -jar jacoco-0.8.12/lib/jacococli.jar \
     report jacoco.exec \
     --classfiles classes \
     --sourcefiles . \
     --html report
```

produces

<img width="948" alt="Screenshot 2024-11-23 at 15 33 12" src="https://github.com/user-attachments/assets/54b331b1-6e13-4d33-a4a7-580e4b7ae45d">

<img width="948" alt="Screenshot 2024-11-23 at 15 33 30" src="https://github.com/user-attachments/assets/72b6678c-5ed9-4bd5-99ad-58e4fcacc437">

```
  public static final void example(Sealed);
    descriptor: (LSealed;)V
    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=2, args_size=1
         0: aload_0
         1: ldc           #9                  // String s
         3: invokestatic  #15                 // Method kotlin/jvm/internal/Intrinsics.checkNotNullParameter:(Ljava/lang/Object;Ljava/lang/String;)V
         6: aload_0
         7: astore_1
         8: aload_1
         9: instanceof    #17                 // class Sealed$Sealed1
        12: ifeq          27
        15: ldc           #19                 // String case 1
        17: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        20: swap
        21: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        24: goto          54
        27: aload_1
        28: instanceof    #33                 // class Sealed$Sealed2
        31: ifeq          46
        34: ldc           #35                 // String case 2
        36: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        39: swap
        40: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        43: goto          54
        46: new           #37                 // class kotlin/NoWhenBranchMatchedException
        49: dup
        50: invokespecial #41                 // Method kotlin/NoWhenBranchMatchedException."<init>":()V
        53: athrow
        54: return
```

Whereas using Kotlin compiler version `1.9.23`

<img width="938" alt="Screenshot 2024-11-23 at 15 31 49" src="https://github.com/user-attachments/assets/59db1906-aeaa-4aa6-92fd-1c6add76aaf9">

<img width="938" alt="Screenshot 2024-11-23 at 15 32 26" src="https://github.com/user-attachments/assets/0ed2b451-a3e6-437a-9a9e-789358e1b5f6">

```
  public static final void example(Sealed);
    descriptor: (LSealed;)V
    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=2, args_size=1
         0: aload_0
         1: ldc           #9                  // String s
         3: invokestatic  #15                 // Method kotlin/jvm/internal/Intrinsics.checkNotNullParameter:(Ljava/lang/Object;Ljava/lang/String;)V
         6: aload_0
         7: astore_1
         8: aload_1
         9: instanceof    #17                 // class Sealed$Sealed1
        12: ifeq          27
        15: ldc           #19                 // String case 1
        17: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        20: swap
        21: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        24: goto          43
        27: aload_1
        28: instanceof    #33                 // class Sealed$Sealed2
        31: ifeq          43
        34: ldc           #35                 // String case 2
        36: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        39: swap
        40: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        43: return
```

which was indistinguishable from bytecode produced for

```Kotlin
abstract class NonSealed {
    class NonSealed1 : NonSealed()
    class NonSealed2 : NonSealed()
    class NonSealed3 : NonSealed()
}

fun example1(nonSealed: NonSealed) {
    when (nonSealed) {
        is NonSealed.NonSealed1 -> println("case 1")
        is NonSealed.NonSealed2 -> println("case 2")
    }
}

fun example2(nonSealed: NonSealed) {
    if (nonSealed is NonSealed.NonSealed1) println("case 1")
    else if (nonSealed is NonSealed.NonSealed2) println("case 2")
}

fun main() {
    example1(NonSealed.NonSealed1())
    example1(NonSealed.NonSealed2())

    example2(NonSealed.NonSealed1())
    example2(NonSealed.NonSealed2())
}
```

```
  public static final void example1(NonSealed);
    descriptor: (LNonSealed;)V
    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=2, args_size=1
         0: aload_0
         1: ldc           #9                  // String nonSealed
         3: invokestatic  #15                 // Method kotlin/jvm/internal/Intrinsics.checkNotNullParameter:(Ljava/lang/Object;Ljava/lang/String;)V
         6: aload_0
         7: astore_1
         8: aload_1
         9: instanceof    #17                 // class NonSealed$NonSealed1
        12: ifeq          27
        15: ldc           #19                 // String case 1
        17: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        20: swap
        21: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        24: goto          43
        27: aload_1
        28: instanceof    #33                 // class NonSealed$NonSealed2
        31: ifeq          43
        34: ldc           #35                 // String case 2
        36: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        39: swap
        40: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        43: return

  public static final void example2(NonSealed);
    descriptor: (LNonSealed;)V
    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=1, args_size=1
         0: aload_0
         1: ldc           #9                  // String nonSealed
         3: invokestatic  #15                 // Method kotlin/jvm/internal/Intrinsics.checkNotNullParameter:(Ljava/lang/Object;Ljava/lang/String;)V
         6: aload_0
         7: instanceof    #17                 // class NonSealed$NonSealed1
        10: ifeq          25
        13: ldc           #19                 // String case 1
        15: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        18: swap
        19: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        22: goto          41
        25: aload_0
        26: instanceof    #33                 // class NonSealed$NonSealed2
        29: ifeq          41
        32: ldc           #35                 // String case 2
        34: getstatic     #25                 // Field java/lang/System.out:Ljava/io/PrintStream;
        37: swap
        38: invokevirtual #31                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
        41: return
```

----

Closes #1219