### PR TITLE
Fix typo: replace "a HTML" by "an HTML"

### DIFF
--- a/org.jacoco.examples/src/org/jacoco/examples/ReportGenerator.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ReportGenerator.java
@@ -25,7 +25,7 @@ import org.jacoco.report.IReportVisitor;
 import org.jacoco.report.html.HTMLFormatter;
 
 /**
- * This example creates a HTML report for eclipse like projects based on a
+ * This example creates an HTML report for eclipse like projects based on a
  * single execution data store called jacoco.exec. The report contains no
  * grouping information.
  *

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/IHTMLReportContext.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/IHTMLReportContext.java
@@ -20,7 +20,7 @@ import org.jacoco.report.internal.html.resources.Resources;
 import org.jacoco.report.internal.html.table.Table;
 
 /**
- * Context and configuration information during creation of a HTML report.
+ * Context and configuration information during creation of an HTML report.
  */
 public interface IHTMLReportContext {
 

--- a/org.jacoco.report/src/org/jacoco/report/internal/html/index/ElementIndex.java
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/index/ElementIndex.java
@@ -29,7 +29,7 @@ public class ElementIndex implements IIndexUpdate {
 	private final Map<Long, String> allClasses = new HashMap<Long, String>();
 
 	/**
-	 * Creates a new empty index for a HTML report.
+	 * Creates a new empty index for an HTML report.
 	 *
 	 * @param baseFolder
 	 *            base folder where all links are calculated relative to


### PR DESCRIPTION
"an" should be used instead of "a" when the
following word starts with a vowel sound.