### PR TITLE
Fix typo: replace "a agent" by "an agent"

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/Agent.java
@@ -64,7 +64,7 @@ public class Agent implements IAgent {
 	}
 
 	/**
-	 * Returns a global instance which is already started. If a agent has not
+	 * Returns a global instance which is already started. If an agent has not
 	 * been initialized before this method will fail.
 	 *
 	 * @return global instance

--- a/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/AgentOptions.java
@@ -610,7 +610,7 @@ public final class AgentOptions {
 
 	/**
 	 * Generate required quotes JVM argument based on current configuration and
-	 * prepends it to the given argument command line. If a agent with the same
+	 * prepends it to the given argument command line. If an agent with the same
 	 * JAR file is already specified this parameter is removed from the existing
 	 * command line.
 	 *


### PR DESCRIPTION
"an" should be used instead of "a" when the
following word starts with a vowel sound.