### PR TITLE
Add convenience method for asserting MethodNodes

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/instr/MethodRecorder.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/instr/MethodRecorder.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.util.Printer;
 import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceMethodVisitor;
@@ -31,6 +32,12 @@ public class MethodRecorder {
 	public MethodRecorder() {
 		printer = new Textifier();
 		visitor = new TraceMethodVisitor(printer);
+	}
+
+	public static MethodRecorder from(final MethodNode method) {
+		final MethodRecorder r = new MethodRecorder();
+		method.accept(r.visitor);
+		return r;
 	}
 
 	public Printer getPrinter() {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodSanitizerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodSanitizerTest.java
@@ -140,12 +140,8 @@ public class MethodSanitizerTest {
 	}
 
 	private void assertOutput() {
-		assertEquals(dump(expected), dump(actual));
+		assertEquals(MethodRecorder.from(expected),
+				MethodRecorder.from(actual));
 	}
 
-	private MethodRecorder dump(MethodNode node) {
-		MethodRecorder rec = new MethodRecorder();
-		node.accept(rec.getVisitor());
-		return rec;
-	}
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassFieldProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassFieldProbeArrayStrategyTest.java
@@ -87,9 +87,9 @@ public class ClassFieldProbeArrayStrategyTest {
 			}
 			expected.visitLabel(label);
 			expected.visitInsn(Opcodes.ARETURN);
-			final MethodRecorder actualMethod = new MethodRecorder();
-			m.instructions.accept(actualMethod.getVisitor());
-			assertEquals(expectedMethod, actualMethod);
+			expected.visitMaxs(2, 0);
+
+			assertEquals(expectedMethod, MethodRecorder.from(m));
 		}
 	}
 


### PR DESCRIPTION
As a follow-up from the previously added new tests I propose to add a new convenience method to the test utils to directly obtain a `MethodRecoder` instance from an existing `MethodNode`.