### PR TITLE
Fix javadoc doclint warnings "no comment"

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/analysis/CounterComparator.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/CounterComparator.java
@@ -56,7 +56,14 @@ public class CounterComparator implements Comparator<ICounter>, Serializable {
 	public static final CounterComparator MISSEDRATIO = new CounterComparator(
 			CounterValue.MISSEDRATIO);
 
+	/**
+	 * Counter value to sort on.
+	 */
 	private final CounterValue value;
+
+	/**
+	 * Specifies whether values are sorted in reverse order or not.
+	 */
 	private final boolean reverse;
 
 	private CounterComparator(final CounterValue value) {

--- a/org.jacoco.core/src/org/jacoco/core/analysis/NodeComparator.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/NodeComparator.java
@@ -31,8 +31,14 @@ public class NodeComparator implements Comparator<ICoverageNode>, Serializable {
 
 	private static final long serialVersionUID = 8550521643608826519L;
 
+	/**
+	 * Comparator to compare {@link ICounter} objects.
+	 */
 	private final Comparator<ICounter> counterComparator;
 
+	/**
+	 * Counter entity to sort on.
+	 */
 	private final CounterEntity entity;
 
 	NodeComparator(final Comparator<ICounter> counterComparator,

--- a/org.jacoco.core/src/org/jacoco/core/data/IncompatibleExecDataVersionException.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/IncompatibleExecDataVersionException.java
@@ -21,6 +21,9 @@ public class IncompatibleExecDataVersionException extends IOException {
 
 	private static final long serialVersionUID = 1L;
 
+	/**
+	 * Actual version found in the execution data.
+	 */
 	private final int actualVersion;
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassCoverageImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/ClassCoverageImpl.java
@@ -119,6 +119,13 @@ public class ClassCoverageImpl extends SourceNodeImpl
 		return fragments;
 	}
 
+	/**
+	 * Stores fragments that contain coverage information about other nodes
+	 * collected during the creation of this node.
+	 *
+	 * @param fragments
+	 *            fragments to store
+	 */
 	public void setFragments(final Collection<SourceNodeImpl> fragments) {
 		this.fragments = fragments;
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilter.java
@@ -24,6 +24,15 @@ public class KotlinGeneratedFilter implements IFilter {
 
 	static final String KOTLIN_METADATA_DESC = "Lkotlin/Metadata;";
 
+	/**
+	 * Checks whether the class corresponding to the given context has
+	 * <code>kotlin/Metadata</code> annotation.
+	 *
+	 * @param context
+	 *            context information
+	 * @return <code>true</code> if the class corresponding to the given context
+	 *         has <code>kotlin/Metadata</code> annotation
+	 */
 	public static boolean isKotlinClass(final IFilterContext context) {
 		return context.getClassAnnotations().contains(KOTLIN_METADATA_DESC);
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinSMAP.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinSMAP.java
@@ -26,6 +26,10 @@ import java.util.regex.Pattern;
  */
 public final class KotlinSMAP {
 
+	/**
+	 * Parsed representation of a single LineSection from SourceDebugExtension
+	 * attribute.
+	 */
 	public static final class Mapping {
 		private final String inputClassName;
 		private final int inputStartLine;


### PR DESCRIPTION
This fixes warnings added in JDK 15,
so that build of `org.jacoco.core` is doclint warnings free with JDK versions from 15 to 17,
I'll raise separate PRs for other modules and warnings introduced in later JDK versions.