### PR TITLE
Improve KotlinSafeCallOperatorFilter for the cases when chain of safe call operators throws exception

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget.kt
@@ -13,6 +13,8 @@
 package org.jacoco.core.test.validation.kotlin.targets
 
 import org.jacoco.core.test.validation.targets.Stubs.nop
+import org.jacoco.core.test.validation.targets.Stubs.StubException
+import org.jacoco.core.test.validation.targets.Stubs.ex
 
 /**
  * Test target for [safe call operator (`?.`)](https://kotlinlang.org/docs/null-safety.html#safe-call-operator).
@@ -76,11 +78,22 @@ object KotlinSafeCallOperatorTarget {
         fullCoverage(A(B("")))
     }
 
+    private fun safeCallChainException() {
+        fun example(a: A?): String? =
+            a?.also { ex() }?.b?.c // assertPartlyCovered(3, 1)
+
+        try {
+            example(A(B("")))
+        } catch (_: StubException) {
+        }
+    }
+
     @JvmStatic
     fun main(args: Array<String>) {
         safeCall()
         safeCallChain()
         safeCallChainMultiline()
+        safeCallChainException()
     }
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
@@ -74,7 +74,7 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 		assertIgnored(m);
 		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
 		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
+				new Replacement(0, ifNullInstruction1, 0),
 				new Replacement(1, popInstruction, 0)));
 		replacements.put(ifNullInstruction2, Arrays.asList( //
 				new Replacement(0, ifNullInstruction2, 0),
@@ -127,7 +127,7 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 		assertIgnored(m);
 		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
 		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
+				new Replacement(0, ifNullInstruction1, 0),
 				new Replacement(1, aconstNullInstruction, 0)));
 		replacements.put(ifNullInstruction2, Arrays.asList( //
 				new Replacement(0, ifNullInstruction2, 0),

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilter.java
@@ -39,10 +39,10 @@ final class KotlinSafeCallOperatorFilter implements IFilter {
 					.get(chain.size() - 1);
 			final AbstractInsnNode nullTarget = AbstractMatcher
 					.skipNonOpcodes(lastIfNullInstruction.label);
-			final Replacements replacements = new Replacements();
-			replacements.add(lastIfNullInstruction, lastIfNullInstruction, 0);
-			replacements.add(nullTarget, nullTarget, 0);
 			for (final AbstractInsnNode ifNullInstruction : chain) {
+				final Replacements replacements = new Replacements();
+				replacements.add(ifNullInstruction, ifNullInstruction, 0);
+				replacements.add(nullTarget, nullTarget, 0);
 				output.replaceBranches(ifNullInstruction, replacements);
 			}
 		}

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -35,6 +35,8 @@
   <li>Fixed handling of implicit <code>default</code> clause of <code>switch</code>
       by <code>String</code> in Java when compiled by ECJ
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1813">#1813</a>).</li>
+  <li>Fixed handling of exceptions in chains of safe call operators in Kotlin
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1819">#1819</a>).</li>
 </ul>
 
 <h2>Release 0.8.13 (2025/04/02)</h2>


### PR DESCRIPTION
Prior to #1810

<img width="490" alt="Screenshot 2024-12-16 at 23 15 52" src="https://github.com/user-attachments/assets/92f3447b-75ed-4e4e-9c47-4de3d00a8f80" />

However after

<img width="490" alt="Screenshot 2024-12-16 at 23 15 17" src="https://github.com/user-attachments/assets/4af51096-bcb7-439a-856e-83accb21987c" />

----

```
  public static final java.lang.String example(org.example.A);
    descriptor: (Lorg/example/A;)Ljava/lang/String;
    flags: (0x0019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL
    Code:
      stack=2, locals=4, args_size=1
         0: aload_0
         1: dup
         2: ifnull        27
         5: astore_1
         6: aload_1
         7: astore_2
         8: iconst_0
         9: istore_3
        10: invokestatic  #16                 // Method exception:()V
        13: aload_1
        14: invokevirtual #22                 // Method org/example/A.getB:()Lorg/example/B;
        17: dup
        18: ifnull        27
        21: invokevirtual #28                 // Method org/example/B.getC:()Ljava/lang/String;
        24: goto          29
        27: pop
        28: aconst_null
        29: areturn
```

branch `0` of `ifnull` instructions of a chain should not be replaced.