### PR TITLE
IntelliJ IDEA should not suggest import of `jdk.internal.*` classes

### DIFF
--- a/.idea/codeInsightSettings.xml
+++ b/.idea/codeInsightSettings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaProjectCodeInsightSettings">
+    <excluded-names>
+      <name>jdk.internal.*</name>
+    </excluded-names>
+  </component>
+</project>


### PR DESCRIPTION
Without this change IntelliJ shows me first
`jdk.internal.org.objectweb.asm.Opcodes`
in the list of suggestions and only then
`org.objectweb.asm.Opcodes`.