### PR TITLE
Use `sonar.token` instead of deprecated `sonar.login`

### DIFF
--- a/.azure-pipelines/maven-settings.xml
+++ b/.azure-pipelines/maven-settings.xml
@@ -13,7 +13,7 @@
       <properties>
         <sonar.host.url>https://sonarcloud.io/</sonar.host.url>
         <sonar.organization>default</sonar.organization>
-        <sonar.login>${env.SONARQUBE_TOKEN}</sonar.login>
+        <sonar.token>${env.SONARQUBE_TOKEN}</sonar.token>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
See https://community.sonarsource.com/t/deprecating-sonar-login-and-sonar-password-in-favor-of-sonar-token/95829