### PR TITLE
Use `Integer.valueOf` instead of deprecated constructor

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/CounterImplTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/CounterImplTest.java
@@ -180,7 +180,7 @@ public class CounterImplTest {
 	@Test
 	public void testEquals4() {
 		ICounter c = CounterImpl.getInstance(300, 123);
-		assertFalse(c.equals(new Integer(123)));
+		assertFalse(c.equals(Integer.valueOf(123)));
 	}
 
 	@Test


### PR DESCRIPTION
Constructors of primitive wrappers
are deprecated since Java 9
* https://bugs.openjdk.org/browse/JDK-8176335
* https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Integer.html#%3Cinit%3E(int)

and deprecated for removal since Java 16
* https://bugs.openjdk.org/browse/JDK-8252180
* https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/Integer.html#%3Cinit%3E(int)