### PR TITLE
Improve `FilterTestBase.assertIgnored`

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/AnnotationGeneratedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/AnnotationGeneratedFilterTest.java
@@ -107,7 +107,7 @@ public class AnnotationGeneratedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -123,7 +123,7 @@ public class AnnotationGeneratedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/AssertFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/AssertFilterTest.java
@@ -63,7 +63,7 @@ public class AssertFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 	}
 
 	/**
@@ -99,7 +99,7 @@ public class AssertFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -139,7 +139,7 @@ public class AssertFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/EnumEmptyConstructorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/EnumEmptyConstructorFilterTest.java
@@ -39,7 +39,7 @@ public class EnumEmptyConstructorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(
+		assertIgnored(m,
 				new Range(m.instructions.getFirst(), m.instructions.getLast()));
 	}
 
@@ -69,7 +69,7 @@ public class EnumEmptyConstructorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -96,7 +96,7 @@ public class EnumEmptyConstructorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -118,7 +118,7 @@ public class EnumEmptyConstructorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -130,7 +130,7 @@ public class EnumEmptyConstructorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/EnumFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/EnumFilterTest.java
@@ -44,7 +44,7 @@ public class EnumFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class EnumFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class EnumFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ExhaustiveSwitchFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/ExhaustiveSwitchFilterTest.java
@@ -99,7 +99,7 @@ public class ExhaustiveSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, switchNode, replacements);
 	}
 
@@ -171,7 +171,7 @@ public class ExhaustiveSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, switchNode, replacements);
 	}
 
@@ -244,7 +244,7 @@ public class ExhaustiveSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, switchNode, replacements);
 	}
 
@@ -306,7 +306,7 @@ public class ExhaustiveSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/FilterTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/FilterTestBase.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.jacoco.core.internal.analysis.filter;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -59,12 +59,30 @@ public abstract class FilterTestBase {
 		}
 	};
 
-	final void assertIgnored(Range... ranges) {
-		assertArrayEquals(ranges, ignoredRanges.toArray(new Range[0]));
+	final void assertIgnored(final MethodNode methodNode,
+			final Range... expected) {
+		assertEquals("ignored ranges",
+				rangesToString(methodNode, Arrays.asList(expected)),
+				rangesToString(methodNode, ignoredRanges));
+	}
+
+	private static String rangesToString(final MethodNode m,
+			final List<Range> ranges) {
+		final StringBuilder stringBuilder = new StringBuilder();
+		for (int i = 0; i < ranges.size(); i++) {
+			final Range range = ranges.get(i);
+			stringBuilder.append("range ").append(i)
+					.append(" from instruction ")
+					.append(m.instructions.indexOf(range.fromInclusive))
+					.append(" to ")
+					.append(m.instructions.indexOf(range.toInclusive))
+					.append("\n");
+		}
+		return stringBuilder.toString();
 	}
 
 	final void assertMethodIgnored(final MethodNode m) {
-		assertIgnored(
+		assertIgnored(m,
 				new Range(m.instructions.getFirst(), m.instructions.getLast()));
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/FilterTestBaseTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/FilterTestBaseTest.java
@@ -12,38 +12,38 @@
  *******************************************************************************/
 package org.jacoco.core.internal.analysis.filter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.jacoco.core.internal.instr.InstrSupport;
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.MethodNode;
 
 /**
- * Unit tests for {@link BridgeFilter}.
+ * Unit tests for {@link FilterTestBase}.
  */
-public class BridgeFilterTest extends FilterTestBase {
-
-	private final BridgeFilter filter = new BridgeFilter();
+public class FilterTestBaseTest extends FilterTestBase {
 
 	@Test
-	public void should_filter_bridge_methods() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
-				Opcodes.ACC_BRIDGE, "m", "()Ljava/lang/Object;", null, null);
-		m.visitInsn(Opcodes.NOP);
-
-		filter.filter(m, context, output);
-
-		assertMethodIgnored(m);
-	}
-
-	@Test
-	public void should_not_filter_non_bridge_methods() {
+	public void assertIgnored_should_throw_ComparisonFailure() {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"m", "()Ljava/lang/Object;", null, null);
+				"example", "()V", null, null);
+		final Range range = new Range();
 		m.visitInsn(Opcodes.NOP);
+		range.fromInclusive = m.instructions.getFirst();
+		range.toInclusive = m.instructions.getLast();
 
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
+		try {
+			assertIgnored(m, range);
+			fail("exception expected");
+		} catch (final ComparisonFailure e) {
+			assertEquals("", e.getActual());
+			assertEquals("range 0 from instruction 0 to 0\n", e.getExpected());
+			assertTrue(e.getMessage().startsWith("ignored ranges expected:"));
+		}
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinComposeFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinComposeFilterTest.java
@@ -249,7 +249,8 @@ public class KotlinComposeFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2, range3, range4, range5, range6, range7);
+		assertIgnored(m, range1, range2, range3, range4, range5, range6,
+				range7);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
@@ -107,7 +107,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1, range2);
+		assertIgnored(m, range0, range1, range2);
 	}
 
 	/**
@@ -218,7 +218,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1, range2);
+		assertIgnored(m, range0, range1, range2);
 	}
 
 	/**
@@ -369,7 +369,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1, range2);
+		assertIgnored(m, range0, range1, range2);
 	}
 
 	/**
@@ -445,7 +445,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 	}
 
 	/**
@@ -508,7 +508,7 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1);
+		assertIgnored(m, range0, range1);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilterTest.java
@@ -60,7 +60,8 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(m.instructions.get(3), m.instructions.get(3)));
+		assertIgnored(m,
+				new Range(m.instructions.get(3), m.instructions.get(3)));
 	}
 
 	@Test
@@ -72,7 +73,7 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -84,7 +85,7 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -137,7 +138,7 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(
+		assertIgnored(m,
 				new Range(m.instructions.getFirst(), m.instructions.get(6)),
 				new Range(m.instructions.get(11), m.instructions.get(11)));
 	}
@@ -173,7 +174,8 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(m.instructions.get(3), m.instructions.get(3)));
+		assertIgnored(m,
+				new Range(m.instructions.get(3), m.instructions.get(3)));
 	}
 
 	/**
@@ -207,7 +209,8 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(m.instructions.get(3), m.instructions.get(3)));
+		assertIgnored(m,
+				new Range(m.instructions.get(3), m.instructions.get(3)));
 	}
 
 	/**
@@ -271,7 +274,7 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 	}
 
 	/**
@@ -346,7 +349,7 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultMethodsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultMethodsFilterTest.java
@@ -53,7 +53,7 @@ public class KotlinDefaultMethodsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -66,7 +66,7 @@ public class KotlinDefaultMethodsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinEnumFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinEnumFilterTest.java
@@ -58,7 +58,7 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -92,7 +92,7 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilterTest.java
@@ -52,7 +52,7 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -67,7 +67,7 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -110,7 +110,7 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineClassFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineClassFilterTest.java
@@ -62,7 +62,7 @@ public class KotlinInlineClassFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -80,7 +80,7 @@ public class KotlinInlineClassFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
@@ -85,7 +85,7 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(expectedRanges.toArray(new Range[0]));
+		assertIgnored(m, expectedRanges.toArray(new Range[0]));
 
 		// should not reparse:
 		context.sourceDebugExtension = "";
@@ -160,7 +160,7 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(expectedRanges.toArray(new Range[0]));
+		assertIgnored(m, expectedRanges.toArray(new Range[0]));
 	}
 
 	/**
@@ -218,7 +218,7 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(expectedRanges.toArray(new Range[0]));
+		assertIgnored(m, expectedRanges.toArray(new Range[0]));
 	}
 
 	/**
@@ -281,7 +281,7 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(expectedRanges.toArray(new Range[0]));
+		assertIgnored(m, expectedRanges.toArray(new Range[0]));
 	}
 
 	@Test
@@ -294,7 +294,7 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	private final List<Range> expectedRanges = new ArrayList<Range>();

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinJvmOverloadsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinJvmOverloadsFilterTest.java
@@ -176,7 +176,7 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -217,7 +217,7 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinLateinitFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinLateinitFilterTest.java
@@ -43,7 +43,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -76,7 +76,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(branch, branch),
+		assertIgnored(m, new Range(branch, branch),
 				new Range(expectedFrom, expectedTo));
 	}
 
@@ -109,7 +109,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -142,7 +142,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(branch, branch),
+		assertIgnored(m, new Range(branch, branch),
 				new Range(expectedFrom, expectedTo));
 	}
 
@@ -177,7 +177,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(branch, branch),
+		assertIgnored(m, new Range(branch, branch),
 				new Range(expectedFrom, expectedTo));
 	}
 
@@ -212,7 +212,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -247,7 +247,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -277,7 +277,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -308,7 +308,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -340,7 +340,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(branch, branch),
+		assertIgnored(m, new Range(branch, branch),
 				new Range(expectedFrom, expectedTo));
 	}
 
@@ -374,7 +374,7 @@ public class KotlinLateinitFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(branch, branch),
+		assertIgnored(m, new Range(branch, branch),
 				new Range(expectedFrom, expectedTo));
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinNotNullOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinNotNullOperatorFilterTest.java
@@ -54,7 +54,7 @@ public class KotlinNotNullOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
@@ -71,7 +71,7 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
 		replacements.put(ifNullInstruction1, Arrays.asList( //
 				new Replacement(0, ifNullInstruction2, 0),
@@ -124,7 +124,7 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
 		replacements.put(ifNullInstruction1, Arrays.asList( //
 				new Replacement(0, ifNullInstruction2, 0),

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSyntheticFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSyntheticFilterTest.java
@@ -43,7 +43,7 @@ public class KotlinSyntheticFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -88,7 +88,7 @@ public class KotlinSyntheticFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -103,7 +103,7 @@ public class KotlinSyntheticFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**
@@ -129,7 +129,7 @@ public class KotlinSyntheticFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	/**

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinUnsafeCastOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinUnsafeCastOperatorFilterTest.java
@@ -49,7 +49,7 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	/**
@@ -118,7 +118,7 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFrom, expectedTo));
+		assertIgnored(m, new Range(expectedFrom, expectedTo));
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinWhenFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinWhenFilterTest.java
@@ -59,7 +59,7 @@ public class KotlinWhenFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 		assertNoReplacedBranches();
 	}
 
@@ -83,7 +83,7 @@ public class KotlinWhenFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 		assertNoReplacedBranches();
 	}
 
@@ -117,7 +117,7 @@ public class KotlinWhenFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1);
+		assertIgnored(m, range1);
 		assertReplacedBranches(m, switchNode, replacements);
 	}
 
@@ -198,7 +198,7 @@ public class KotlinWhenFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 		assertReplacedBranches(m, switchNode, replacements);
 	}
 
@@ -258,7 +258,7 @@ public class KotlinWhenFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1);
+		assertIgnored(m, range1);
 		assertNoReplacedBranches();
 	}
 
@@ -318,7 +318,7 @@ public class KotlinWhenFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1);
+		assertIgnored(m, range1);
 		assertNoReplacedBranches();
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilterTest.java
@@ -104,7 +104,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 
 		assertReplacedBranches(m, expectedFromInclusive.getPrevious(),
 				replacements);
-		assertIgnored(new Range(expectedFromInclusive, expectedToInclusive));
+		assertIgnored(m, new Range(expectedFromInclusive, expectedToInclusive));
 	}
 
 	/**
@@ -178,7 +178,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFromInclusive, expectedToInclusive));
+		assertIgnored(m, new Range(expectedFromInclusive, expectedToInclusive));
 		assertReplacedBranches(m, expectedFromInclusive.getPrevious(),
 				replacements);
 	}
@@ -197,7 +197,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/RecordPatternFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/RecordPatternFilterTest.java
@@ -107,7 +107,7 @@ public class RecordPatternFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range, range);
+		assertIgnored(m, range, range);
 	}
 
 	/**
@@ -214,7 +214,7 @@ public class RecordPatternFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range, range);
+		assertIgnored(m, range, range);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/RecordsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/RecordsFilterTest.java
@@ -53,7 +53,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -96,7 +96,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -152,7 +152,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -212,7 +212,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -225,7 +225,7 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -240,6 +240,6 @@ public class RecordsFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/StringSwitchFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/StringSwitchFilterTest.java
@@ -104,7 +104,7 @@ public class StringSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, range.fromInclusive.getPrevious(),
 				replacements);
 	}
@@ -152,7 +152,7 @@ public class StringSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, range.fromInclusive.getPrevious(),
 				replacements);
 	}
@@ -268,7 +268,7 @@ public class StringSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, range.fromInclusive.getPrevious(),
 				replacements);
 	}
@@ -362,7 +362,7 @@ public class StringSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, range.fromInclusive.getPrevious(),
 				replacements);
 	}
@@ -463,7 +463,7 @@ public class StringSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range);
+		assertIgnored(m, range);
 		assertReplacedBranches(m, range.fromInclusive.getPrevious(),
 				replacements);
 	}
@@ -483,7 +483,7 @@ public class StringSwitchFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 		assertNoReplacedBranches();
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/StringSwitchJavacFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/StringSwitchJavacFilterTest.java
@@ -99,7 +99,7 @@ public class StringSwitchJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFromInclusive, expectedToInclusive));
+		assertIgnored(m, new Range(expectedFromInclusive, expectedToInclusive));
 	}
 
 	@Test
@@ -112,7 +112,7 @@ public class StringSwitchJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range(expectedFromInclusive, expectedToInclusive));
+		assertIgnored(m, new Range(expectedFromInclusive, expectedToInclusive));
 	}
 
 	/**
@@ -163,7 +163,7 @@ public class StringSwitchJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -210,7 +210,7 @@ public class StringSwitchJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SynchronizedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SynchronizedFilterTest.java
@@ -62,7 +62,7 @@ public class SynchronizedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range((LabelNode) handler.info,
+		assertIgnored(m, new Range((LabelNode) handler.info,
 				((LabelNode) exit.info).getPrevious()));
 	}
 
@@ -116,7 +116,7 @@ public class SynchronizedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -152,7 +152,7 @@ public class SynchronizedFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(new Range((LabelNode) handler.info,
+		assertIgnored(m, new Range((LabelNode) handler.info,
 				((LabelNode) exit.info).getPrevious()));
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SyntheticFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/SyntheticFilterTest.java
@@ -32,7 +32,7 @@ public class SyntheticFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -54,7 +54,7 @@ public class SyntheticFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class SyntheticFilterTest extends FilterTestBase {
 
 		context.classAttributes.add("ScalaSig");
 		filter.filter(m, context, output);
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class SyntheticFilterTest extends FilterTestBase {
 
 		context.classAttributes.add("Scala");
 		filter.filter(m, context, output);
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesEcjFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesEcjFilterTest.java
@@ -309,7 +309,7 @@ public class TryWithResourcesEcjFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1);
+		assertIgnored(m, range0, range1);
 	}
 
 	/**
@@ -591,7 +591,7 @@ public class TryWithResourcesEcjFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1);
+		assertIgnored(m, range0, range1);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesJavac11FilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesJavac11FilterTest.java
@@ -77,7 +77,7 @@ public class TryWithResourcesJavac11FilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 	}
 
 	/**
@@ -133,7 +133,7 @@ public class TryWithResourcesJavac11FilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range1, range2);
+		assertIgnored(m, range1, range2);
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesJavacFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/TryWithResourcesJavacFilterTest.java
@@ -218,7 +218,7 @@ public class TryWithResourcesJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1, range2, range3);
+		assertIgnored(m, range0, range1, range2, range3);
 	}
 
 	/**
@@ -535,7 +535,7 @@ public class TryWithResourcesJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1, range2, range3);
+		assertIgnored(m, range0, range1, range2, range3);
 	}
 
 	/**
@@ -701,7 +701,7 @@ public class TryWithResourcesJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored(range0, range1);
+		assertIgnored(m, range0, range1);
 	}
 
 	/**
@@ -763,7 +763,7 @@ public class TryWithResourcesJavacFilterTest extends FilterTestBase {
 
 		filter.filter(m, context, output);
 
-		assertIgnored();
+		assertIgnored(m);
 	}
 
 }


### PR DESCRIPTION
Similarly to changes of `FilterTestBase.assertReplacedBranches` in https://github.com/jacoco/jacoco/pull/1813

## Eclipse IDE

### before

<img width="503" alt="Screenshot 2025-04-09 at 15 52 57" src="https://github.com/user-attachments/assets/416bf030-fbdb-4468-a49d-75182ef2fc0e" />

### after

<img width="1333" alt="Screenshot 2025-04-09 at 15 51 33" src="https://github.com/user-attachments/assets/2462b65b-ad86-40b7-8c28-8f7c44025981" />

## IntelliJ IDEA

### before

<img width="1312" alt="Screenshot 2025-04-09 at 14 41 48" src="https://github.com/user-attachments/assets/3ca964f4-e8a8-4ff2-a3bc-10a335fe4935" />

### after

<img width="1309" alt="Screenshot 2025-04-09 at 14 47 20" src="https://github.com/user-attachments/assets/7b78421d-c620-4048-948d-848f94654cff" />

## Command line

### before

<img width="1132" alt="Screenshot 2025-04-09 at 16 08 12" src="https://github.com/user-attachments/assets/9b2b56e9-1557-47ff-add5-05c9562230ff" />

### after

<img width="1132" alt="Screenshot 2025-04-09 at 16 07 05" src="https://github.com/user-attachments/assets/e9929229-9af7-4d2f-ac48-8b0a0f26e9ac" />
