### PR TITLE
Migrate publishing of snapshot to the Central Publisher Portal

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -125,7 +125,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
+    <sonatypeOssDistMgmtSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
 
     <maven.build.timestamp.format>yyyyMMddhhmm</maven.build.timestamp.format>
     <jacoco.home.url>http://www.jacoco.org/jacoco</jacoco.home.url>

--- a/org.jacoco.doc/docroot/doc/repo.html
+++ b/org.jacoco.doc/docroot/doc/repo.html
@@ -40,7 +40,7 @@
     </tr>
     <tr>
       <td>Snapshot</td>
-      <td><code>https://oss.sonatype.org/content/repositories/snapshots</code></td>
+      <td><code>https://central.sonatype.com/repository/maven-snapshots/</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Part of #1896 

https://central.sonatype.org/publish/publish-portal-snapshots/#publishing-via-other-methods

----

https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/jacoco/jacoco/