### PR TITLE
Use branch index 1 of the jumps into the case instead of 0.

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilterTest.java
@@ -66,7 +66,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 				"(Ljava/lang/Object;)Z", false);
 		m.visitJumpInsn(Opcodes.IFEQ, sameHash);
 		m.visitJumpInsn(Opcodes.GOTO, case1);
-		replacements.add(new Replacement(1, m.instructions.getLast(), 0));
+		replacements.add(new Replacement(1, m.instructions.getLast(), 1));
 
 		// case "\u0000a"
 		m.visitLabel(sameHash);
@@ -77,7 +77,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 		m.visitJumpInsn(Opcodes.IFEQ, defaultCase);
 		replacements.add(new Replacement(0, m.instructions.getLast(), 1));
 		m.visitJumpInsn(Opcodes.GOTO, case2);
-		replacements.add(new Replacement(2, m.instructions.getLast(), 0));
+		replacements.add(new Replacement(2, m.instructions.getLast(), 1));
 
 		// case "b"
 		m.visitLabel(h2);
@@ -89,7 +89,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 		replacements.add(new Replacement(0, m.instructions.getLast(), 1));
 		m.visitJumpInsn(Opcodes.GOTO, case3);
 		final AbstractInsnNode expectedToInclusive = m.instructions.getLast();
-		replacements.add(new Replacement(3, m.instructions.getLast(), 0));
+		replacements.add(new Replacement(3, m.instructions.getLast(), 1));
 
 		m.visitLabel(case1);
 		m.visitInsn(Opcodes.RETURN);
@@ -145,7 +145,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 				"(Ljava/lang/Object;)Z", false);
 		m.visitJumpInsn(Opcodes.IFEQ, sameHash);
 		m.visitJumpInsn(Opcodes.GOTO, case2);
-		replacements.add(new Replacement(1, m.instructions.getLast(), 0));
+		replacements.add(new Replacement(1, m.instructions.getLast(), 1));
 
 		m.visitLabel(sameHash);
 		m.visitVarInsn(Opcodes.ALOAD, 2);
@@ -155,7 +155,7 @@ public class KotlinWhenStringFilterTest extends FilterTestBase {
 		m.visitJumpInsn(Opcodes.IFEQ, defaultCase);
 		replacements.add(new Replacement(0, m.instructions.getLast(), 1));
 		m.visitJumpInsn(Opcodes.GOTO, case3);
-		replacements.add(new Replacement(2, m.instructions.getLast(), 0));
+		replacements.add(new Replacement(2, m.instructions.getLast(), 1));
 
 		m.visitLabel(h2);
 		m.visitVarInsn(Opcodes.ALOAD, 2);

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinWhenStringFilter.java
@@ -86,7 +86,7 @@ final class KotlinWhenStringFilter implements IFilter {
 					} else if (cursor.getOpcode() == Opcodes.GOTO) {
 						// jump to case body
 						replacements.add(((JumpInsnNode) cursor).label, cursor,
-								0);
+								1);
 						if (jump.label == defaultLabel) {
 							// end of comparisons for same hashCode
 							replacements.add(defaultLabel, jump, 1);


### PR DESCRIPTION
Currently KotlinWhenStringFilter breaks branch coverage for String based when statements because the replacement branches into the case statements can never be covered.

This is because the new branches point to the "first" branch of the unconditional jumps to the bodies of the case statement (after the String equality check).

But the first branch of a jump is the "fallthrough" (the path if the jump is not taken), which is never taken for a simple goto. The target of a jump is the second branch.

Fixes https://github.com/jacoco/jacoco/issues/1938