### PR TITLE
Fix KotlinCrossinlineTest

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinCrossinlineTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinCrossinlineTest.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.jacoco.core.test.validation.kotlin;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinCrossinlineTarget;
 
@@ -25,12 +28,11 @@ public class KotlinCrossinlineTest extends ValidationTestBase {
 	}
 
 	@Override
-	protected void run(final Class<?> targetClass) throws Exception {
-		super.run(targetClass);
-		// Trigger the analysis of SMAPs in non executed classes:
-		targetClass.getClassLoader().loadClass(
-				"org.jacoco.core.test.validation.kotlin.targets.KotlinCrossinlineTarget$example$1");
-		targetClass.getClassLoader().loadClass(
+	protected Collection<String> additionalClassesForAnalysis() {
+		// Analyze SMAPs in non executed classes:
+		return Arrays.asList(
+				"org.jacoco.core.test.validation.kotlin.targets.KotlinCrossinlineTarget$example$1",
 				"org.jacoco.core.test.validation.kotlin.targets.KotlinCrossinlineTarget$example$1$1");
 	}
+
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinCrossinlineTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinCrossinlineTest.java
@@ -24,4 +24,13 @@ public class KotlinCrossinlineTest extends ValidationTestBase {
 		super(KotlinCrossinlineTarget.class);
 	}
 
+	@Override
+	protected void run(final Class<?> targetClass) throws Exception {
+		super.run(targetClass);
+		// Trigger the analysis of SMAPs in non executed classes:
+		targetClass.getClassLoader().loadClass(
+				"org.jacoco.core.test.validation.kotlin.targets.KotlinCrossinlineTarget$example$1");
+		targetClass.getClassLoader().loadClass(
+				"org.jacoco.core.test.validation.kotlin.targets.KotlinCrossinlineTarget$example$1$1");
+	}
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinCrossinlineTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinCrossinlineTarget.kt
@@ -21,8 +21,12 @@ object KotlinCrossinlineTarget {
 
     inline fun example(crossinline lambda: () -> Unit): () -> Unit { // assertEmpty()
         return { // assertFullyCovered()
-            requireCrossinline { lambda() } // assertFullyCovered()
-        } // assertFullyCovered()
+            /* TODO next two lines are partly covered due to regression in Kotlin compiler version 2.0
+            https://github.com/jacoco/jacoco/issues/1840
+            https://youtrack.jetbrains.com/issue/KT-74617/Trivial-SMAP-optimization-leads-to-missing-debug-info-after-inline
+            */
+            requireCrossinline { lambda() } // assertPartlyCovered()
+        } // assertPartlyCovered()
     } // assertEmpty()
 
     fun requireCrossinline(lambda: () -> Unit) = lambda()

--- a/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoader.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoader.java
@@ -13,8 +13,6 @@
 package org.jacoco.core.test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfoStore;
@@ -36,8 +34,6 @@ public final class InstrumentingLoader extends ClassLoader {
 	private final RuntimeData data;
 	private final Instrumenter instrumenter;
 
-	private final ArrayList<String> instrumentedClasses;
-
 	public InstrumentingLoader(IRuntime runtime, String scope,
 			ClassLoader delegate) throws Exception {
 		this.runtime = runtime;
@@ -46,7 +42,6 @@ public final class InstrumentingLoader extends ClassLoader {
 		this.data = new RuntimeData();
 		runtime.startup(data);
 		this.instrumenter = new Instrumenter(runtime);
-		this.instrumentedClasses = new ArrayList<String>();
 	}
 
 	public InstrumentingLoader(Class<?> target) throws Exception {
@@ -71,7 +66,6 @@ public final class InstrumentingLoader extends ClassLoader {
 			final byte[] instrumented;
 			try {
 				instrumented = instrumenter.instrument(bytes, name);
-				instrumentedClasses.add(name);
 			} catch (IOException e) {
 				throw new ClassNotFoundException("Unable to instrument", e);
 			}
@@ -89,10 +83,6 @@ public final class InstrumentingLoader extends ClassLoader {
 		data.collect(store, new SessionInfoStore(), false);
 		runtime.shutdown();
 		return store;
-	}
-
-	public Collection<String> getInstrumentedClasses() {
-		return instrumentedClasses;
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoader.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/InstrumentingLoader.java
@@ -13,6 +13,8 @@
 package org.jacoco.core.test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.jacoco.core.data.ExecutionDataStore;
 import org.jacoco.core.data.SessionInfoStore;
@@ -34,6 +36,8 @@ public final class InstrumentingLoader extends ClassLoader {
 	private final RuntimeData data;
 	private final Instrumenter instrumenter;
 
+	private final ArrayList<String> instrumentedClasses;
+
 	public InstrumentingLoader(IRuntime runtime, String scope,
 			ClassLoader delegate) throws Exception {
 		this.runtime = runtime;
@@ -42,6 +46,7 @@ public final class InstrumentingLoader extends ClassLoader {
 		this.data = new RuntimeData();
 		runtime.startup(data);
 		this.instrumenter = new Instrumenter(runtime);
+		this.instrumentedClasses = new ArrayList<String>();
 	}
 
 	public InstrumentingLoader(Class<?> target) throws Exception {
@@ -66,6 +71,7 @@ public final class InstrumentingLoader extends ClassLoader {
 			final byte[] instrumented;
 			try {
 				instrumented = instrumenter.instrument(bytes, name);
+				instrumentedClasses.add(name);
 			} catch (IOException e) {
 				throw new ClassNotFoundException("Unable to instrument", e);
 			}
@@ -83,6 +89,10 @@ public final class InstrumentingLoader extends ClassLoader {
 		data.collect(store, new SessionInfoStore(), false);
 		runtime.shutdown();
 		return store;
+	}
+
+	public Collection<String> getInstrumentedClasses() {
+		return instrumentedClasses;
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -99,20 +99,20 @@ public abstract class ValidationTestBase {
 	private void analyze(final ExecutionDataStore store) throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
 		final Analyzer analyzer = new Analyzer(store, builder);
-		for (ExecutionData data : store.getContents()) {
-			analyze(analyzer, data);
+		for (String className : loader.getInstrumentedClasses()) {
+			analyze(analyzer, className);
 		}
 		final String testClassSimpleName = getClass().getSimpleName();
 		bundle = builder.getBundle(testClassSimpleName);
 		source = Source.load(target, bundle);
 	}
 
-	private void analyze(final Analyzer analyzer, final ExecutionData data)
+	private void analyze(final Analyzer analyzer, final String className)
 			throws IOException {
 		final byte[] bytes = TargetLoader
-				.getClassDataAsBytes(target.getClassLoader(), data.getName());
-		analyzer.analyzeClass(bytes, data.getName());
-		saveBytecodeRepresentations(bytes, data.getName());
+				.getClassDataAsBytes(target.getClassLoader(), className);
+		analyzer.analyzeClass(bytes, className);
+		saveBytecodeRepresentations(bytes, className);
 	}
 
 	private void saveBytecodeRepresentations(final byte[] classBytes,

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -21,6 +21,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 import org.jacoco.core.analysis.Analyzer;
@@ -96,10 +97,17 @@ public abstract class ValidationTestBase {
 				(Object) new String[0]);
 	}
 
+	protected Collection<String> additionalClassesForAnalysis() {
+		return Collections.emptyList();
+	}
+
 	private void analyze(final ExecutionDataStore store) throws IOException {
 		final CoverageBuilder builder = new CoverageBuilder();
 		final Analyzer analyzer = new Analyzer(store, builder);
-		for (String className : loader.getInstrumentedClasses()) {
+		for (ExecutionData data : store.getContents()) {
+			analyze(analyzer, data.getName());
+		}
+		for (String className : additionalClassesForAnalysis()) {
 			analyze(analyzer, className);
 		}
 		final String testClassSimpleName = getClass().getSimpleName();


### PR DESCRIPTION
`KotlinCrossinlineTest` did not caught regression in Kotlin compiler version 2.0

* https://github.com/jacoco/jacoco/issues/1840
* https://youtrack.jetbrains.com/issue/KT-74617/Trivial-SMAP-optimization-leads-to-missing-debug-info-after-inline

because `ValidationTestBase` does not analyse non executed classes,
and for `KotlinCrossinlineTarget.kt` Kotlin compiler produces

 ```
KotlinCrossinlineTarget$example$1$1.class
KotlinCrossinlineTarget$example$1.class
KotlinCrossinlineTarget$main$$inlined$example$1$1.class
KotlinCrossinlineTarget$main$$inlined$example$1.class
KotlinCrossinlineTarget.class
```

where first two are not executed, however should provide SMAP essential for proper analysis.

This change allows `KotlinCrossinlineTest` to catch this regression and needed for [update of Kotlin compiler to version 2.2.0](https://github.com/jacoco/jacoco/pull/1935) where regression is fixed.