### PR TITLE
Bump org.apache.maven.shared:file-management from 3.1.0 to 3.2.0

### DIFF
--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>file-management</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This version of `org.apache.maven.shared:file-management` upgrades `commons-io:commons-io` which fixed [CVE-2024-47554](https://avd.aquasec.com/nvd/2024/cve-2024-47554/)