### PR TITLE
Migrate release staging to the Central Publisher Portal

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -114,7 +114,7 @@
     <repository>
       <id>sonatype-nexus-staging</id>
       <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>


### PR DESCRIPTION
Part of #1896

https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#plugins-tested-for-compatibility