### PR TITLE
Replace outdated Maven Central Search links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ JaCoCo Java Code Coverage Library
 =================================
 
 [![Build Status](https://dev.azure.com/jacoco-org/JaCoCo/_apis/build/status/JaCoCo?branchName=master)](https://dev.azure.com/jacoco-org/JaCoCo/_build/latest?definitionId=1&branchName=master)
-[![Maven Central](https://img.shields.io/maven-central/v/org.jacoco/jacoco.svg)](http://search.maven.org/#search|ga|1|g%3Aorg.jacoco)
+[![Maven Central](https://img.shields.io/maven-central/v/org.jacoco/jacoco.svg)](https://central.sonatype.com/namespace/org.jacoco)
 
 JaCoCo is a free Java code coverage library distributed under the Eclipse Public
 License.

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -98,7 +98,7 @@
 <h3>Development Build Artifacts</h3>
 
 <p>
-  Beside the <a href="http://search.maven.org/#search|ga|1|g%3Aorg.jacoco"> JaCoCo releases</a>
+  Beside the <a href="https://central.sonatype.com/namespace/org.jacoco">JaCoCo releases</a>
   the following build artifacts are automatically available during the
   development cycle:
 </p>

--- a/org.jacoco.doc/docroot/doc/maven.html
+++ b/org.jacoco.doc/docroot/doc/maven.html
@@ -83,7 +83,7 @@
 <p>
   The Maven plug-in can be included in your build with the following
   declaration. Please check
-  <a href="http://search.maven.org/#search|ga|1|g%3Aorg.jacoco%20a%3Ajacoco-maven-plugin">here</a>
+  <a href="https://central.sonatype.com/artifact/org.jacoco/jacoco-maven-plugin">here</a>
   for the latest release version in the repository.
 </p>
 

--- a/org.jacoco.doc/docroot/doc/repo.html
+++ b/org.jacoco.doc/docroot/doc/repo.html
@@ -119,7 +119,7 @@
 </table>
 
 <p>
-  Please check <a href="http://search.maven.org/#search|ga|1|g%3Aorg.jacoco">here</a>
+  Please check <a href="https://central.sonatype.com/namespace/org.jacoco">here</a>
   for the latest release versions in the repository.
 </p>
 


### PR DESCRIPTION
See https://central.sonatype.org/faq/what-happened-to-search-maven-org/

Also as of today https://search.maven.org/search?q=g:org.jacoco wrongly shows 0.8.13 as latest version,
whereas https://central.sonatype.com/namespace/org.jacoco correctly shows 0.8.14