### PR TITLE
fix a syntax error in AbstractAgentMojo.java

### DIFF
--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -46,7 +46,7 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	@Parameter(property = "plugin.artifactMap", required = true, readonly = true)
 	Map<String, Artifact> pluginArtifactMap;
 	/**
-	 * Allows to specify property which will contains settings for JaCoCo Agent.
+	 * Allows to specify property which will contain settings for JaCoCo Agent.
 	 * If not specified, then "argLine" would be used for "jar" packaging and
 	 * "tycho.testArgLine" for "eclipse-test-plugin".
 	 */


### PR DESCRIPTION
This synatx error is exposed externally when maven's help task is used as below:

```shell
mvn help:describe -Dplugin=org.jacoco:jacoco-maven-plugin -Ddetail
```