### PR TITLE
Build of `org.jacoco.examples.test` should not pollute local maven repository

### DIFF
--- a/org.jacoco.examples.test/pom.xml
+++ b/org.jacoco.examples.test/pom.xml
@@ -81,9 +81,14 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <executions>
           <execution>
-            <id>test-pom</id>
+            <id>install</id>
             <goals>
               <goal>install</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-pom</id>
+            <goals>
               <goal>run</goal>
             </goals>
             <configuration>
@@ -97,7 +102,6 @@
           <execution>
             <id>test-pom-it</id>
             <goals>
-              <goal>install</goal>
               <goal>run</goal>
             </goals>
             <configuration>
@@ -113,7 +117,6 @@
           <execution>
             <id>test-pom-offline</id>
             <goals>
-              <goal>install</goal>
               <goal>run</goal>
             </goals>
             <configuration>
@@ -129,6 +132,8 @@
         </executions>
         <configuration>
           <projectsDirectory>${project.build.directory}/build/examples</projectsDirectory>
+          <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+          <settingsFile>src/test/resources/settings.xml</settingsFile>
           <properties>
             <!--
             maven-invoker-plugin for forked Maven invocations uses the same JDK that is used for Maven,

--- a/org.jacoco.examples.test/src/test/resources/settings.xml
+++ b/org.jacoco.examples.test/src/test/resources/settings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   https://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Evgeny Mandrikov - initial API and implementation
+-->
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
Execution of

```
rm -r ~/.m2/repository/org/jacoco
mvn clean verify
```

produces many messages about installing files to local repository, here is first one of them

```
[INFO] --- invoker:2.0.0:install (test-pom) @ org.jacoco.examples.test ---
[INFO] Installing /Users/evgeny.mandrikov/projects/jacoco/jacoco/org.jacoco.build/pom.xml to /Users/evgeny.mandrikov/.m2/repository/org/jacoco/org.jacoco.build/0.8.13-SNAPSHOT/org.jacoco.build-0.8.13-SNAPSHOT.pom
```

these messages are also duplicated later

```
[INFO] --- invoker:2.0.0:install (test-pom-it) @ org.jacoco.examples.test ---
[INFO] Installing /Users/evgeny.mandrikov/projects/jacoco/jacoco/org.jacoco.build/pom.xml to /Users/evgeny.mandrikov/.m2/repository/org/jacoco/org.jacoco.build/0.8.13-SNAPSHOT/org.jacoco.build-0.8.13-SNAPSHOT.pom
```

```
[INFO] --- invoker:2.0.0:install (test-pom-offline) @ org.jacoco.examples.test ---
[INFO] Installing /Users/evgeny.mandrikov/projects/jacoco/jacoco/org.jacoco.build/pom.xml to /Users/evgeny.mandrikov/.m2/repository/org/jacoco/org.jacoco.build/0.8.13-SNAPSHOT/org.jacoco.build-0.8.13-SNAPSHOT.pom
```

after which execution of

```
ls ~/.m2/repository/org/jacoco
```

confirms that these files were installed, whereas `verify` was requested and not `install`.

Quoting https://maven.apache.org/plugins/maven-invoker-plugin/install-mojo.html#localRepositoryPath

> To prevent soiling of your regular local repository with possibly broken artifacts, it is strongly recommended to use an isolated repository for the integration tests