### PR TITLE
Import of project into IntelliJ IDEA should not require `mvn install`

### DIFF
--- a/org.jacoco.doc/pom.xml
+++ b/org.jacoco.doc/pom.xml
@@ -120,32 +120,6 @@
 
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${project.version}</version>
-        <executions>
-          <execution>
-            <id>report-aggregate</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report-aggregate</goal>
-            </goals>
-            <configuration>
-              <title>JaCoCo</title>
-              <footer>Code Coverage Report for JaCoCo ${project.version}</footer>
-              <includes>
-                <!-- Analyze class files only to exclude shaded agent JAR from report -->
-                <include>**/*.class</include>
-              </includes>
-              <excludes>
-                <exclude>**/HelpMojo.class</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
@@ -322,4 +296,49 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!--
+    The following profile is to work around IntelliJ IDEA inability
+    during project import to resolve plugin snapshot without it being installed.
+    See https://youtrack.jetbrains.com/issue/IDEA-238307
+    -->
+    <profile>
+      <id>not-intellij-sync</id>
+      <activation>
+        <property>
+          <name>!idea.maven.embedder.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${project.version}</version>
+            <executions>
+              <execution>
+                <id>report-aggregate</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <configuration>
+                  <title>JaCoCo</title>
+                  <footer>Code Coverage Report for JaCoCo ${project.version}</footer>
+                  <includes>
+                    <!-- Analyze class files only to exclude shaded agent JAR from report -->
+                    <include>**/*.class</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/HelpMojo.class</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/org.jacoco.tests/pom.xml
+++ b/org.jacoco.tests/pom.xml
@@ -56,30 +56,47 @@
 
   <build>
     <sourceDirectory>src</sourceDirectory>
-
-    <plugins>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${project.version}</version>
-        <configuration>
-          <exclClassLoaders>sun.reflect.DelegatingClassLoader:org.jacoco.core.test.TargetLoader:org.jacoco.core.test.InstrumentingLoader</exclClassLoaders>
-          <sessionId>${project.artifactId}</sessionId>
-          <includes>
-            <include>${jacoco.includes}</include>
-          </includes>
-          <excludes>
-            <exclude>${jacoco.excludes}</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
+
+  <profiles>
+    <!--
+    The following profile is to work around IntelliJ IDEA inability
+    during project import to resolve plugin snapshot without it being installed.
+    See https://youtrack.jetbrains.com/issue/IDEA-238307
+    -->
+    <profile>
+      <id>not-intellij-sync</id>
+      <activation>
+        <property>
+          <name>!idea.maven.embedder.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${project.version}</version>
+            <configuration>
+              <exclClassLoaders>sun.reflect.DelegatingClassLoader:org.jacoco.core.test.TargetLoader:org.jacoco.core.test.InstrumentingLoader</exclClassLoaders>
+              <sessionId>${project.artifactId}</sessionId>
+              <includes>
+                <include>${jacoco.includes}</include>
+              </includes>
+              <excludes>
+                <exclude>${jacoco.excludes}</exclude>
+            </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This was reported privately by @asm0dey 

<img width="1149" height="553" alt="Screenshot 2025-12-19 at 23 33 51" src="https://github.com/user-attachments/assets/95a1fbb4-3156-4c8b-908d-0897d49f5b2b" />
