### PR TITLE
[spotless] Ignore IDEA project configuration files

### DIFF
--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -581,6 +581,7 @@
               </includes>
               <excludes>
                 <exclude>target/**</exclude>
+                <exclude>.idea/**</exclude>
               </excludes>
               <lineEndings>UNIX</lineEndings>
               <trimTrailingWhitespace/>


### PR DESCRIPTION
Currently build fails with:

    [ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:3.1.0:check (default) on project jacoco-maven-plugin: The following files had format violations:
    [ERROR]     .idea/misc.xml
    [ERROR]         @@ -9,4 +9,4 @@
    [ERROR]          ····</option>
    [ERROR]          ··</component>
    [ERROR]          ··<component·name="ProjectRootManager"·version="2"·project-jdk-name="25"·project-jdk-type="JavaSDK"·/>
    [ERROR]         -</project>
    [ERROR]         +</project>
    [ERROR]     .idea/workspace.xml
    [ERROR]         @@ -48,4 +48,4 @@
    [ERROR]          ····</task>
    ...
    [ERROR]          ··</component>
    [ERROR]         -</project>
    [ERROR]         +</project>
    [ERROR] Run 'mvn spotless:apply' to fix these violations.

As these files are not under version control anyway, there is no point to let spotless check them.