### PR TITLE
Add workaround for JDK-8166253

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/FileOutputTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/FileOutputTest.java
@@ -95,12 +95,11 @@ public class FileOutputTest {
 		File destFile = folder.newFile("jacoco.exec");
 		AgentOptions options = new AgentOptions();
 		options.setDestfile(destFile.getAbsolutePath());
-		// Note that due to https://bugs.openjdk.org/browse/JDK-8166253
-		// (fixed in JDK version 11)
-		// reference to lock object must be maintained
+		// Note that reference to lock object must be maintained
 		// till the end of this test
 		// to guarantee that observation of OverlappingFileLockException
 		// does not depend on GC in JDK versions from 6 to 10
+		// affected by https://bugs.openjdk.org/browse/JDK-8166253
 		FileLock lock = new FileOutputStream(destFile).getChannel().lock();
 		FileOutput controller = new FileOutput();
 
@@ -125,12 +124,11 @@ public class FileOutputTest {
 		File destFile = folder.newFile("jacoco.exec");
 		AgentOptions options = new AgentOptions();
 		options.setDestfile(destFile.getAbsolutePath());
-		// Note that due to https://bugs.openjdk.org/browse/JDK-8166253
-		// (fixed in JDK version 11)
-		// reference to lock object must be maintained
+		// Note that reference to lock object must be maintained
 		// till the end of this test
 		// to guarantee that observation of OverlappingFileLockException
 		// does not depend on GC in JDK versions from 6 to 10
+		// affected by https://bugs.openjdk.org/browse/JDK-8166253
 		FileLock lock = new FileOutputStream(destFile).getChannel().lock();
 		FileOutput controller = new FileOutput();
 		Thread.currentThread().interrupt();

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/FileOutput.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/FileOutput.java
@@ -82,12 +82,11 @@ public class FileOutput implements IAgentOutput {
 				// An agent from another JVM might have a lock. In this case
 				// this method blocks until the lock is freed.
 				final FileLock lock = fc.lock();
-				// Note that due to https://bugs.openjdk.org/browse/JDK-8166253
-				// (fixed in JDK version 11)
-				// reference to lock object must be maintained
+				// Note that reference to lock object must be maintained
 				// till the end of writing
 				// to guarantee that observation of OverlappingFileLockException
 				// does not depend on GC in JDK versions from 6 to 10
+				// affected by https://bugs.openjdk.org/browse/JDK-8166253
 				return new OutputStream() {
 					@Override
 					public void write(final int b) throws IOException {

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -38,6 +38,10 @@
 <ul>
   <li>Fixed processing of Kotlin SMAP in synthetic classes
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/1985">#1985</a>).</li>
+  <li>Multiple JaCoCo runtimes within one JVM writing to the same output file
+      should not cause data corruption when running on JDK versions from 6 to 10
+      affected by <a href="https://bugs.openjdk.org/browse/JDK-8166253">JDK-8166253</a>
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/2065">#2065</a>).</li>
 </ul>
 
 <h2>Release 0.8.14 (2025/10/11)</h2>


### PR DESCRIPTION
For the past few days I observe frequent failures in AzurePipelines on JDK 6:

```
[INFO] Running org.jacoco.agent.rt.internal.output.FileOutputTest
[ERROR] Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.51 s <<< FAILURE! - in org.jacoco.agent.rt.internal.output.FileOutputTest
[ERROR] startup_should_throw_OverlappingFileLockException_when_execfile_is_permanently_locked(org.jacoco.agent.rt.internal.output.FileOutputTest)  Time elapsed: 0.506 s  <<< FAILURE!
java.lang.AssertionError: OverlappingFileLockException expected
	at org.jacoco.agent.rt.internal.output.FileOutputTest.startup_should_throw_OverlappingFileLockException_when_execfile_is_permanently_locked(FileOutputTest.java:103)
```

see build log for first commit in this PR

---

While

```
System.runFinalization();
System.gc();
System.runFinalization();
System.gc();
```

does not guarantee GCs and finalizations to happen, addition of it after every `out.getChannel().lock()` in tests seems to increase chances to reproduce, so that it becomes even visible also in another test on JDK versions from 6 to 10, as well as in GitHub Actions and locally on my machine:

```
[INFO] Running org.jacoco.agent.rt.internal.output.FileOutputTest
[ERROR] Tests run: 5, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.032 s <<< FAILURE! - in org.jacoco.agent.rt.internal.output.FileOutputTest
[ERROR] startup_should_throw_InterruptedIOException_when_execfile_is_locked_and_thread_is_interrupted(org.jacoco.agent.rt.internal.output.FileOutputTest)  Time elapsed: 0.019 s  <<< FAILURE!
java.lang.AssertionError: InterruptedIOException expected
	at org.jacoco.agent.rt.internal.output.FileOutputTest.startup_should_throw_InterruptedIOException_when_execfile_is_locked_and_thread_is_interrupted(FileOutputTest.java:131)

[ERROR] startup_should_throw_OverlappingFileLockException_when_execfile_is_permanently_locked(org.jacoco.agent.rt.internal.output.FileOutputTest)  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.AssertionError: OverlappingFileLockException expected
	at org.jacoco.agent.rt.internal.output.FileOutputTest.startup_should_throw_OverlappingFileLockException_when_execfile_is_permanently_locked(FileOutputTest.java:104)
```

see build logs for second commit in this PR

---

And so I suspect that these tests demonstrate http://bugs.openjdk.org/browse/JDK-8166253 which was fixed in JDK 11.

Our main code seems to be affected too - like tests it does not preserve reference on lock object:
https://github.com/jacoco/jacoco/blob/2eb248366f0eb63fd964fc7a81804b27229a6edd/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/FileOutput.java#L83
so there is a chance that another FileOutput writing to the same file within same JVM will not receive OverlappingFileLockException while first one not yet finished writing data.

Note that this does not seem to affect filesystem level lock - see build log on Windows for the second commit in this PR - it hangs (blocked on the above call) in test `startup_should_throw_InterruptedIOException_when_execfile_is_locked_and_thread_is_interrupted` because `OverlappingFileLockException` is not be observed after GC of FileLock.

---

And maybe this might be an explanation of past reports about data corruption such as https://groups.google.com/g/jacoco/c/wrKJbyJyNII/m/WIe6yrewAwAJ

Following test

```java
	@Test
	public void test() throws Exception {
		File destFile = folder.newFile("jacoco.exec");
		final AgentOptions options = new AgentOptions();
		options.setDestfile(destFile.getAbsolutePath());

		final RuntimeData runtimeData = new RuntimeData();
		runtimeData.setSessionId(new String(new char[1024]));

		Thread thread0 = new Thread() {
			@Override
			public void run() {
				for (int i = 0; i < 100; i++) {
					System.runFinalization();
					System.gc();
				}
			}
		};
		thread0.start();

		Thread thread1 = new Thread() {
			@Override
			public void run() {
				FileOutput output = new FileOutput();
				try {
					output.startup(options, runtimeData);
					output.writeExecutionData(false);
				} catch (IOException e) {
					throw new RuntimeException(e);
				}
			}
		};
		thread1.start();

		Thread thread2 = new Thread() {
			@Override
			public void run() {
				FileOutput output = new FileOutput();
				try {
					output.startup(options, runtimeData);
					output.writeExecutionData(false);
				} catch (IOException e) {
					throw new RuntimeException(e);
				}
			}
		};
		thread2.start();

		thread0.join();
		thread1.join();
		thread2.join();
		new ExecFileLoader().load(destFile);
	}
```

demonstrates such corruption:

```
java.io.UTFDataFormatException: malformed input around byte 1153
	at java.io.DataInputStream.readUTF(DataInputStream.java:634)
	at java.io.DataInputStream.readUTF(DataInputStream.java:564)
	at org.jacoco.core.data.ExecutionDataReader.readSessionInfo(ExecutionDataReader.java:138)
	at org.jacoco.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:113)
	at org.jacoco.core.data.ExecutionDataReader.read(ExecutionDataReader.java:93)
	at org.jacoco.core.tools.ExecFileLoader.load(ExecFileLoader.java:60)
	at org.jacoco.core.tools.ExecFileLoader.load(ExecFileLoader.java:74)
	at org.jacoco.agent.rt.internal.output.FileOutputTest.test(FileOutputTest.java:200)
```