### PR TITLE
Fix typo

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataWriter.java
@@ -65,7 +65,7 @@ public class ExecutionDataWriter
 	}
 
 	/**
-	 * Writes an file header to identify the stream and its protocol version.
+	 * Writes a file header to identify the stream and its protocol version.
 	 *
 	 * @throws IOException
 	 *             if the header can't be written


### PR DESCRIPTION
"a" should be used instead of "an" when the
following word doesn't start with a vowel sound.

---

[As before](https://github.com/jacoco/jacoco/pull/1799#issuecomment-2504972956) I did my best, but can't guarantee that this is the last existing typo of the same kind 😅 
