### PR TITLE
Transfer of execution data through socket should use buffered stream

### DIFF
--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/TcpConnection.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/TcpConnection.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.agent.rt.internal.output;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
@@ -43,7 +44,8 @@ class TcpConnection implements IRemoteCommandVisitor {
 	}
 
 	public void init() throws IOException {
-		this.writer = new RemoteControlWriter(socket.getOutputStream());
+		this.writer = new RemoteControlWriter(
+				new BufferedOutputStream(socket.getOutputStream()));
 		this.reader = new RemoteControlReader(socket.getInputStream());
 		this.reader.setRemoteCommandVisitor(this);
 		this.initialized = true;
@@ -107,6 +109,7 @@ class TcpConnection implements IRemoteCommandVisitor {
 			}
 		}
 		writer.sendCmdOk();
+		writer.flush();
 	}
 
 }

--- a/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/TcpConnection.java
+++ b/org.jacoco.agent.rt/src/org/jacoco/agent/rt/internal/output/TcpConnection.java
@@ -46,7 +46,10 @@ class TcpConnection implements IRemoteCommandVisitor {
 	public void init() throws IOException {
 		this.writer = new RemoteControlWriter(
 				new BufferedOutputStream(socket.getOutputStream()));
-		this.reader = new RemoteControlReader(socket.getInputStream());
+		this.reader = new RemoteControlReader(
+				// BufferedInputStream will not improve performance here
+				// while will add memory overhead because commands are short
+				socket.getInputStream());
 		this.reader.setRemoteCommandVisitor(this);
 		this.initialized = true;
 	}

--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/data/CompactDataThroughSocketBenchmark.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/data/CompactDataThroughSocketBenchmark.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.data;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+/**
+ * Benchmark for {@link CompactDataOutput} and {@link CompactDataInput} with
+ * {@link Socket} connection. {@link BenchmarkSide#SENDER} and
+ * {@link BenchmarkSide#RECEIVER} respectively.
+ *
+ * Demonstrates benefits of using {@link #bufferedSender}
+ * ({@link BufferedInputStream} over raw {@link Socket#getInputStream()}) and
+ * {@link #bufferedReceiver} ({@link BufferedOutputStream} over raw
+ * {@link Socket#getOutputStream()}).
+ *
+ * Use of buffering only on sender side is less beneficial.
+ *
+ * Use of buffering only on receiver side is neither beneficial nor harmful.
+ *
+ * This asymmetry when only one side buffered is due to difference between
+ * {@link Socket#getSendBufferSize()} and {@link Socket#getReceiveBufferSize()}.
+ *
+ * @see CompactDataOutputBenchmark
+ */
+@State(Scope.Thread)
+public class CompactDataThroughSocketBenchmark {
+
+	public enum BenchmarkSide {
+		SENDER, RECEIVER
+	}
+
+	@Param({ "SENDER", "RECEIVER" })
+	private BenchmarkSide benchmarkSide;
+
+	@Param({ "true", "false" })
+	private boolean bufferedReceiver;
+
+	@Param({ "true", "false" })
+	private boolean bufferedSender;
+
+	public enum DataType {
+		STRING, BOOLEAN_ARRAY
+	}
+
+	@Param({ "STRING", "BOOLEAN_ARRAY" })
+	public DataType dataType;
+
+	@Param({ "32", "128", "1024" })
+	private int dataSize;
+
+	private boolean[] booleanArray;
+	private String string;
+
+	interface Operation {
+		void execute() throws Exception;
+	}
+
+	private Operation operation;
+	private Socket socket;
+
+	@Setup
+	public void setup() throws Exception {
+		booleanArray = new boolean[dataSize];
+		string = new String(new char[dataSize]);
+		final ServerSocket serverSocket = new ServerSocket(0, 1);
+		new Thread() {
+			@Override
+			public void run() {
+				try {
+					final Socket socket = serverSocket.accept();
+					serverSocket.close();
+					final Operation operation = setup(socket,
+							benchmarkSide == BenchmarkSide.RECEIVER);
+					while (true) {
+						operation.execute();
+					}
+				} catch (final Exception e) {
+					// ignore
+				}
+			}
+		}.start();
+		socket = new Socket(InetAddress.getByName(null),
+				serverSocket.getLocalPort());
+		operation = setup(socket, benchmarkSide == BenchmarkSide.SENDER);
+	}
+
+	private Operation setup(final Socket socket, final boolean sender)
+			throws Exception {
+		if (sender) {
+			OutputStream outputStream = socket.getOutputStream();
+			if (bufferedSender) {
+				outputStream = new BufferedOutputStream(outputStream);
+			}
+			final CompactDataOutput output = new CompactDataOutput(
+					outputStream);
+			return new Operation() {
+				public void execute() throws Exception {
+					sendTo(output);
+				}
+			};
+		} else {
+			InputStream inputStream = socket.getInputStream();
+			if (bufferedReceiver) {
+				inputStream = new BufferedInputStream(inputStream);
+			}
+			final CompactDataInput input = new CompactDataInput(inputStream);
+			return new Operation() {
+
+				public void execute() throws Exception {
+					receiveFrom(input);
+				}
+
+			};
+		}
+	}
+
+	private void sendTo(final CompactDataOutput output) throws Exception {
+		switch (dataType) {
+		case STRING:
+			output.writeUTF(string);
+			break;
+		case BOOLEAN_ARRAY:
+			output.writeBooleanArray(booleanArray);
+			break;
+		default:
+			throw new IllegalStateException();
+		}
+	}
+
+	private void receiveFrom(final CompactDataInput input) throws Exception {
+		switch (dataType) {
+		case STRING:
+			input.readUTF();
+			break;
+		case BOOLEAN_ARRAY:
+			input.readBooleanArray();
+			break;
+		default:
+			throw new IllegalStateException();
+		}
+	}
+
+	@Benchmark
+	public void benchmark() throws Exception {
+		operation.execute();
+	}
+
+	@TearDown
+	public void tearDown() throws Exception {
+		socket.close();
+	}
+
+	public static void main(String[] args) throws Exception {
+		new Runner(new OptionsBuilder() //
+				.include(CompactDataThroughSocketBenchmark.class.getName()) //
+				.mode(Mode.AverageTime) //
+				.timeUnit(TimeUnit.MICROSECONDS) //
+				.warmupIterations(5) //
+				.warmupTime(TimeValue.seconds(1)) //
+				.measurementIterations(10) //
+				.measurementTime(TimeValue.seconds(1)) //
+				.forks(1) //
+				.build()).run();
+	}
+}

--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/data/CompactDataThroughSocketToFileBenchmark.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/data/CompactDataThroughSocketToFileBenchmark.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.data;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+/**
+ * Benchmark for {@link CompactDataOutput} and {@link CompactDataInput}
+ * connected through {@link Socket} to {@link FileOutputStream}.
+ *
+ * Demonstrates benefits of using {@link #bufferedFileWriter}
+ * ({@link BufferedOutputStream} over raw {@link FileOutputStream}),
+ * {@link #bufferedSocketReceiver} ({@link BufferedInputStream} over raw
+ * {@link Socket#getInputStream()}) and {@link #bufferedSocketSender}
+ * ({@link BufferedOutputStream} over raw {@link Socket#getOutputStream()})
+ * together.
+ *
+ * @see CompactDataOutputBenchmark
+ * @see CompactDataThroughSocketBenchmark
+ */
+@State(Scope.Thread)
+public class CompactDataThroughSocketToFileBenchmark {
+
+	@Param({ "32", "128", "1024" })
+	private int dataSize;
+
+	private boolean[] booleanArray;
+
+	private Socket socket;
+
+	@Param({ "true", "false" })
+	private boolean bufferedSocketSender;
+
+	@Param({ "true", "false" })
+	private boolean bufferedSocketReceiver;
+
+	@Param({ "true", "false" })
+	private boolean bufferedFileWriter;
+
+	private CompactDataInput input;
+	private CompactDataOutput output;
+	private FileOutputStream fileOutputStream;
+
+	@Setup
+	public void setup() throws Exception {
+		booleanArray = new boolean[dataSize];
+		final ServerSocket serverSocket = new ServerSocket(0, 1);
+		new Thread() {
+			@Override
+			public void run() {
+				try {
+					final Socket socket = serverSocket.accept();
+					serverSocket.close();
+					OutputStream outputStream = socket.getOutputStream();
+					if (bufferedSocketSender) {
+						outputStream = new BufferedOutputStream(outputStream);
+					}
+					final CompactDataOutput output = new CompactDataOutput(
+							outputStream);
+					while (true) {
+						output.writeBooleanArray(booleanArray);
+					}
+				} catch (final Exception e) {
+					// ignore
+				}
+			}
+		}.start();
+		socket = new Socket(InetAddress.getByName(null),
+				serverSocket.getLocalPort());
+
+		InputStream inputStream = socket.getInputStream();
+		if (bufferedSocketReceiver) {
+			inputStream = new BufferedInputStream(inputStream);
+		}
+		input = new CompactDataInput(inputStream);
+
+		final File file = File.createTempFile(
+				CompactDataThroughSocketToFileBenchmark.class.getName(), "out");
+		fileOutputStream = new FileOutputStream(file);
+		output = new CompactDataOutput(
+				bufferedFileWriter ? new BufferedOutputStream(fileOutputStream)
+						: fileOutputStream);
+	}
+
+	@Benchmark
+	public void benchmark() throws Exception {
+		fileOutputStream.getChannel().position(0);
+		output.writeBooleanArray(input.readBooleanArray());
+		output.flush();
+	}
+
+	@TearDown
+	public void tearDown() throws Exception {
+		socket.close();
+	}
+
+	public static void main(String[] args) throws Exception {
+		new Runner(new OptionsBuilder() //
+				.include(
+						CompactDataThroughSocketToFileBenchmark.class.getName()) //
+				.mode(Mode.AverageTime) //
+				.timeUnit(TimeUnit.MICROSECONDS) //
+				.warmupIterations(5) //
+				.warmupTime(TimeValue.seconds(1)) //
+				.measurementIterations(10) //
+				.measurementTime(TimeValue.seconds(1)) //
+				.forks(1) //
+				.build()).run();
+	}
+}

--- a/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlReader.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlReader.java
@@ -27,6 +27,15 @@ public class RemoteControlReader extends ExecutionDataReader {
 	/**
 	 * Creates a new reader based on the given input stream.
 	 *
+	 * Depending on the nature of the underlying stream input should be buffered
+	 * as most data is read in single bytes.
+	 *
+	 * Should be buffered when used to read execution data from
+	 * {@link java.net.Socket#getInputStream()}.
+	 *
+	 * Should not be buffered when used only for commands because they are short
+	 * and this will merely add memory overhead.
+	 *
 	 * @param input
 	 *            input stream to read commands from
 	 * @throws IOException

--- a/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlWriter.java
+++ b/org.jacoco.core/src/org/jacoco/core/runtime/RemoteControlWriter.java
@@ -32,6 +32,15 @@ public class RemoteControlWriter extends ExecutionDataWriter
 	/**
 	 * Creates a new writer based on the given output stream.
 	 *
+	 * Depending on the nature of the underlying stream output should be
+	 * buffered as most data is written in single bytes.
+	 *
+	 * Should be buffered when used to write execution data to
+	 * {@link java.net.Socket#getOutputStream()}.
+	 *
+	 * Should not be buffered when used only for commands because they are short
+	 * and this will merely add memory overhead.
+	 *
 	 * @param output
 	 *            stream to write commands to
 	 * @throws IOException

--- a/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.core.tools;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.InetAddress;
@@ -118,7 +119,7 @@ public class ExecDumpClient {
 			final RemoteControlWriter remoteWriter = new RemoteControlWriter(
 					socket.getOutputStream());
 			final RemoteControlReader remoteReader = new RemoteControlReader(
-					socket.getInputStream());
+					new BufferedInputStream(socket.getInputStream()));
 			remoteReader.setSessionInfoVisitor(loader.getSessionInfoStore());
 			remoteReader
 					.setExecutionDataVisitor(loader.getExecutionDataStore());

--- a/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
@@ -117,6 +117,8 @@ public class ExecDumpClient {
 		final Socket socket = tryConnect(address, port);
 		try {
 			final RemoteControlWriter remoteWriter = new RemoteControlWriter(
+					// BufferedOutputStream will not improve performance here
+					// while will add memory overhead because commands are short
 					socket.getOutputStream());
 			final RemoteControlReader remoteReader = new RemoteControlReader(
 					new BufferedInputStream(socket.getInputStream()));

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -48,11 +48,12 @@
   <li>Improved performance of Kotlin files analysis by parsing SMAPs only once
       per class
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/2114">#2114</a>).</li>
-  <li>For better performance Agent output methods <code>tcpclient</code> and
-      <code>tcpserver</code> use <code>BufferedOutputStream</code> to write data.
-      Maven plugin goal, Ant task, CLI command and <code>ExecDumpClient</code> API
-      method <code>dump</code> use <code>BufferedInputStream</code> to read data.
-      Third-party integrations should do the same to benefit from this change in Agent
+  <li>For better performance agent output methods <code>tcpclient</code> and
+      <code>tcpserver</code> use <code>BufferedOutputStream</code> to write
+      execution data to socket. Maven plugin, Ant tasks, CLI, API usage examples,
+      and <code>ExecDumpClient</code> API use <code>BufferedInputStream</code>
+      to read execution data from socket. Third-party integrations should do
+      the same to benefit from this change in agent
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/2089">#2089</a>).</li>
 </ul>
 

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -48,6 +48,12 @@
   <li>Improved performance of Kotlin files analysis by parsing SMAPs only once
       per class
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/2114">#2114</a>).</li>
+  <li>For better performance Agent output methods <code>tcpclient</code> and
+      <code>tcpserver</code> use <code>BufferedOutputStream</code> to write data.
+      Maven plugin goal, Ant task, CLI command and <code>ExecDumpClient</code> API
+      method <code>dump</code> use <code>BufferedInputStream</code> to read data.
+      Third-party integrations should do the same to benefit from this change in Agent
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/2089">#2089</a>).</li>
 </ul>
 
 <h3>Fixed bugs</h3>

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecDump.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecDump.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.examples;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -60,7 +61,8 @@ public final class ExecDump {
 		out.println("CLASS ID         HITS/PROBES   CLASS NAME");
 
 		final FileInputStream in = new FileInputStream(file);
-		final ExecutionDataReader reader = new ExecutionDataReader(in);
+		final ExecutionDataReader reader = new ExecutionDataReader(
+				new BufferedInputStream(in));
 		reader.setSessionInfoVisitor(new ISessionInfoVisitor() {
 			public void visitSessionInfo(final SessionInfo info) {
 				out.printf("Session \"%s\": %s - %s%n", info.getId(),

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataClient.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataClient.java
@@ -13,6 +13,7 @@
 package org.jacoco.examples;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -44,7 +45,7 @@ public final class ExecutionDataClient {
 	public static void main(final String[] args) throws IOException {
 		final FileOutputStream localFile = new FileOutputStream(DESTFILE);
 		final ExecutionDataWriter localWriter = new ExecutionDataWriter(
-				localFile);
+				new BufferedOutputStream(localFile));
 
 		// Open a socket to the coverage agent:
 		final Socket socket = new Socket(InetAddress.getByName(ADDRESS), PORT);
@@ -64,6 +65,7 @@ public final class ExecutionDataClient {
 		}
 
 		socket.close();
+		localWriter.flush();
 		localFile.close();
 	}
 

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataClient.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataClient.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.examples;
 
+import java.io.BufferedInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -48,9 +49,11 @@ public final class ExecutionDataClient {
 		// Open a socket to the coverage agent:
 		final Socket socket = new Socket(InetAddress.getByName(ADDRESS), PORT);
 		final RemoteControlWriter writer = new RemoteControlWriter(
+				// BufferedOutputStream will not improve performance here
+				// while will add memory overhead because commands are short
 				socket.getOutputStream());
 		final RemoteControlReader reader = new RemoteControlReader(
-				socket.getInputStream());
+				new BufferedInputStream(socket.getInputStream()));
 		reader.setSessionInfoVisitor(localWriter);
 		reader.setExecutionDataVisitor(localWriter);
 

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataServer.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataServer.java
@@ -13,6 +13,7 @@
 package org.jacoco.examples;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -48,7 +49,7 @@ public final class ExecutionDataServer {
 	 */
 	public static void main(final String[] args) throws IOException {
 		final ExecutionDataWriter fileWriter = new ExecutionDataWriter(
-				new FileOutputStream(DESTFILE));
+				new BufferedOutputStream(new FileOutputStream(DESTFILE)));
 		final ServerSocket server = new ServerSocket(PORT, 0,
 				InetAddress.getByName(ADDRESS));
 		while (true) {

--- a/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataServer.java
+++ b/org.jacoco.examples/src/org/jacoco/examples/ExecutionDataServer.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.examples;
 
+import java.io.BufferedInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -71,9 +72,13 @@ public final class ExecutionDataServer {
 			this.fileWriter = fileWriter;
 
 			// Just send a valid header:
-			new RemoteControlWriter(socket.getOutputStream());
+			new RemoteControlWriter(
+					// BufferedOutputStream will not improve performance here
+					// while will add memory overhead because header is short
+					socket.getOutputStream());
 
-			reader = new RemoteControlReader(socket.getInputStream());
+			reader = new RemoteControlReader(
+					new BufferedInputStream(socket.getInputStream()));
 			reader.setSessionInfoVisitor(this);
 			reader.setExecutionDataVisitor(this);
 		}


### PR DESCRIPTION
While working on https://github.com/jacoco/jacoco/pull/2073 I noticed that

* `socket.getOutputStream()` is not wrapped into `BufferedOutputStream` when writing execution data
* `socket.getInputStream()` is not wrapped into `BufferedInputStream` when reading execution data

Seems that this always been like that since version `0.4.0` that 16 years ago introduced remote dumps via TCP/IP connections.

Corresponding change for EclEmma - https://github.com/eclipse-eclemma/eclemma/pull/130

---

For the record here is results from my machine of benchmark added in this PR when executed on JDK 25:

```text
Benchmark                                    (benchmarkSide)  (bufferedReceiver)  (bufferedSender)  (dataSize)     (dataType)  Mode  Cnt   Score   Error  Units
CompactDataThroughSocketBenchmark.benchmark           SENDER                true              true          32         STRING  avgt   10   0.052 ± 0.003  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true              true         128         STRING  avgt   10   0.147 ± 0.013  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true              true        1024         STRING  avgt   10   1.286 ± 0.101  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true              true          32  BOOLEAN_ARRAY  avgt   10   0.031 ± 0.001  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true              true         128  BOOLEAN_ARRAY  avgt   10   0.119 ± 0.004  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true              true        1024  BOOLEAN_ARRAY  avgt   10   0.845 ± 0.041  us/op

CompactDataThroughSocketBenchmark.benchmark           SENDER                true             false          32         STRING  avgt   10   0.729 ± 0.009  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true             false         128         STRING  avgt   10   0.943 ± 0.048  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true             false        1024         STRING  avgt   10   1.713 ± 0.025  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true             false          32  BOOLEAN_ARRAY  avgt   10   3.275 ± 0.045  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true             false         128  BOOLEAN_ARRAY  avgt   10  11.783 ± 0.212  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER                true             false        1024  BOOLEAN_ARRAY  avgt   10  85.378 ± 1.166  us/op

CompactDataThroughSocketBenchmark.benchmark           SENDER               false              true          32         STRING  avgt   10   0.703 ± 0.010  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false              true         128         STRING  avgt   10   0.843 ± 0.011  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false              true        1024         STRING  avgt   10   1.863 ± 0.011  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false              true          32  BOOLEAN_ARRAY  avgt   10   1.496 ± 0.022  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false              true         128  BOOLEAN_ARRAY  avgt   10   5.231 ± 0.107  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false              true        1024  BOOLEAN_ARRAY  avgt   10  38.525 ± 0.655  us/op

CompactDataThroughSocketBenchmark.benchmark           SENDER               false             false          32         STRING  avgt   10   0.891 ± 0.042  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false             false         128         STRING  avgt   10   1.077 ± 0.073  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false             false        1024         STRING  avgt   10   1.672 ± 0.074  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false             false          32  BOOLEAN_ARRAY  avgt   10   3.434 ± 0.039  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false             false         128  BOOLEAN_ARRAY  avgt   10  11.991 ± 0.210  us/op
CompactDataThroughSocketBenchmark.benchmark           SENDER               false             false        1024  BOOLEAN_ARRAY  avgt   10  91.538 ± 7.731  us/op

CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true              true          32         STRING  avgt   10   0.054 ± 0.002  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true              true         128         STRING  avgt   10   0.143 ± 0.002  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true              true        1024         STRING  avgt   10   1.285 ± 0.222  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true              true          32  BOOLEAN_ARRAY  avgt   10   0.029 ± 0.002  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true              true         128  BOOLEAN_ARRAY  avgt   10   0.115 ± 0.006  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true              true        1024  BOOLEAN_ARRAY  avgt   10   0.825 ± 0.022  us/op

CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true             false          32         STRING  avgt   10   0.738 ± 0.023  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true             false         128         STRING  avgt   10   0.882 ± 0.029  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true             false        1024         STRING  avgt   10   1.698 ± 0.037  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true             false          32  BOOLEAN_ARRAY  avgt   10   3.181 ± 0.077  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true             false         128  BOOLEAN_ARRAY  avgt   10  11.605 ± 0.216  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER                true             false        1024  BOOLEAN_ARRAY  avgt   10  84.648 ± 1.607  us/op

CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false              true          32         STRING  avgt   10   0.697 ± 0.028  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false              true         128         STRING  avgt   10   0.810 ± 0.017  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false              true        1024         STRING  avgt   10   1.729 ± 0.109  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false              true          32  BOOLEAN_ARRAY  avgt   10   1.526 ± 0.055  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false              true         128  BOOLEAN_ARRAY  avgt   10   5.251 ± 0.229  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false              true        1024  BOOLEAN_ARRAY  avgt   10  37.466 ± 0.832  us/op

CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false             false          32         STRING  avgt   10   0.889 ± 0.038  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false             false         128         STRING  avgt   10   1.031 ± 0.067  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false             false        1024         STRING  avgt   10   1.768 ± 0.116  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false             false          32  BOOLEAN_ARRAY  avgt   10   3.281 ± 0.147  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false             false         128  BOOLEAN_ARRAY  avgt   10  12.009 ± 0.269  us/op
CompactDataThroughSocketBenchmark.benchmark         RECEIVER               false             false        1024  BOOLEAN_ARRAY  avgt   10  86.965 ± 3.639  us/op
```

---

- [x] apply suggestions from code review
- [x] update examples
- [x] update javadocs of `RemoteControlWriter` and `RemoteControlReader` constructors
- [x] update changelog