### PR TITLE
Parent POM of module `org.jacoco.benchmarks` should be `org.jacoco.tests`

### DIFF
--- a/org.jacoco.benchmarks/pom.xml
+++ b/org.jacoco.benchmarks/pom.xml
@@ -15,9 +15,9 @@
 
   <parent>
     <groupId>org.jacoco</groupId>
-    <artifactId>org.jacoco.build</artifactId>
+    <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.15-SNAPSHOT</version>
-    <relativePath>../org.jacoco.build</relativePath>
+    <relativePath>../org.jacoco.tests</relativePath>
   </parent>
 
   <artifactId>org.jacoco.benchmarks</artifactId>


### PR DESCRIPTION
* To prevent its deployment to Maven release and snapshot repositories.
* To disable unnecessary generation of javadocs and so silence doclint warnings.

This was overlooked in d91c6d8de48a64c2afc62182337e8179faadab83.