### PR TITLE
Use `org.junit.Assert.assertArrayEquals` instead of custom implementation

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.jacoco.core.data;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -23,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
 import java.util.Random;
 
 import org.junit.Before;
@@ -316,11 +316,6 @@ public class ExecutionDataReaderWriterTest {
 			data[j] = random.nextBoolean();
 		}
 		return data;
-	}
-
-	private void assertArrayEquals(final boolean[] expected,
-			final boolean[] actual) {
-		assertTrue(Arrays.equals(expected, actual));
 	}
 
 	protected ExecutionDataWriter createWriter(OutputStream out)


### PR DESCRIPTION
At time of last modification of custom implementation -https://github.com/jacoco/jacoco/commit/c867b24b5db477588ceae7128db83a8f4467d161
JUnit 4.8.2 was used https://github.com/jacoco/jacoco/blob/c867b24b5db477588ceae7128db83a8f4467d161/org.jacoco.build/pom.xml#L137
That had no `assertArrayEquals` for `boolean[]` - https://github.com/junit-team/junit4/blob/r4.8.2/src/main/java/org/junit/Assert.java
That was added in JUnit 4.12 - https://github.com/junit-team/junit4/pull/632