### PR TITLE
Use try-catch idiom for testing exceptions

### DIFF
--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/MockServerSocketTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/MockServerSocketTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -80,7 +81,7 @@ public class MockServerSocketTest extends ExecutorTestBase {
 		assertTrue(serverSocket.isClosed());
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testCloseWhileAccept() throws Throwable {
 		final Future<Socket> f = executor.submit(new Callable<Socket>() {
 			public Socket call() throws Exception {
@@ -90,9 +91,14 @@ public class MockServerSocketTest extends ExecutorTestBase {
 		assertBlocks(f);
 		serverSocket.close();
 		try {
-			f.get();
-		} catch (ExecutionException e) {
-			throw e.getCause();
+			try {
+				f.get();
+			} catch (final ExecutionException e) {
+				throw e.getCause();
+			}
+			fail("SocketException expected");
+		} catch (final SocketException e) {
+			// expected
 		}
 	}
 
@@ -110,10 +116,15 @@ public class MockServerSocketTest extends ExecutorTestBase {
 		assertEquals(123, socket.getInputStream().read());
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testAcceptOnClosedServerSocket() throws Exception {
 		serverSocket.close();
-		serverSocket.accept();
+		try {
+			serverSocket.accept();
+			fail("SocketException expected");
+		} catch (final SocketException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/MockSocketConnectionTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/MockSocketConnectionTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -135,8 +134,8 @@ public class MockSocketConnectionTest extends ExecutorTestBase {
 		a.close();
 		try {
 			a.getOutputStream();
-			fail("IOException expected");
-		} catch (final IOException e) {
+			fail("SocketException expected");
+		} catch (final SocketException e) {
 			// expected
 		}
 	}
@@ -147,8 +146,8 @@ public class MockSocketConnectionTest extends ExecutorTestBase {
 		a.close();
 		try {
 			out.write(123);
-			fail("IOException expected");
-		} catch (final IOException e) {
+			fail("SocketException expected");
+		} catch (final SocketException e) {
 			// expected
 		}
 	}

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/MockSocketConnectionTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/MockSocketConnectionTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -81,20 +82,30 @@ public class MockSocketConnectionTest extends ExecutorTestBase {
 		assertTrue(a.isClosed());
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testGetInputStreamOnClosedSocket() throws Exception {
 		a.close();
-		a.getInputStream();
+		try {
+			a.getInputStream();
+			fail("SocketException expected");
+		} catch (final SocketException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testReadOnClosedSocket() throws Exception {
 		final InputStream in = a.getInputStream();
 		a.close();
-		in.read();
+		try {
+			in.read();
+			fail("SocketException expected");
+		} catch (final SocketException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testReadOnClosedSocketAsync() throws Throwable {
 		final InputStream in = a.getInputStream();
 		final Future<Void> f = executor.submit(new Callable<Void>() {
@@ -108,23 +119,38 @@ public class MockSocketConnectionTest extends ExecutorTestBase {
 
 		a.close();
 		try {
-			f.get();
-		} catch (ExecutionException e) {
-			throw e.getCause();
+			try {
+				f.get();
+			} catch (final ExecutionException e) {
+				throw e.getCause();
+			}
+			fail("SocketException expected");
+		} catch (final SocketException e) {
+			// expected
 		}
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testGetOutputStreamOnClosedSocket() throws Exception {
 		a.close();
-		a.getOutputStream();
+		try {
+			a.getOutputStream();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = SocketException.class)
+	@Test
 	public void testWriteOnClosedSocket() throws Exception {
 		final OutputStream out = a.getOutputStream();
 		a.close();
-		out.write(123);
+		try {
+			out.write(123);
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpConnectionTest.java
+++ b/org.jacoco.agent.rt.test/src/org/jacoco/agent/rt/internal/output/TcpConnectionTest.java
@@ -15,6 +15,7 @@ package org.jacoco.agent.rt.internal.output;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -49,7 +50,7 @@ public class TcpConnectionTest extends ExecutorTestBase {
 		data = new RuntimeData();
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testInvalidHeader() throws Exception {
 		final OutputStream remoteOut = mockConnection.getSocketB()
 				.getOutputStream();
@@ -59,10 +60,15 @@ public class TcpConnectionTest extends ExecutorTestBase {
 		final TcpConnection connection = new TcpConnection(
 				mockConnection.getSocketA(), data);
 		connection.init();
-		connection.run();
+		try {
+			connection.run();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testInvalidContent() throws Exception {
 		final OutputStream remoteOut = mockConnection.getSocketB()
 				.getOutputStream();
@@ -71,7 +77,12 @@ public class TcpConnectionTest extends ExecutorTestBase {
 				data);
 		con.init();
 		remoteOut.write(123);
-		con.run();
+		try {
+			con.run();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	/**

--- a/org.jacoco.agent.test/src/org/jacoco/agent/AgentJarTest.java
+++ b/org.jacoco.agent.test/src/org/jacoco/agent/AgentJarTest.java
@@ -14,6 +14,7 @@ package org.jacoco.agent;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -59,12 +60,17 @@ public class AgentJarTest {
 		assertAgentContents(new FileInputStream(file));
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testExtractToNegative() throws IOException {
 		file = File.createTempFile("folder", null);
 		file.delete();
 		file.mkdirs();
-		AgentJar.extractTo(file);
+		try {
+			AgentJar.extractTo(file);
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/analysis/CoverageBuilderTest.java
@@ -14,6 +14,7 @@ package org.jacoco.core.analysis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -113,7 +114,7 @@ public class CoverageBuilderTest {
 		assertEquals(1, coverageBuilder.getClasses().size());
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testDuplicateClassNameDifferent() {
 		MethodCoverageImpl method = new MethodCoverageImpl("doit", "()V", null);
 		method.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
@@ -122,7 +123,12 @@ public class CoverageBuilderTest {
 		// Add class with different id must fail:
 		method = new MethodCoverageImpl("doit", "()V", null);
 		method.increment(CounterImpl.COUNTER_1_0, CounterImpl.COUNTER_0_0, 3);
-		addClass(345L, false, "Sample", null, method);
+		try {
+			addClass(345L, false, "Sample", null, method);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -158,6 +158,9 @@ public class ExecutionDataReaderWriterTest {
 			fail("IncompatibleExecDataVersionException expected");
 		} catch (final IncompatibleExecDataVersionException e) {
 			// expected
+			assertEquals(version, e.getActualVersion());
+			assertEquals(ExecutionDataWriter.FORMAT_VERSION,
+					e.getExpectedVersion());
 		}
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataReaderWriterTest.java
@@ -128,16 +128,22 @@ public class ExecutionDataReaderWriterTest {
 		assertFalse(createReader().read());
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testInvalidMagicNumber() throws IOException {
 		buffer = new ByteArrayOutputStream();
 		buffer.write(ExecutionDataWriter.BLOCK_HEADER);
 		buffer.write(0x12);
 		buffer.write(0x34);
-		createReader().read();
+		final ExecutionDataReader reader = createReader();
+		try {
+			reader.read();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IncompatibleExecDataVersionException.class)
+	@Test
 	public void testInvalidVersion() throws IOException {
 		buffer = new ByteArrayOutputStream();
 		buffer.write(ExecutionDataWriter.BLOCK_HEADER);
@@ -146,31 +152,55 @@ public class ExecutionDataReaderWriterTest {
 		final char version = (char) (ExecutionDataWriter.FORMAT_VERSION - 1);
 		buffer.write(version >> 8);
 		buffer.write(version & 0xFF);
-		createReader().read();
+		final ExecutionDataReader reader = createReader();
+		try {
+			reader.read();
+			fail("IncompatibleExecDataVersionException expected");
+		} catch (final IncompatibleExecDataVersionException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testMissingHeader() throws IOException {
 		buffer.reset();
 		writer.visitClassExecution(
 				new ExecutionData(Long.MIN_VALUE, "Sample", createData(8)));
-		createReaderWithVisitors().read();
+		final ExecutionDataReader readerWithVisitors = createReaderWithVisitors();
+		try {
+			readerWithVisitors.read();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testUnknownBlock() throws IOException {
 		buffer.write(0xff);
-		createReader().read();
+		final ExecutionDataReader reader = createReader();
+		try {
+			reader.read();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = EOFException.class)
+	@Test
 	public void testTruncatedFile() throws IOException {
 		writer.visitClassExecution(
 				new ExecutionData(Long.MIN_VALUE, "Sample", createData(8)));
 		final byte[] content = buffer.toByteArray();
 		buffer.reset();
 		buffer.write(content, 0, content.length - 1);
-		createReaderWithVisitors().read();
+		final ExecutionDataReader readerWithVisitors = createReaderWithVisitors();
+		try {
+			readerWithVisitors.read();
+			fail("EOFException expected");
+		} catch (final EOFException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -181,10 +211,16 @@ public class ExecutionDataReaderWriterTest {
 
 	// === Session Info ===
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testNoSessionInfoVisitor() throws IOException {
 		writer.visitSessionInfo(new SessionInfo("x", 0, 1));
-		createReader().read();
+		final ExecutionDataReader reader = createReader();
+		try {
+			reader.read();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -198,7 +234,7 @@ public class ExecutionDataReaderWriterTest {
 		assertEquals(3444234223498879234L, sessionInfo.getDumpTimeStamp());
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testSessionInfoIOException() throws IOException {
 		final boolean[] broken = new boolean[1];
 		final ExecutionDataWriter writer = createWriter(new OutputStream() {
@@ -210,16 +246,28 @@ public class ExecutionDataReaderWriterTest {
 			}
 		});
 		broken[0] = true;
-		writer.visitSessionInfo(new SessionInfo("X", 0, 0));
+		final SessionInfo sessionInfo = new SessionInfo("X", 0, 0);
+		try {
+			writer.visitSessionInfo(sessionInfo);
+			fail("RuntimeException expected");
+		} catch (final RuntimeException e) {
+			// expected
+		}
 	}
 
 	// === Execution Data ===
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testNoExecutionDataVisitor() throws IOException {
 		writer.visitClassExecution(
 				new ExecutionData(Long.MIN_VALUE, "Sample", createData(8)));
-		createReader().read();
+		final ExecutionDataReader reader = createReader();
+		try {
+			reader.read();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -283,7 +331,7 @@ public class ExecutionDataReaderWriterTest {
 		assertArrayEquals(data, store.get(123).getProbes());
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testExecutionDataIOException() throws IOException {
 		final boolean[] broken = new boolean[1];
 		final ExecutionDataWriter writer = createWriter(new OutputStream() {
@@ -295,8 +343,14 @@ public class ExecutionDataReaderWriterTest {
 			}
 		});
 		broken[0] = true;
-		writer.visitClassExecution(
-				new ExecutionData(3, "Sample", createData(1)));
+		final ExecutionData executionData = new ExecutionData(3, "Sample",
+				createData(1));
+		try {
+			writer.visitClassExecution(executionData);
+			fail("RuntimeException expected");
+		} catch (final RuntimeException e) {
+			// expected
+		}
 	}
 
 	private ExecutionDataReader createReaderWithVisitors() throws IOException {

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,25 +117,44 @@ public class ExecutionDataStoreTest implements IExecutionDataVisitor {
 		assertTrue(store.contains("Sample"));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testGetNegative1() {
 		final boolean[] data = new boolean[] { false, false, true };
 		store.put(new ExecutionData(1000, "Sample", data));
-		store.get(Long.valueOf(1000), "Other", 3);
+		try {
+			store.get(Long.valueOf(1000), "Other", 3);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testGetNegative2() {
 		final boolean[] data = new boolean[] { false, false, true };
 		store.put(new ExecutionData(1000, "Sample", data));
-		store.get(Long.valueOf(1000), "Sample", 4);
+		try {
+			store.get(Long.valueOf(1000), "Sample", 4);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testPutNegative() {
 		final boolean[] data = new boolean[0];
-		store.put(new ExecutionData(1000, "Sample1", data));
-		store.put(new ExecutionData(1000, "Sample2", data));
+		final ExecutionData executionData1 = new ExecutionData(1000, "Sample1",
+				data);
+		store.put(executionData1);
+		final ExecutionData executionData2 = new ExecutionData(1000, "Sample2",
+				data);
+		try {
+			store.put(executionData2);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -151,12 +171,21 @@ public class ExecutionDataStoreTest implements IExecutionDataVisitor {
 		assertTrue(result[3]);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testMergeNegative() {
 		final boolean[] data1 = new boolean[] { false, false };
-		store.visitClassExecution(new ExecutionData(1000, "Sample", data1));
+		final ExecutionData executionData1 = new ExecutionData(1000, "Sample",
+				data1);
+		store.visitClassExecution(executionData1);
 		final boolean[] data2 = new boolean[] { false, false, false };
-		store.visitClassExecution(new ExecutionData(1000, "Sample", data2));
+		final ExecutionData executionData2 = new ExecutionData(1000, "Sample",
+				data2);
+		try {
+			store.visitClassExecution(executionData2);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -119,25 +120,40 @@ public class ExecutionDataTest {
 		a.assertCompatibility(5, "Example", 1);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testAssertCompatibilityNegative1() {
 		final ExecutionData a = new ExecutionData(5, "Example",
 				new boolean[] { true });
-		a.assertCompatibility(55, "Example", 1);
+		try {
+			a.assertCompatibility(55, "Example", 1);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testAssertCompatibilityNegative2() {
 		final ExecutionData a = new ExecutionData(5, "Example",
 				new boolean[] { true });
-		a.assertCompatibility(5, "Exxxample", 1);
+		try {
+			a.assertCompatibility(5, "Exxxample", 1);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testAssertCompatibilityNegative3() {
 		final ExecutionData a = new ExecutionData(5, "Example",
 				new boolean[] { true });
-		a.assertCompatibility(5, "Example", 3);
+		try {
+			a.assertCompatibility(5, "Example", 3);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/data/SessionInfoTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/SessionInfoTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -21,9 +22,14 @@ import org.junit.Test;
  */
 public class SessionInfoTest {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testNullId() {
-		new SessionInfo(null, 1, 2);
+		try {
+			new SessionInfo(null, 1, 2);
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/ClassAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/ClassAnalyzerTest.java
@@ -41,18 +41,28 @@ public class ClassAnalyzerTest {
 				"java/lang/Object", null);
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void should_throw_IllegalStateException_when_class_is_instrumented_with_data_field() {
-		analyzer.visitField(InstrSupport.DATAFIELD_ACC,
-				InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC, null,
-				null);
+		try {
+			analyzer.visitField(InstrSupport.DATAFIELD_ACC,
+					InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC,
+					null, null);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void should_throw_IllegalStateException_when_class_is_instrumented_with_init_method() {
-		analyzer.visitMethod(InstrSupport.INITMETHOD_ACC,
-				InstrSupport.INITMETHOD_NAME, InstrSupport.INITMETHOD_DESC,
-				null, null);
+		try {
+			analyzer.visitMethod(InstrSupport.INITMETHOD_ACC,
+					InstrSupport.INITMETHOD_NAME, InstrSupport.INITMETHOD_DESC,
+					null, null);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	/**

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/LabelFlowAnalyzerTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.objectweb.asm.Opcodes.*;
 
 import org.jacoco.core.data.ExecutionDataWriter;
@@ -280,9 +281,15 @@ public class LabelFlowAnalyzerTest {
 		assertFalse(analyzer.first);
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testVisitVarInsnNegative() {
-		analyzer.visitVarInsn(RET, 0);
+		try {
+			analyzer.visitVarInsn(RET, 0);
+			fail("AssertionError expected");
+		} catch (final AssertionError e) {
+			// expected
+			assertEquals("Subroutines not supported.", e.getMessage());
+		}
 	}
 
 	@Test
@@ -368,9 +375,15 @@ public class LabelFlowAnalyzerTest {
 		assertFalse(analyzer.first);
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testVisitJumpInsnNegative() {
-		analyzer.visitJumpInsn(JSR, label);
+		try {
+			analyzer.visitJumpInsn(JSR, label);
+			fail("AssertionError expected");
+		} catch (final AssertionError e) {
+			// expected
+			assertEquals("Subroutines not supported.", e.getMessage());
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassInstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ClassInstrumenterTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.internal.instr;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,18 +34,28 @@ public class ClassInstrumenterTest implements IProbeArrayStrategy {
 				});
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testInstrumentInstrumentedClass1() {
-		instrumenter.visitField(InstrSupport.DATAFIELD_ACC,
-				InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC, null,
-				null);
+		try {
+			instrumenter.visitField(InstrSupport.DATAFIELD_ACC,
+					InstrSupport.DATAFIELD_NAME, InstrSupport.DATAFIELD_DESC,
+					null, null);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testInstrumentInstrumentedClass2() {
-		instrumenter.visitMethod(InstrSupport.INITMETHOD_ACC,
-				InstrSupport.INITMETHOD_NAME, InstrSupport.INITMETHOD_DESC,
-				null, null);
+		try {
+			instrumenter.visitMethod(InstrSupport.INITMETHOD_ACC,
+					InstrSupport.INITMETHOD_NAME, InstrSupport.INITMETHOD_DESC,
+					null, null);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/MethodInstrumenterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/MethodInstrumenterTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.internal.instr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.jacoco.core.instr.MethodRecorder;
 import org.jacoco.core.internal.flow.IFrame;
@@ -166,9 +167,14 @@ public class MethodInstrumenterTest {
 		testVisitJumpInsnWithProbe(Opcodes.IFNONNULL, Opcodes.IFNULL);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testVisitJumpInsnWithProbe_InvalidOpcode() {
-		testVisitJumpInsnWithProbe(Opcodes.NOP, Opcodes.NOP);
+		try {
+			testVisitJumpInsnWithProbe(Opcodes.NOP, Opcodes.NOP);
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
 	private void testVisitJumpInsnWithProbe(int opcodeOrig, int opcodeInstr) {

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/NoneProbeArrayStrategyTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/NoneProbeArrayStrategyTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.internal.instr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,9 +31,14 @@ public class NoneProbeArrayStrategyTest {
 		strategy = new NoneProbeArrayStrategy();
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void storeInstance_should_throw_UnsupportedOperationException() {
-		strategy.storeInstance(null, false, 0);
+		try {
+			strategy.storeInstance(null, false, 0);
+			fail("UnsupportedOperationException expected");
+		} catch (final UnsupportedOperationException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeArrayStrategyFactoryTest.java
@@ -140,11 +140,16 @@ public class ProbeArrayStrategyFactoryTest {
 		assertNoInitMethod();
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testEmptyInterface7StoreInstance() {
 		IProbeArrayStrategy strategy = test(Opcodes.V1_7, Opcodes.ACC_INTERFACE,
 				false, false, false);
-		strategy.storeInstance(null, false, 0);
+		try {
+			strategy.storeInstance(null, false, 0);
+			fail("UnsupportedOperationException expected");
+		} catch (final UnsupportedOperationException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -170,11 +175,16 @@ public class ProbeArrayStrategyFactoryTest {
 		assertNoInitMethod();
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testEmptyInterface8StoreInstance() {
 		final IProbeArrayStrategy strategy = test(Opcodes.V1_8,
 				Opcodes.ACC_INTERFACE, false, false, false);
-		strategy.storeInstance(null, false, 0);
+		try {
+			strategy.storeInstance(null, false, 0);
+			fail("UnsupportedOperationException expected");
+		} catch (final UnsupportedOperationException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/instr/ProbeInserterTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.internal.instr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.jacoco.core.instr.MethodRecorder;
 import org.junit.After;
@@ -366,11 +367,16 @@ public class ProbeInserterTest {
 		}, 0, new Object[] {});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void visitFrame_must_only_support_resolved_frames() {
 		ProbeInserter pi = new ProbeInserter(0, "m", "()V", actualVisitor,
 				arrayStrategy);
-		pi.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+		try {
+			pi.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/AgentOptionsTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.Properties;
@@ -303,15 +304,25 @@ public class AgentOptionsTest {
 		assertEquals(AgentOptions.OutputMode.tcpclient, options.getOutput());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidOutput1() {
-		new AgentOptions("output=foo");
+		try {
+			new AgentOptions("output=foo");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidOutput2() {
 		AgentOptions options = new AgentOptions();
-		options.setOutput("foo");
+		try {
+			options.setOutput("foo");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -327,15 +338,25 @@ public class AgentOptionsTest {
 		assertEquals(1234, options.getPort());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testParseInvalidPort() {
-		new AgentOptions("port=xxx");
+		try {
+			new AgentOptions("port=xxx");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testSetNegativePort() {
 		AgentOptions options = new AgentOptions();
-		options.setPort(-1234);
+		try {
+			options.setPort(-1234);
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -359,19 +380,34 @@ public class AgentOptionsTest {
 		assertEquals("destfile=test.exec,append=false", options.toString());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidOptionFormat() {
-		new AgentOptions("destfile");
+		try {
+			new AgentOptions("destfile");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidOptionKey() {
-		new AgentOptions("destfile=test.exec,Some-thing_1=true");
+		try {
+			new AgentOptions("destfile=test.exec,Some-thing_1=true");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidPortOptionValue() {
-		new AgentOptions("port=-1234");
+		try {
+			new AgentOptions("port=-1234");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/ModifiedSystemClassRuntimeTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/ModifiedSystemClassRuntimeTest.java
@@ -40,10 +40,15 @@ public class ModifiedSystemClassRuntimeTest extends RuntimeTestBase {
 				ModifiedSystemClassRuntimeTest.class, "accessField");
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void testCreateForNegative() throws Exception {
 		Instrumentation inst = newInstrumentationMock();
-		ModifiedSystemClassRuntime.createFor(inst, TARGET_CLASS_NAME);
+		try {
+			ModifiedSystemClassRuntime.createFor(inst, TARGET_CLASS_NAME);
+			fail("RuntimeException expected");
+		} catch (final RuntimeException e) {
+			// expected
+		}
 	}
 
 	/** This static member emulate the instrumented system class. */

--- a/org.jacoco.core.test/src/org/jacoco/core/runtime/RemoteControlReaderWriterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/runtime/RemoteControlReaderWriterTest.java
@@ -15,6 +15,7 @@ package org.jacoco.core.runtime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -43,11 +44,16 @@ public class RemoteControlReaderWriterTest
 		writer = createWriter(buffer);
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testNoRemoteCommandVisitor() throws IOException {
 		writer.visitDumpCommand(false, false);
 		final RemoteControlReader reader = createReader();
-		reader.read();
+		try {
+			reader.read();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/tools/ExecFileLoaderTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/tools/ExecFileLoaderTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.tools;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,14 +70,19 @@ public class ExecFileLoaderTest {
 		assertLoaderContents("a", "bb");
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testLoadBrokenContent() throws IOException {
 		final File file = new File(sourceFolder.getRoot(), "broken.exec");
 		final FileWriter writer = new FileWriter(file);
 		writer.write("Invalid Content");
 		writer.close();
 
-		loader.load(file);
+		try {
+			loader.load(file);
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/FileMultiReportOutputTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/FileMultiReportOutputTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.report;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -52,12 +53,17 @@ public class FileMultiReportOutputTest {
 		actual.close();
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testCreateFileNegative() throws IOException {
 		folder.newFile("a");
 		final IMultiReportOutput output = new FileMultiReportOutput(
 				folder.getRoot());
-		output.createFile("a/b/c/test");
+		try {
+			output.createFile("a/b/c/test");
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 }

--- a/org.jacoco.report.test/src/org/jacoco/report/ZipMultiReportOutputTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/ZipMultiReportOutputTest.java
@@ -15,6 +15,7 @@ package org.jacoco.report;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -139,39 +140,64 @@ public class ZipMultiReportOutputTest {
 		assertArrayEquals(content2, entries.get("readme.txt"));
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testWriteToClosedStream1() throws IOException {
 		OutputStream out = zipOutput.createFile("index.html");
 		out.close();
-		out.write("HelloZip".getBytes());
+		try {
+			out.write("HelloZip".getBytes());
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testWriteToClosedStream2() throws IOException {
 		OutputStream out = zipOutput.createFile("index.html");
 		out.close();
-		out.write("HelloZip".getBytes(), 2, 3);
+		try {
+			out.write("HelloZip".getBytes(), 2, 3);
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testWriteToClosedStream3() throws IOException {
 		OutputStream out = zipOutput.createFile("index.html");
 		out.close();
-		out.write(32);
+		try {
+			out.write(32);
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testFlushToClosedStream3() throws IOException {
 		OutputStream out = zipOutput.createFile("index.html");
 		out.close();
-		out.flush();
+		try {
+			out.flush();
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void testWriteToObsoleteStream() throws IOException {
 		final OutputStream out1 = zipOutput.createFile("a.txt");
 		zipOutput.createFile("b.txt");
-		out1.write(32);
+		try {
+			out1.write(32);
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	private Map<String, byte[]> readEntries() throws IOException {

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/ReportOutputFolderTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/ReportOutputFolderTest.java
@@ -14,6 +14,7 @@ package org.jacoco.report.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
@@ -98,11 +99,16 @@ public class ReportOutputFolderTest {
 		assertEquals("../f2/test.html", folder.getLink(base, "test.html"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidRelativeLink() throws IOException {
 		final ReportOutputFolder folder = root.subFolder("f1").subFolder("f2");
 		final ReportOutputFolder base = new ReportOutputFolder(
 				new MemoryMultiReportOutput()).subFolder("g1");
-		folder.getLink(base, "test.html");
+		try {
+			folder.getLink(base, "test.html");
+			fail("IllegalArgumentException expected");
+		} catch (final IllegalArgumentException e) {
+			// expected
+		}
 	}
 }

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/TableTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/html/table/TableTest.java
@@ -139,17 +139,18 @@ public class TableTest {
 		html.close();
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testTwoDefaultSorts() throws IOException {
 		html.close();
-		table.add("Header1", null,
-				new StubRenderer(
-						CounterComparator.TOTALITEMS.on(CounterEntity.CLASS)),
-				true);
-		table.add("Header2", null,
-				new StubRenderer(
-						CounterComparator.TOTALITEMS.on(CounterEntity.CLASS)),
-				true);
+		final StubRenderer renderer = new StubRenderer(
+				CounterComparator.TOTALITEMS.on(CounterEntity.CLASS));
+		table.add("Header1", null, renderer, true);
+		try {
+			table.add("Header2", null, renderer, true);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
 	}
 
 	@Test

--- a/org.jacoco.report.test/src/org/jacoco/report/internal/xml/XMLElementTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/internal/xml/XMLElementTest.java
@@ -13,6 +13,7 @@
 package org.jacoco.report.internal.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -67,23 +68,38 @@ public class XMLElementTest {
 		assertContent("<root/>");
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void attr_should_throw_exception_when_closed() throws IOException {
 		root.close();
-		root.attr("attr", "value");
+		try {
+			root.attr("attr", "value");
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void element_should_throw_exception_when_closed()
 			throws IOException {
 		root.close();
-		root.element("child");
+		try {
+			root.element("child");
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void text_should_throw_exception_when_closed() throws IOException {
 		root.close();
-		root.text("text");
+		try {
+			root.text("text");
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	@Test
@@ -154,18 +170,28 @@ public class XMLElementTest {
 				"<root min=\"-9223372036854775808\" max=\"9223372036854775807\"/>");
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void attr_should_throw_exception_when_text_was_added()
 			throws IOException {
 		root.text("text");
-		root.attr("id", "12345");
+		try {
+			root.attr("id", "12345");
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
-	@Test(expected = IOException.class)
+	@Test
 	public void attr_should_throw_exception_when_child_was_added()
 			throws IOException {
 		root.element("child");
-		root.attr("id", "12345");
+		try {
+			root.attr("id", "12345");
+			fail("IOException expected");
+		} catch (final IOException e) {
+			// expected
+		}
 	}
 
 	private void assertContent(String expected) throws IOException {


### PR DESCRIPTION
This was discussed multiple times in past:
* https://github.com/jacoco/jacoco/pull/1057#discussion_r664138632
* https://github.com/jacoco/jacoco/pull/618#discussion_r150205478

----

Quoting https://github.com/junit-team/junit4/wiki/exception-testing

> If you project is not yet using JUnit 4.13 or your code base does
> not support lambdas, you can use the try/catch idiom

> The `expected` parameter should be used with care. The test will
> pass if any code in the method throws expected Exception. Also
> cannot test the value of the message in the exception, or the state
> of a domain object after the exception has been thrown.