### PR TITLE
Upgrade Maven to 3.9.15

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
-distributionSha256Sum=305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
-distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionSha256Sum=b0d9292f06c5faded31ddcb6cb69099f316d6fea40a7778624b259bad9fed18a

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -540,7 +540,7 @@
                   <version>17</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>3.9.14</version>
+                  <version>3.9.15</version>
                 </requireMavenVersion>
                 <requireNoRepositories>
                   <message>The rules for repo1.maven.org are that pom.xml files should not include repository definitions.</message>

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -540,7 +540,7 @@
                   <version>17</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>3.9.12</version>
+                  <version>3.9.14</version>
                 </requireMavenVersion>
                 <requireNoRepositories>
                   <message>The rules for repo1.maven.org are that pom.xml files should not include repository definitions.</message>

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -76,7 +76,7 @@
 
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a>
-  and requires at least Maven 3.9.14 and JDK 17.
+  and requires at least Maven 3.9.15 and JDK 17.
   See the <a href="build.html">build description</a> for details.
 </p>
 

--- a/org.jacoco.doc/docroot/doc/environment.html
+++ b/org.jacoco.doc/docroot/doc/environment.html
@@ -76,7 +76,7 @@
 
 <p>
   The JaCoCo build is based on <a href="http://maven.apache.org/">Maven</a>
-  and requires at least Maven 3.9.12 and JDK 17.
+  and requires at least Maven 3.9.14 and JDK 17.
   See the <a href="build.html">build description</a> for details.
 </p>
 


### PR DESCRIPTION
* https://maven.apache.org/docs/3.9.13/release-notes.html
* https://maven.apache.org/docs/3.9.14/release-notes.html
* https://maven.apache.org/docs/3.9.15/release-notes.html

3.9.13 contains fix for warning that appears during our build on JDK 26:

```
WARNING: Final field _cipher in class org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher has been mutated reflectively by class org.eclipse.sisu.bean.BeanPropertyField in unnamed module @7ff95560 (file:/Users/evgeny.mandrikov/.m2/wrapper/dists/apache-maven-3.9.12/6068d197/lib/org.eclipse.sisu.inject-0.9.0.M4.jar)
WARNING: Use --enable-final-field-mutation=ALL-UNNAMED to avoid a warning
WARNING: Mutating final fields will be blocked in a future release unless final field mutation is enabled
```