### PR TITLE
Add test of memory required for `LineImpl` instance and its singletons

### DIFF
--- a/org.jacoco.benchmarks/pom.xml
+++ b/org.jacoco.benchmarks/pom.xml
@@ -46,6 +46,16 @@
       <version>${jmh.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jol</groupId>
+      <artifactId>jol-core</artifactId>
+      <version>0.17</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/org.jacoco.benchmarks/pom.xml
+++ b/org.jacoco.benchmarks/pom.xml
@@ -32,7 +32,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>org.jacoco.core</artifactId>
+      <artifactId>org.jacoco.core.test</artifactId>
     </dependency>
 
     <dependency>
@@ -48,13 +48,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.openjdk.jol</groupId>
       <artifactId>jol-core</artifactId>
       <version>0.17</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
 
@@ -62,13 +63,6 @@
     <sourceDirectory>src</sourceDirectory>
 
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration combine.self="override">
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+import org.openjdk.jol.datamodel.Model64;
+import org.openjdk.jol.datamodel.Model64_Lilliput;
+import org.openjdk.jol.info.ClassData;
+import org.openjdk.jol.layouters.CurrentLayouter;
+import org.openjdk.jol.layouters.HotSpotLayouter;
+import org.openjdk.jol.layouters.Layouter;
+
+/**
+ * Test of memory required for {@link LineImpl} instance and its singletons.
+ */
+public class LineImplMemoryTest {
+
+	/**
+	 * Current VM. Intentionally - to be able to catch changes in VM when heap
+	 * size is below 32 GB.
+	 */
+	@Test
+	public void currentVM() throws Exception {
+		final Layouter layouter = new CurrentLayouter();
+		assertEquals(text( //
+				"Current VM Layout",
+				"org.jacoco.core.internal.analysis.LineImpl object internals:",
+				"OFF  SZ                                            TYPE DESCRIPTION               VALUE",
+				"  0   8                                                 (object header: mark)     N/A",
+				"  8   4                                                 (object header: class)    N/A",
+				" 12   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A",
+				" 16   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A",
+				" 20   4                                                 (object alignment gap)    ",
+				"Instance size: 24 bytes",
+				"Space losses: 0 bytes internal + 4 bytes external = 4 bytes total"),
+				layout(layouter));
+		assertEquals(68600, sizeOfSingletons(layouter));
+	}
+
+	/**
+	 * JDK 24 and above with {@code -XX:+UseCompactObjectHeaders}.
+	 *
+	 * @see <a href="https://openjdk.org/jeps/450">JEP 450: Compact Object
+	 *      Headers (Experimental)</a> delivered in JDK 24
+	 * @see <a href="https://openjdk.org/jeps/519">JEP 519: Compact Object
+	 *      Headers</a> delivered in JDK 25
+	 * @see <a href="https://openjdk.org/jeps/534">JEP 534: Compact Object
+	 *      Headers by Default</a>
+	 */
+	@Test
+	public void compact_object_headers() throws Exception {
+		final Layouter layouter = new HotSpotLayouter(
+				new Model64_Lilliput(true, 8, //
+						/*
+						 * Not Lilliput 2 (4-byte headers)
+						 * https://openjdk.org/jeps/8349069
+						 */
+						false),
+				24);
+		assertEquals(text(
+				"Hotspot Layout Simulation (JDK 24, 64-bit model, Lilliput (current experiment), compressed references, compressed classes, 8-byte aligned)",
+				"org.jacoco.core.internal.analysis.LineImpl object internals:",
+				"OFF  SZ                                            TYPE DESCRIPTION               VALUE",
+				"  0   8                                                 (object header: mark)     N/A",
+				"  8   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A",
+				" 12   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A",
+				"Instance size: 16 bytes",
+				"Space losses: 0 bytes internal + 0 bytes external = 0 bytes total"),
+				layout(layouter));
+		assertEquals(48432, sizeOfSingletons(layouter));
+	}
+
+	/**
+	 * JDK 24 and above with {@code -XX:+UseCompactObjectHeaders -Xmx32g}.
+	 */
+	@Test
+	public void compact_object_headers_without_compressed_references()
+			throws Exception {
+		final Layouter layouter = new HotSpotLayouter(new Model64_Lilliput(),
+				24);
+		assertEquals(text(
+				"Hotspot Layout Simulation (JDK 24, 64-bit model, Lilliput (current experiment), NO compressed references, compressed classes, 8-byte aligned)",
+				"org.jacoco.core.internal.analysis.LineImpl object internals:",
+				"OFF  SZ                                            TYPE DESCRIPTION               VALUE",
+				"  0   8                                                 (object header: mark)     N/A",
+				"  8   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A",
+				" 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A",
+				"Instance size: 24 bytes",
+				"Space losses: 0 bytes internal + 0 bytes external = 0 bytes total"),
+				layout(layouter));
+		assertEquals(76696, sizeOfSingletons(layouter));
+	}
+
+	/**
+	 * JDK 15 and above with {@code -Xmx32g}.
+	 *
+	 * @see <a href= "https://bugs.openjdk.org/browse/JDK-8241825">JDK-8241825:
+	 *      Make compressed oops and compressed class pointers independent</a>
+	 */
+	@Test
+	public void compressed_class_pointers() throws Exception {
+		final Layouter layouter = new HotSpotLayouter(new Model64(false, true),
+				15);
+		assertEquals(text(
+				"Hotspot Layout Simulation (JDK 15, 64-bit model, NO compressed references, compressed classes, 8-byte aligned)",
+				"org.jacoco.core.internal.analysis.LineImpl object internals:",
+				"OFF  SZ                                            TYPE DESCRIPTION               VALUE",
+				"  0   8                                                 (object header: mark)     N/A",
+				"  8   4                                                 (object header: class)    N/A",
+				" 12   4                                                 (alignment/padding gap)   ",
+				" 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A",
+				" 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A",
+				"Instance size: 32 bytes",
+				"Space losses: 4 bytes internal + 0 bytes external = 4 bytes total"),
+				layout(layouter));
+		assertEquals(92896, sizeOfSingletons(layouter));
+	}
+
+	/**
+	 * Prior to JDK 15 with {@code -Xmx32g}.
+	 */
+	@Test
+	public void without_compressed_class_pointers_and_without_compressed_references()
+			throws Exception {
+		final Layouter layouter = new HotSpotLayouter(new Model64(false, false),
+				8);
+		assertEquals(text(
+				"Hotspot Layout Simulation (JDK 8, 64-bit model, NO compressed references, NO compressed classes, 8-byte aligned)",
+				"org.jacoco.core.internal.analysis.LineImpl object internals:",
+				"OFF  SZ                                            TYPE DESCRIPTION               VALUE",
+				"  0   8                                                 (object header: mark)     N/A",
+				"  8   8                                                 (object header: class)    N/A",
+				" 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A",
+				" 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A",
+				"Instance size: 32 bytes",
+				"Space losses: 0 bytes internal + 0 bytes external = 0 bytes total"),
+				layout(layouter));
+		assertEquals(96864, sizeOfSingletons(layouter));
+	}
+
+	private static String layout(final Layouter layouter) {
+		return layouter + "\n" //
+				+ layouter.layout(ClassData.parseClass(LineImpl.class))
+						.toPrintable();
+	}
+
+	private static long sizeOfSingletons(final Layouter layouter)
+			throws NoSuchFieldException, IllegalAccessException {
+		final Field field = LineImpl.class.getDeclaredField("SINGLETONS");
+		field.setAccessible(true);
+		final LineImpl[][][][] singletons = (LineImpl[][][][]) field.get(null);
+		int instances = 0;
+		long size = sizeOf(singletons, layouter);
+		for (int i = 0; i < singletons.length; i++) {
+			size += sizeOf(singletons[i], layouter);
+			for (int j = 0; j < singletons[i].length; j++) {
+				size += sizeOf(singletons[i][j], layouter);
+				for (int k = 0; k < singletons[i][j].length; k++) {
+					size += sizeOf(singletons[i][j][k], layouter);
+					for (int l = 0; l < singletons[i][j][k].length; l++) {
+						instances++;
+						size += sizeOf(singletons[i][j][k][l], layouter);
+					}
+				}
+			}
+		}
+		assertEquals("instances", 2025, instances);
+		return size;
+	}
+
+	private static long sizeOf(final Object instance, final Layouter layouter) {
+		return layouter.layout(ClassData.parseInstance(instance))
+				.instanceSize();
+	}
+
+	/**
+	 * Poor man's replacement for <a href="https://openjdk.org/jeps/378">Java 15
+	 * Text Blocks</a>.
+	 */
+	private static String text(String... text) {
+		final StringBuilder sb = new StringBuilder();
+		for (String line : text) {
+			sb.append(line).append('\n');
+		}
+		return sb.toString();
+	}
+
+}

--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
@@ -29,6 +29,18 @@ import org.openjdk.jol.layouters.Layouter;
 
 /**
  * Test of memory required for {@link LineImpl} instance and its singletons.
+ *
+ * Goal of simulations with {@link HotSpotLayouter} such as
+ * {@link #compact_object_headers()} is to catch changes in JaCoCo for already
+ * explored VM changes in known configurations.
+ *
+ * These simulations might miss changes in VM unknown to JOL version in use, but
+ * hopefully such will be caught by {@link #currentVM() test} with
+ * {@link CurrentLayouter} - see {@link #clusterOops()} for examples of such
+ * changes.
+ *
+ * @see <a href="https://shipilev.net/jvm/objects-inside-out/">Java Objects
+ *      Inside Out</a>
  */
 public class LineImplMemoryTest {
 
@@ -38,23 +50,7 @@ public class LineImplMemoryTest {
 	 */
 	@Test
 	public void currentVM() throws Exception {
-		try {
-			ManagementFactory.getPlatformMBeanServer();
-		} catch (final NullPointerException e) {
-			// Frequently happens in CI with JDK version 18 due to
-			// https://bugs.openjdk.java.net/browse/JDK-8287073
-			// preventing use of
-			// "com.sun.management:type=HotSpotDiagnostic" MXBean
-			// in org.openjdk.jol.vm.VMOptions
-			// to obtain "ObjectAlignmentInBytes"
-			if (JavaVersion.current().isBefore("19")
-					&& !JavaVersion.current().isBefore("18")) {
-				throw new AssumptionViolatedException(
-						"this test requires HotSpotDiagnosticMXBean");
-			}
-			throw e;
-		}
-		final Layouter layouter = new CurrentLayouter();
+		final Layouter layouter = currentLayouter();
 		assertEquals(text( //
 				"Current VM Layout",
 				"org.jacoco.core.internal.analysis.LineImpl object internals:",
@@ -131,7 +127,8 @@ public class LineImplMemoryTest {
 	 *      Make compressed oops and compressed class pointers independent</a>
 	 */
 	@Test
-	public void compressed_class_pointers() throws Exception {
+	public void compressed_class_pointers_without_compressed_references()
+			throws Exception {
 		final Layouter layouter = new HotSpotLayouter(new Model64(false, true),
 				15);
 		assertEquals(text(
@@ -204,6 +201,84 @@ public class LineImplMemoryTest {
 	private static long sizeOf(final Object instance, final Layouter layouter) {
 		return layouter.layout(ClassData.parseInstance(instance))
 				.instanceSize();
+	}
+
+	private static CurrentLayouter currentLayouter() {
+		try {
+			ManagementFactory.getOperatingSystemMXBean();
+		} catch (final NullPointerException e) {
+			// Frequently happens in CI with JDK version 18 due to
+			// https://bugs.openjdk.java.net/browse/JDK-8287073
+			// preventing use of
+			// "com.sun.management:type=HotSpotDiagnostic" MXBean
+			// in org.openjdk.jol.vm.VMOptions
+			// to obtain "ObjectAlignmentInBytes"
+			if (JavaVersion.current().isBefore("19")
+					&& !JavaVersion.current().isBefore("18")) {
+				throw new AssumptionViolatedException(
+						"this test requires HotSpotDiagnosticMXBean");
+			}
+			throw e;
+		}
+		return new CurrentLayouter();
+	}
+
+	/**
+	 * @see <a href="https://bugs.openjdk.org/browse/JDK-8353273">JDK-8353273:
+	 *      Reduce number of oop map entries in instances</a> in JDK 25 and
+	 *      <a href=
+	 *      "https://github.com/openjdk/jol/commit/acb7bf9480bfd0588e93b353aa7217d3fe3efabe">corresponding
+	 *      change in JOL</a>
+	 * @see <a href="https://bugs.openjdk.org/browse/JDK-8139457">JDK-8139457:
+	 *      Relax alignment of array elements</a> in JDK 23 and <a href=
+	 *      "https://github.com/openjdk/jol/commit/8c4d7be996489676b9ff9caef83610b15c726019">corresponding
+	 *      change in JOL</a> as another example of change in VM unknown to JOL
+	 *      {@link HotSpotLayouter} in version 0.17
+	 */
+	@Test
+	public void clusterOops() {
+		final Layouter layouter = currentLayouter();
+		if (JavaVersion.current().isBefore("25")) {
+			assertEquals(text(
+					"org.jacoco.core.internal.analysis.LineImplMemoryTest$Derived object internals:",
+					"OFF  SZ               TYPE DESCRIPTION               VALUE",
+					"  0   8                    (object header: mark)     N/A",
+					"  8   4                    (object header: class)    N/A",
+					" 12   4                int Base.nonOop               N/A",
+					" 16   4   java.lang.Object Base.oop                  N/A",
+					" 20   4                int Derived.nonOop            N/A",
+					" 24   4   java.lang.Object Derived.oop               N/A",
+					" 28   4                    (object alignment gap)    ",
+					"Instance size: 32 bytes",
+					"Space losses: 0 bytes internal + 4 bytes external = 4 bytes total"),
+					layouter.layout(ClassData.parseClass(Derived.class))
+							.toPrintable());
+		} else {
+			assertEquals(text(
+					"org.jacoco.core.internal.analysis.LineImplMemoryTest$Derived object internals:",
+					"OFF  SZ               TYPE DESCRIPTION               VALUE",
+					"  0   8                    (object header: mark)     N/A",
+					"  8   4                    (object header: class)    N/A",
+					" 12   4                int Base.nonOop               N/A",
+					" 16   4   java.lang.Object Base.oop                  N/A",
+					" 20   4   java.lang.Object Derived.oop               N/A",
+					" 24   4                int Derived.nonOop            N/A",
+					" 28   4                    (object alignment gap)    ",
+					"Instance size: 32 bytes",
+					"Space losses: 0 bytes internal + 4 bytes external = 4 bytes total"),
+					layouter.layout(ClassData.parseClass(Derived.class))
+							.toPrintable());
+		}
+	}
+
+	private static class Base {
+		private Object oop;
+		private int nonOop;
+	}
+
+	private static class Derived extends Base {
+		private Object oop;
+		private int nonOop;
 	}
 
 	/**

--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
@@ -14,8 +14,11 @@ package org.jacoco.core.internal.analysis;
 
 import static org.junit.Assert.assertEquals;
 
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 
+import org.jacoco.core.test.validation.JavaVersion;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.openjdk.jol.datamodel.Model64;
 import org.openjdk.jol.datamodel.Model64_Lilliput;
@@ -35,6 +38,22 @@ public class LineImplMemoryTest {
 	 */
 	@Test
 	public void currentVM() throws Exception {
+		try {
+			ManagementFactory.getPlatformMBeanServer();
+		} catch (final NullPointerException e) {
+			// Frequently happens in CI with JDK version 18 due to
+			// https://bugs.openjdk.java.net/browse/JDK-8287073
+			// preventing use of
+			// "com.sun.management:type=HotSpotDiagnostic" MXBean
+			// in org.openjdk.jol.vm.VMOptions
+			// to obtain "ObjectAlignmentInBytes"
+			if (JavaVersion.current().isBefore("19")
+					&& !JavaVersion.current().isBefore("18")) {
+				throw new AssumptionViolatedException(
+						"this test requires HotSpotDiagnosticMXBean");
+			}
+			throw e;
+		}
 		final Layouter layouter = new CurrentLayouter();
 		assertEquals(text( //
 				"Current VM Layout",

--- a/org.jacoco.core.test.validation/pom.xml
+++ b/org.jacoco.core.test.validation/pom.xml
@@ -143,6 +143,7 @@
         <groovy.targetBytecode>1.8</groovy.targetBytecode>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -164,6 +165,7 @@
         <groovy.targetBytecode>9</groovy.targetBytecode>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -184,6 +186,7 @@
         <groovy.targetBytecode>10</groovy.targetBytecode>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -204,6 +207,7 @@
         <groovy.targetBytecode>11</groovy.targetBytecode>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -225,6 +229,7 @@
         <groovy.targetBytecode>12</groovy.targetBytecode>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -249,6 +254,7 @@
         <maven.compiler.target>13</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -273,6 +279,7 @@
         <maven.compiler.target>14</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -298,6 +305,7 @@
         <maven.compiler.target>15</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -323,6 +331,7 @@
         <maven.compiler.target>16</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -349,6 +358,7 @@
         <maven.compiler.target>17</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -376,6 +386,7 @@
         <maven.compiler.target>18</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -403,6 +414,7 @@
         <maven.compiler.target>19</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -430,6 +442,7 @@
         <maven.compiler.target>20</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -457,6 +470,7 @@
         <maven.compiler.target>21</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -485,6 +499,7 @@
         <maven.compiler.target>22</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -513,6 +528,7 @@
         <maven.compiler.target>23</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -541,6 +557,7 @@
         <maven.compiler.target>24</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -571,6 +588,7 @@
         <maven.compiler.target>25</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -600,6 +618,7 @@
         <maven.compiler.target>26</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>
@@ -631,6 +650,7 @@
         <maven.compiler.target>27</maven.compiler.target>
       </properties>
       <modules>
+        <module>../org.jacoco.benchmarks</module>
         <module>../org.jacoco.core.test.validation.kotlin</module>
         <module>../org.jacoco.core.test.validation.java7</module>
         <module>../org.jacoco.core.test.validation.java8</module>


### PR DESCRIPTION
This PR is to prepare landing of https://github.com/jacoco/jacoco/pull/1680
that requires addition to `LineImpl` of `int` field - `bitMask` storing covered branches.

Also IMO this test is useful on its own even without https://github.com/jacoco/jacoco/pull/1680 - provides verifiable insights about memory consumption.

---

This PR demonstrates that on all JDK versions with heap size below 32 GB (compressed OOPs) there is object alignment gap in `LineImpl`:

```text
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4                                                 (object header: class)    N/A
 12   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 16   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
 20   4                                                 (object alignment gap)
Instance size: 24 bytes",
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total"),
```

That is, size of `LineImpl` instance won't increase after addition of field when heap size is below 32 GB:

```text
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4                                                 (object header: class)    N/A
 12   4                                             int LineImpl.bitMask          N/A
 16   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 20   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 24 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

---

Starting from JDK 15 use of compressed class pointers is independent from compressed oops (https://bugs.openjdk.org/browse/JDK-8241825) - execution of
`java -Xmx32g -XX:+PrintFlagsFinal -version 2>&1 | grep -E "Compressed|OpenJDK"`

```
   size_t CompressedClassSpaceSize                 = 1073741824                                {product} {default}
     bool UseCompressedClassPointers               = true                                 {lp64_product} {ergonomic}
     bool UseCompressedOops                        = false                                {lp64_product} {default}
OpenJDK Runtime Environment Zulu15.46+17-CA (build 15.0.10+5-MTS)
OpenJDK 64-Bit Server VM Zulu15.46+17-CA (build 15.0.10+5-MTS, mixed mode)
```

So execution of same test with `-Xmx32g` on JDK versions above 14 shows that while instance size increases there is still gap:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4                                                 (object header: class)    N/A
 12   4                                                 (alignment/padding gap)
 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 32 bytes
Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
```

Use of uncompressed class pointers is deprecated since JDK 25 and removed in JDK 27 (https://bugs.openjdk.org/browse/JDK-8363996).

That is, size of `LineImpl` instance won't increase after addition of field on JDK versions above 14 even when heap size is above 32 GB:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4                                                 (object header: class)    N/A
 12   4                                             int LineImpl.bitMask          N/A
 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 32 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

---

Execution of the same test on JDK versions prior to 15 with `-Xmx32g` unfortunately shows that there is no gap:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   8                                                 (object header: class)    N/A
 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 32 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

That is, this is the only case where instance size will increase after addition of field:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   8                                                 (object header: class)    N/A
 16   4                                             int LineImpl.bitMask          N/A
 20   4                                                 (alignment/padding gap)   
 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 32   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 40 bytes
Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
```

But IMO majority of users do not have heap size above 32 GB, and those who do IMO then should be able to tolerate such increase.

---

On JDK 25 and 26 with `-XX:+UseCompactObjectHeaders` (https://openjdk.org/jeps/519) there is no more gap, but instance size becomes smaller:
 
```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 12   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 16 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

That is, size of `LineImpl` instance won't increase after addition of field compared to current without JEP 519 when heap size is below 32 GB:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4                                             int LineImpl.bitMask          N/A
 12   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 16   4   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
 20   4                                                 (object alignment gap)    
Instance size: 24 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

---

Similarly on JDK 25 and 26 with `-XX:+UseCompactObjectHeaders -Xmx32g`:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 24 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

That is, size of `LineImpl` instance won't increase after addition of field compared to current without JEP 519 even when heap size is above 32 GB:

```
org.jacoco.core.internal.analysis.LineImpl object internals:
OFF  SZ                                            TYPE DESCRIPTION               VALUE
  0   8                                                 (object header: mark)     N/A
  8   4                                             int LineImpl.bitMask          N/A
 12   4                                                 (alignment/padding gap)   
 16   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.instructions     N/A
 24   8   org.jacoco.core.internal.analysis.CounterImpl LineImpl.branches         N/A
Instance size: 32 bytes
Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
```

---

While test added by this PR also provides size of singletons, the impact of https://github.com/jacoco/jacoco/pull/1680 on singletons is described in https://github.com/jacoco/jacoco/pull/2107.