### PR TITLE
`LineImpl.SINGLETONS`

### DIFF
--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineCount.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineCount.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.internal.analysis;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ILine;
+import org.jacoco.core.analysis.IMethodCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class LineCount {
+
+	private final int instructionsLimit = 32;
+	private final int branchesLimit = 16;
+	private final int[][] counts = new int[instructionsLimit + 1][branchesLimit
+			+ 1];
+	private int total = 0;
+
+	private void process(String path) throws IOException {
+		final CoverageBuilder coverageBuilder = new CoverageBuilder();
+		final Analyzer analyzer = new Analyzer(new ExecutionDataStore(),
+				coverageBuilder) {
+			@Override
+			public int analyzeAll(final File file) throws IOException {
+				if (file.getName().endsWith(".jmod")) {
+					return analyzeJmod(new FileInputStream(file),
+							file.getPath());
+				}
+				return super.analyzeAll(file);
+			}
+
+			private int analyzeJmod(final InputStream input,
+					final String location) throws IOException {
+				input.skip(4); // JM\003\004
+				final ZipInputStream zip = new ZipInputStream(input);
+				ZipEntry entry;
+				int count = 0;
+				while ((entry = zip.getNextEntry()) != null) {
+					count += analyzeAll(zip, location + "@" + entry.getName());
+				}
+				return count;
+			}
+
+			@Override
+			public void analyzeClass(final byte[] buffer, final String location)
+					throws IOException {
+				try {
+					super.analyzeClass(buffer, location);
+				} catch (final IOException e) {
+					if (!e.getCause().getMessage().startsWith(
+							"Can't add different class with same name:")) {
+						throw e;
+					}
+				}
+			}
+		};
+		analyzer.analyzeAll(new File(path));
+		for (final IClassCoverage classCoverage : coverageBuilder
+				.getClasses()) {
+			for (final IMethodCoverage methodCoverage : classCoverage
+					.getMethods()) {
+				for (int line = methodCoverage
+						.getFirstLine(); line <= methodCoverage
+								.getLastLine(); line++) {
+					final ILine methodLine = methodCoverage.getLine(line);
+					if (methodLine.getInstructionCounter()
+							.getTotalCount() == 0) {
+						continue;
+					}
+					total++;
+					int it = methodLine.getInstructionCounter().getTotalCount();
+					int bt = methodCoverage.getBranchCounter().getTotalCount();
+					if (it <= instructionsLimit && bt <= branchesLimit) {
+						counts[it][bt]++;
+					}
+				}
+			}
+		}
+	}
+
+	private void print() {
+		int current = 0;
+		int all_8_8 = 0;
+		int even_8_8 = 0;
+		int all_4_16 = 0;
+		int even_6_16 = 0;
+		int all_6_16 = 0;
+		int even_8_16 = 0;
+		int all_8_16 = 0;
+		int even_4_32 = 0;
+		for (int i = 0; i <= instructionsLimit; i++) {
+			for (int b = 0; b <= branchesLimit; b++) {
+				int count = counts[i][b];
+				System.out.printf("%8d,", count);
+
+				if (b <= 4 && i <= 8) {
+					current += count;
+				}
+				if (b <= 8 && i <= 8) {
+					all_8_8 += count;
+					if (b % 2 == 0) {
+						even_8_8 += count;
+					}
+				}
+				if (b <= 4 && i <= 16) {
+					all_4_16 += count;
+				}
+				if (b <= 6 && i <= 16) {
+					all_6_16 += count;
+					if (b % 2 == 0) {
+						even_6_16 += count;
+					}
+				}
+				if (b <= 8 && i <= 16) {
+					all_8_16 += count;
+					if (b % 2 == 0) {
+						even_8_16 += count;
+					}
+				}
+				if (b <= 4 && i <= 32 && b % 2 == 0) {
+					even_4_32 += count;
+				}
+			}
+			System.out.println();
+		}
+
+		// ~ 68 KB
+		System.out.println("Total lines in IMethodCoverage nodes: " + total);
+		System.out.printf("Current guaranteed: %.2f%%\n", //
+				100.0 * current / total);
+
+		// 15_004 instances, 425_688 bytes
+		System.out.printf("       Even ( 8,8): %.2f%%\n",
+				100.0 * even_8_8 / total);
+		System.out.printf("        All ( 8,8): %.2f%%\n",
+				100.0 * all_8_8 / total);
+
+		// 4_712 instances, 149_624 bytes
+		System.out.printf("        All (4,16): %.2f%%\n",
+				100.0 * all_4_16 / total);
+
+		// 12_920 instances, 376_032 bytes
+		System.out.printf("       Even (6,16): %.2f%%\n",
+				100.0 * even_6_16 / total);
+		System.out.printf("        All (6,16): %.2f%%\n",
+				100.0 * all_6_16 / total);
+
+		// 51_832 instances, 1_468_984 bytes
+		System.out.printf("       Even (8,16): %.2f%%\n",
+				100.0 * even_8_16 / total);
+		// 2_206_152 bytes
+		System.out.printf("        All (8,16): %.2f%%\n",
+				100.0 * all_8_16 / total);
+
+		// 11_760 instances, 367_312 bytes
+		System.out.printf("       Even (4,32): %.2f%%\n",
+				100.0 * even_4_32 / total);
+	}
+
+	private static void count(String... paths) throws IOException {
+		System.out.println(Arrays.toString(paths));
+		final LineCount count = new LineCount();
+		for (final String path : paths) {
+			count.process(path);
+		}
+		count.print();
+	}
+
+	private static String user(String path) {
+		return System.getProperty("user.home") + "/" + path;
+	}
+
+	private static String maven(final String groupId, final String artifactId,
+			final String version, final String classifier, final String type) {
+		final String path = user(".m2/repository/" + groupId.replace('.', '/')
+				+ "/" + artifactId + "/" + version + "/" + artifactId + "-"
+				+ version + (classifier == null ? "" : "-" + classifier) + "."
+				+ type);
+		if (!new File(path).exists()) {
+			throw new IllegalStateException("\n" + path + "\n" + //
+					"mvn dependency:get" + //
+					" -DgroupId=" + groupId.replace('/', '.') //
+					+ " -DartifactId=" + artifactId //
+					+ " -Dversion=" + version //
+					+ (classifier == null ? "" : "-Dclassifier=" + classifier) //
+					+ " -Dpackaging=" + type);
+		}
+		return path;
+	}
+
+	private static String maven(final String groupId, final String artifactId,
+			final String version) {
+		return maven(groupId, artifactId, version, null, "jar");
+	}
+
+	public static void main(String[] args) throws IOException {
+		count(user(".java-select/versions/25/jmods/java.base.jmod"));
+		count(user("eclipse/Eclipse.app/Contents"));
+		count(user("Applications/IntelliJ IDEA.app/Contents"));
+		count(maven("org/jetbrains/kotlin", "kotlin-compiler", "2.3.20"));
+		count(maven("org/eclipse/jdt", "ecj", "3.44.0"));
+		count(maven("org.eclipse.collections", "eclipse-collections",
+				"13.0.0"));
+		count(maven("com/google/guava", "guava", "33.6.0-jre"));
+		count(maven("org/http4k", "http4k-core", "6.42.0.0"));
+		count(maven("org/http4k", "http4k-core", "6.42.0.0"));
+		count(maven("io/mockk", "mockk", "1.9.3"));
+		count(maven("org/junit/jupiter", "junit-jupiter-engine", "6.0.3"));
+		count(maven("junit", "junit", "4.13.2"));
+		count(maven("org/ow2/asm", "asm", "9.9.1"));
+		count("org.jacoco.core/target/classes");
+	}
+
+}


### PR DESCRIPTION
https://github.com/jacoco/jacoco/pull/1680 requires generation of singletons for all permutations of covered and uncovered branches.

Choice of number of singletons is a trade-off between
* constant amount of memory required for singletons
* amount of memory saved by usage of these singletons in `IBundleCoverage` for some coverage report

The first one can be calculated relatively easily - see https://github.com/jacoco/jacoco/pull/2105

However IMO currently it is quite hard to reason about second one without runtime data,
because limits for singletons are defined in terms of `covered` and `missed` rather than `total`.

That is, by looking only at the bytecode of some class files,
for some lines it is impossible to answer unambiguously question
whether it will be represented by singleton or not. For example:

```
for (String s : stringsCollection) { // total 10 instructions, 2 branches
  // singleton only when collection is empty - 4 missed, 6 covered
  // otherwise 10 missing when not executed at all
  // or 10 covered when executed
}
```

For another example

```
if (a || b || c || d) { // total 8 instructions, 8 branches
  // singleton only when all are false
}
```

```
if (a && b && c) { // total 6 instruction, 6 branches
  // not singleton when two or more evaluate to both true and false
}
```

The only lines for which unambiguously possible to say that they use singletons currently -
are the ones that have no more than 8 total instructions and no more than 4 total branches.

Gathering of statistical data for various project by analysis of their class files is much easier than gathering of execution data from their tests.

---

Can be observed that there are no lines with 1 branch.

https://github.com/jacoco/jacoco/blob/v0.8.14/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java#L219-L220

Also no lines with 0 instructions and more than 0 branches.

Whereas such singletons are currently allocated.

---

Can be observed also that only
language constructions that compile to `TABLESWITCH` and `LOOKUPSWITCH` bytecode instructions
will use singletons with odd number of `total` branches - all `IF...` instructions have 2 branches.

That is, in Java, these would be `switch` statements and expressions,
which, in my opinion, are used less frequently than `if` statements.

---

According to #2105 when heap size below 32 GB (compressed OOPs) on all JDK versions

* Current singletons - 2_025 instances requiring 68_600 bytes.
* Singletons for all possible permutations
  * up to 4 total branches and up to 16 instructions - 4_712 instances in 425_688 bytes.
  * up to 6 total branches and up to 16 total instructions - 19_304 instances in 565_024 bytes.
    * for only even total number of branches - 12_920 instances in 376_032 bytes.
  * up to 8 total branches and up to 16 total instructions - 77_672 instances in 2_206_152 bytes.
    * for only even total number of branches - 51_832 instances in 1_468_984 bytes.
  * up to 8 total branches and up to 8 total instructions - 22_484 instances in 639_432 bytes.
    * for only even total number of branches - 15_004 instances in 425_688 bytes.

|           | instances |            | JDK < 15   | JDK >= 15  | JEP 519    | JEP 519    |
| --------- | --------- | ---------- | ---------- | ---------- | ---------- | ---------- |
|           |           | heap < 32g | heap > 32g | heap > 32g | heap < 32g | heap > 32g |
| current   |     2_025 |     68_600 |     96_864 |    92_896  |     48_432 |     76_696 |
| 4x16      |     4_712 |    425_688 |    253_240 |    208_776 |    148_080 |    208_776 |
| 6x16      |    19_304 |    565_024 |    964_472 |    800_568 |    563_352 |    800_568 |
| 6x16 even |    12_920 |    376_032 |    641_816 |    533_040 |    374_560 |    533_040 |
| 8x16      |    77_672 |  2_206_152 |  3_776_952 |  3_143_400 |  2_204_352 |  3_143_400 |
| 8x16 even |    51_832 |  1_468_984 |  2_515_000 |  2_093_576 |  1_467_440 |  2_093_576 |
| 8x8       |    22_484 |    639_432 |  1_094_520 |    910_824 |    638_784 |    910_824 |
| 8x8 even  |    15_004 |    425_688 |    728_696 |    606_536 |    425_168 |    606_536 |

Note that also according to #2105: #1680 won't impact non-singleton instances in most of the cases, except when heap size is above 32 GB on JDK versions prior to 15 where additional 8 bytes will be required per each non-singleton.

---

This PR provides code to count number of lines in class files
that can be represented by singletons
for the above various strategies.

```text
[/Users/evgeny.mandrikov/.java-select/versions/25/jmods/java.base.jmod]
Total lines in IMethodCoverage nodes: 306884
Current guaranteed: 43.00%
       Even ( 8,8): 54.24%
        All ( 8,8): 54.58%
        All (4,16): 47.27%
       Even (6,16): 54.31%
        All (6,16): 54.57%
       Even (8,16): 59.73%
        All (8,16): 60.12%
       Even (4,32): 47.63%
```

Eclipse IDE for Java Developers 2026-03

```text
[/Users/evgeny.mandrikov/eclipse/Eclipse.app/Contents]
Total lines in IMethodCoverage nodes: 3127271
Current guaranteed: 45.15%
       Even ( 8,8): 57.67%
        All ( 8,8): 58.15%
        All (4,16): 48.01%
       Even (6,16): 55.53%
        All (6,16): 55.85%
       Even (8,16): 61.60%
        All (8,16): 62.12%
       Even (4,32): 48.19%
```

IntelliJ IDEA 2026.1.1

```text
[/Users/evgeny.mandrikov/Applications/IntelliJ IDEA.app/Contents]
Total lines in IMethodCoverage nodes: 10347737
Current guaranteed: 47.46%
       Even ( 8,8): 57.80%
        All ( 8,8): 58.16%
        All (4,16): 52.67%
       Even (6,16): 59.44%
        All (6,16): 59.69%
       Even (8,16): 64.63%
        All (8,16): 65.01%
       Even (4,32): 53.49%
```

```text
[/Users/evgeny.mandrikov/.m2/repository/org/junit/jupiter/junit-jupiter-engine/6.0.3/junit-jupiter-engine-6.0.3.jar]
Total lines in IMethodCoverage nodes: 3436
Current guaranteed: 82.57%
       Even ( 8,8): 89.90%
        All ( 8,8): 90.02%
        All (4,16): 88.62%
       Even (6,16): 94.47%
        All (6,16): 94.59%
       Even (8,16): 96.68%
        All (8,16): 96.80%
       Even (4,32): 88.94%
```

```text

[/Users/evgeny.mandrikov/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar]
Total lines in IMethodCoverage nodes: 4960
Current guaranteed: 75.26%
       Even ( 8,8): 83.91%
        All ( 8,8): 83.99%
        All (4,16): 82.16%
       Even (6,16): 86.96%
        All (6,16): 87.06%
       Even (8,16): 92.20%
        All (8,16): 92.30%
       Even (4,32): 83.17%
```

```text

[/Users/evgeny.mandrikov/.m2/repository/org/ow2/asm/asm/9.9.1/asm-9.9.1.jar]
Total lines in IMethodCoverage nodes: 5567
Current guaranteed: 24.02%
       Even ( 8,8): 30.95%
        All ( 8,8): 31.38%
        All (4,16): 26.66%
       Even (6,16): 30.32%
        All (6,16): 30.52%
       Even (8,16): 34.40%
        All (8,16): 34.85%
       Even (4,32): 26.75%
```

```text

[/Users/evgeny.mandrikov/.m2/repository/com/google/guava/guava/33.6.0-jre/guava-33.6.0-jre.jar]
Total lines in IMethodCoverage nodes: 39719
Current guaranteed: 65.25%
       Even ( 8,8): 77.09%
        All ( 8,8): 77.80%
        All (4,16): 70.99%
       Even (6,16): 78.79%
        All (6,16): 79.29%
       Even (8,16): 83.98%
        All (8,16): 84.74%
       Even (4,32): 71.33%
```

```text
[/Users/evgeny.mandrikov/.m2/repository/org/eclipse/jdt/ecj/3.44.0/ecj-3.44.0.jar]
Total lines in IMethodCoverage nodes: 121330
Current guaranteed: 23.70%
       Even ( 8,8): 32.53%
        All ( 8,8): 32.84%
        All (4,16): 25.78%
       Even (6,16): 30.77%
        All (6,16): 30.93%
       Even (8,16): 35.61%
        All (8,16): 35.94%
       Even (4,32): 26.05%
```

```text
[/Users/evgeny.mandrikov/.m2/repository/org/eclipse/collections/eclipse-collections/13.0.0/eclipse-collections-13.0.0.jar]
Total lines in IMethodCoverage nodes: 199200
Current guaranteed: 61.66%
       Even ( 8,8): 68.43%
        All ( 8,8): 68.52%
        All (4,16): 65.70%
       Even (6,16): 70.75%
        All (6,16): 70.82%
       Even (8,16): 73.17%
        All (8,16): 73.26%
       Even (4,32): 65.86%
```

```text

[/Users/evgeny.mandrikov/.m2/repository/org/jetbrains/kotlin/kotlin-compiler/2.3.20/kotlin-compiler-2.3.20.jar]
Total lines in IMethodCoverage nodes: 656534
Current guaranteed: 45.65%
       Even ( 8,8): 54.76%
        All ( 8,8): 55.21%
        All (4,16): 51.36%
       Even (6,16): 57.40%
        All (6,16): 57.71%
       Even (8,16): 62.22%
        All (8,16): 62.71%
       Even (4,32): 52.19%
```

```text

[/Users/evgeny.mandrikov/.m2/repository/org/http4k/http4k-core/6.42.0.0/http4k-core-6.42.0.0.jar]
Total lines in IMethodCoverage nodes: 3770
Current guaranteed: 62.10%
       Even ( 8,8): 65.62%
        All ( 8,8): 65.78%
        All (4,16): 82.25%
       Even (6,16): 85.31%
        All (6,16): 85.46%
       Even (8,16): 87.59%
        All (8,16): 87.75%
       Even (4,32): 86.74%
```

```text
[/Users/evgeny.mandrikov/.m2/repository/io/mockk/mockk/1.9.3/mockk-1.9.3.jar]
Total lines in IMethodCoverage nodes: 2869
Current guaranteed: 57.89%
       Even ( 8,8): 68.49%
        All ( 8,8): 68.49%
        All (4,16): 68.98%
       Even (6,16): 76.75%
        All (6,16): 76.75%
       Even (8,16): 82.01%
        All (8,16): 82.01%
       Even (4,32): 71.24%
```

```text
[org.jacoco.core/target/classes]
Total lines in IMethodCoverage nodes: 4084
Current guaranteed: 54.87%
       Even ( 8,8): 67.29%
        All ( 8,8): 69.17%
        All (4,16): 57.86%
       Even (6,16): 64.30%
        All (6,16): 65.38%
       Even (8,16): 71.28%
        All (8,16): 73.21%
       Even (4,32): 57.93%
```

---

From the above to me seems that creation of singletons
for even total number of branches up to 6
and for total number of instructions up to 16
is the best trade-off.
