### PR TITLE
Annotation processors should be enabled explicitly

### DIFF
--- a/org.jacoco.benchmarks/pom.xml
+++ b/org.jacoco.benchmarks/pom.xml
@@ -61,6 +61,16 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessors>
+            <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+          </annotationProcessors>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
Because of https://bugs.openjdk.org/browse/JDK-8314833
following note is produced when building with JDK 21 and 22:

```
[INFO] Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```

Because of https://bugs.openjdk.org/browse/JDK-8338926
with JDK >=23 note is not produced and annotation processors are not executed.

---

This was overlooked in d91c6d8de48a64c2afc62182337e8179faadab83.
