### PR TITLE
Add validation test for Kotlin `if` as expression

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinBooleanExpressionsTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinBooleanExpressionsTarget.kt
@@ -103,6 +103,10 @@ object KotlinBooleanExpressionsTarget {
         }
         nop(f() xor f()) // assertFullyCovered()
 
+        /* `if` as expression */
+        nop(if (t()) i1() else i2()) // assertPartlyCovered(1, 1)
+        nop(if (f()) i1() else i2()) // assertPartlyCovered(1, 1)
+
         /* Not (one case) */
         nop(!t()) // assertPartlyCovered(1, 1)
         nop(!f()) // assertPartlyCovered(1, 1)


### PR DESCRIPTION
While [Kotlin has no conditional operator](https://discuss.kotlinlang.org/t/ternary-operator/2116/171) unlike Java, [`if` can be used as expression](https://kotlinlang.org/docs/control-flow.html#if-expression).

This was overlooked in https://github.com/jacoco/jacoco/pull/2110