### PR TITLE
Do not execute `LineImplMemoryTest.currentVM` on 32-bit platforms such as AArch32

### DIFF
--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
@@ -222,7 +222,7 @@ public class LineImplMemoryTest {
 		}
 		if ("32".equals(System.getProperty("sun.arch.data.model"))) {
 			throw new AssumptionViolatedException(
-					"this test requires 64-bit architecture");
+					"this test does not support 32-bit architecture");
 		}
 		return new CurrentLayouter();
 	}

--- a/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
+++ b/org.jacoco.benchmarks/src/org/jacoco/core/internal/analysis/LineImplMemoryTest.java
@@ -220,6 +220,10 @@ public class LineImplMemoryTest {
 			}
 			throw e;
 		}
+		if ("32".equals(System.getProperty("sun.arch.data.model"))) {
+			throw new AssumptionViolatedException(
+					"this test requires 64-bit architecture");
+		}
 		return new CurrentLayouter();
 	}
 


### PR DESCRIPTION
Fixes #2113 