### PR TITLE
Remove unnecessary `KOTLIN_METADATA_DESC` from unit tests of individual filters

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinComposeFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinComposeFilterTest.java
@@ -76,8 +76,6 @@ public class KotlinComposeFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"f", "(Landroidx/compose/runtime/Composer;I)V", null, null);
 		m.visitAnnotation("Landroidx/compose/runtime/Composable;", false);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinCoroutineFilterTest.java
@@ -30,8 +30,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"invokeSuspend", "(Ljava/lang/Object;)Ljava/lang/Object;", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitMethodInsn(Opcodes.INVOKESTATIC,
 				"kotlin/coroutines/intrinsics/IntrinsicsKt",
@@ -125,8 +123,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"invokeSuspend", "(Ljava/lang/Object;)Ljava/lang/Object;", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitMethodInsn(Opcodes.INVOKESTATIC,
 				"kotlin/coroutines/intrinsics/IntrinsicsKt",
@@ -334,8 +330,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 				Opcodes.ACC_STATIC, "example",
 				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		final int continuationArgumentIndex = 0;
 		final int continuationIndex = 2;
@@ -487,8 +481,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 				"example",
 				"(ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		final Label exit = new Label();
 
@@ -564,8 +556,6 @@ public class KotlinCoroutineFilterTest extends FilterTestBase {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, "invokeSuspend",
 				"(Ljava/lang/Object;)Ljava/lang/Object;", null, null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitMethodInsn(Opcodes.INVOKESTATIC,
 				"kotlin/coroutines/intrinsics/IntrinsicsKt",

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilterTest.java
@@ -55,8 +55,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 	public void should_filter() {
 		final MethodNode m = createMethod(Opcodes.ACC_SYNTHETIC,
 				"origin$default", "(LTarget;IILjava/lang/Object;)V");
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		filter.filter(m, context, output);
 
@@ -68,8 +66,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 	public void should_not_filter_when_suffix_absent() {
 		final MethodNode m = createMethod(Opcodes.ACC_SYNTHETIC,
 				"synthetic_without_suffix", "(LTarget;IILjava/lang/Object;)V");
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		filter.filter(m, context, output);
 
@@ -80,8 +76,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 	public void should_not_filter_when_not_synthetic() {
 		final MethodNode m = createMethod(0, "not_synthetic$default",
 				"(LTarget;IILjava/lang/Object;)V");
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		filter.filter(m, context, output);
 
@@ -101,8 +95,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
 				Opcodes.ACC_SYNTHETIC, "foo$default",
 				"(LOpen;IILjava/lang/Object;)V", null, null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		{
 			m.visitVarInsn(Opcodes.ALOAD, 3);
 			final Label label = new Label();
@@ -154,8 +146,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 				Opcodes.ACC_SYNTHETIC, "<init>",
 				"(IILkotlin/jvm/internal/DefaultConstructorMarker;)V", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitVarInsn(Opcodes.ILOAD, 2);
 		m.visitInsn(Opcodes.ICONST_1);
@@ -189,8 +179,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 				Opcodes.ACC_SYNTHETIC, "<init>",
 				"(JILkotlin/jvm/internal/DefaultConstructorMarker;)V", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitVarInsn(Opcodes.ILOAD, 3);
 		m.visitInsn(Opcodes.ICONST_1);
@@ -237,8 +225,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 				"(" + paramTypes
 						+ "IILkotlin/jvm/internal/DefaultConstructorMarker;)V",
 				null, null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitVarInsn(Opcodes.ILOAD, 34);
 		m.visitLdcInsn(Integer.valueOf(1 << 31));
@@ -312,8 +298,6 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 				"(" + paramTypes
 						+ "IIIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V",
 				null, null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitVarInsn(Opcodes.ILOAD, 226);
 		m.visitInsn(Opcodes.ICONST_1);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultMethodsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultMethodsFilterTest.java
@@ -26,8 +26,6 @@ public class KotlinDefaultMethodsFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_filter() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"m", "()V", null, null);
 		m.visitVarInsn(Opcodes.ALOAD, 0);
@@ -42,8 +40,6 @@ public class KotlinDefaultMethodsFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_not_filter_when_invokestatic_owner_does_not_match() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"m", "()V", null, null);
 		m.visitVarInsn(Opcodes.ALOAD, 0);
@@ -58,8 +54,6 @@ public class KotlinDefaultMethodsFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_not_filter_when_instructions_do_not_match() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"m", "()V", null, null);
 		m.visitInsn(Opcodes.RETURN);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinEnumFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinEnumFilterTest.java
@@ -31,8 +31,6 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 	@Test
 	public void should_filter() {
 		context.superClassName = "java/lang/Enum";
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "getEntries",
 				"()Lkotlin/enums/EnumEntries;", null, null);
@@ -47,8 +45,6 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_not_filter_when_not_Enum() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "getEntries",
 				"()Lkotlin/enums/EnumEntries;", null, null);
@@ -64,8 +60,6 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 	@Test
 	public void should_not_filter_when_not_getEntries_name() {
 		context.superClassName = "java/lang/Enum";
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "get",
 				"()Lkotlin/enums/EnumEntries;", null, null);
@@ -81,8 +75,6 @@ public class KotlinEnumFilterTest extends FilterTestBase {
 	@Test
 	public void should_not_filter_when_not_getEntries_descriptor() {
 		context.superClassName = "java/lang/Enum";
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "getEntries",
 				"(I)Lkotlin/enums/EnumEntries;", null, null);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinGeneratedFilterTest.java
@@ -31,8 +31,6 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 				"hashCode", "()I", null, null);
 		m.visitInsn(Opcodes.ICONST_0);
 		m.visitInsn(Opcodes.IRETURN);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		filter.filter(m, context, output);
 
@@ -47,8 +45,6 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 		m.visitLineNumber(12, new Label());
 		m.visitInsn(Opcodes.ICONST_0);
 		m.visitInsn(Opcodes.IRETURN);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		filter.filter(m, context, output);
 
@@ -61,8 +57,6 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 				"hashCode", "()I", null, null);
 		m.visitInsn(Opcodes.ICONST_0);
 		m.visitInsn(Opcodes.IRETURN);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		context.sourceFileName = null;
 
 		filter.filter(m, context, output);
@@ -77,8 +71,6 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 		m.visitInsn(Opcodes.ICONST_0);
 		m.visitInsn(Opcodes.IRETURN);
 		m.visitLineNumber(12, new Label());
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		context.sourceFileName = null;
 
 		filter.filter(m, context, output);
@@ -95,8 +87,6 @@ public class KotlinGeneratedFilterTest extends FilterTestBase {
 	@Test
 	public void should_filter_instructions_without_line_numbers() {
 		context.sourceFileName = "Example.kt";
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"f", "()V", null, null);
 		m.visitInsn(Opcodes.ICONST_0);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineClassFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineClassFilterTest.java
@@ -31,8 +31,6 @@ public class KotlinInlineClassFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		context.classAnnotations.add("Lkotlin/jvm/JvmInline;");
 		final MethodNode m = new MethodNode(0, "getValue",
 				"()Ljava/lang/String;", null, null);
@@ -53,8 +51,6 @@ public class KotlinInlineClassFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_not_filter_static() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		context.classAnnotations.add("Lkotlin/jvm/JvmInline;");
 		final MethodNode m = new MethodNode(Opcodes.ACC_STATIC, "f-impl", "()V",
 				null, null);
@@ -72,8 +68,6 @@ public class KotlinInlineClassFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_not_filter_when_no_JvmInline_annotation() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(0, "getValue",
 				"()Ljava/lang/String;", null, null);
 		m.visitInsn(Opcodes.NOP);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinInlineFilterTest.java
@@ -53,8 +53,6 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 				+ "2#2,2:9\n" // InputStartLine=2,LineFileID=2,RepeatCount=2,OutputStartLine=9
 				+ "2#3,2:11\n" // InputStartLine=2,LineFileID=3,RepeatCount=2,OutputStartLine=11
 				+ "*E\n"; // EndSection
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitLineNumber(2, new Label());
 		m.visitInsn(Opcodes.NOP);
@@ -129,8 +127,6 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 				+ "7#1,2:18\n" // InputStartLine=7,LineFileID=1,RepeatCount=2,OutputStartLine=18
 				+ "2#2,2:16\n" // InputStartLine=2,LineFileID=2,RepeatCount=2,OutputStartLine=16
 				+ "*E\n"; // EndSection
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		m.visitLineNumber(11, new Label());
 		m.visitInsn(Opcodes.NOP);
@@ -196,8 +192,6 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 				+ "1#1,6:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=6,OutputStartLine=1
 				+ "7#2:7\n" // InputStartLine=7,LineFileID=2,OutputStartLine=7
 				+ "*S KotlinDebug"; // StratumID=KotlinDebug
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		Label label0 = new Label();
 		m.visitLabel(label0);
@@ -253,8 +247,6 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 				+ "1#1,11:1\n" // InputStartLine=1,LineFileID=1,RepeatCount=11,OutputStartLine=1
 				+ "9#2:12\n" // InputStartLine=9,LineFileID=2,OutputStartLine=12
 				+ "*E\n"; // EndSection
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 
 		Label label0 = new Label();
 		m.visitLabel(label0);
@@ -286,9 +278,6 @@ public class KotlinInlineFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_not_filter_when_no_SourceDebugExtension_attribute() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
-
 		m.visitLineNumber(1, new Label());
 		m.visitInsn(Opcodes.RETURN);
 

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinJvmOverloadsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinJvmOverloadsFilterTest.java
@@ -31,8 +31,6 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_generated_constructors() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(Opcodes.ACC_PUBLIC, "<init>", "()V",
 				null, null);
 		m.visitAnnotation("Lkotlin/jvm/JvmOverloads;", false);
@@ -74,8 +72,6 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_generated_functions() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(Opcodes.ACC_PUBLIC, "example",
 				"()V", null, null);
 		m.visitAnnotation("Lkotlin/jvm/JvmOverloads;", false);
@@ -112,8 +108,6 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_generated_freestanding_functions() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_STATIC,
 				"example", "()V", null, null);
@@ -152,8 +146,6 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_not_filter_non_generated_functions() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(Opcodes.ACC_PUBLIC, "call", "()V",
 				null, null);
 		m.visitAnnotation("Lkotlin/jvm/JvmOverloads;", false);
@@ -195,8 +187,6 @@ public class KotlinJvmOverloadsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_not_filter_non_generated_freestanding_functions() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(
 				Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_STATIC,
 				"call", "()V", null, null);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
@@ -42,8 +42,6 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_optimized_safe_call_chain() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"example", "(LA;)Ljava/lang/String;", null, null);
 		m.visitVarInsn(Opcodes.ALOAD, 1);
@@ -94,8 +92,6 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_unoptimized_safe_call_chain() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
 				"example", "(LA;)Ljava/lang/String;", null, null);
 		m.visitVarInsn(Opcodes.ALOAD, 0);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSyntheticAccessorsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSyntheticAccessorsFilterTest.java
@@ -35,8 +35,6 @@ public class KotlinSyntheticAccessorsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_not_filter_synthetic_non_accessor_methods_in_Kotlin_classes() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
 				Opcodes.ACC_SYNTHETIC, "example", "()V", null, null);
 		m.visitInsn(Opcodes.RETURN);
@@ -63,8 +61,6 @@ public class KotlinSyntheticAccessorsFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_synthetic_accessor_methods_in_Kotlin_classes() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
 				Opcodes.ACC_SYNTHETIC, "access$getX$p", "(Outer;)I", null,
 				null);
@@ -82,8 +78,6 @@ public class KotlinSyntheticAccessorsFilterTest extends FilterTestBase {
 		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
 				Opcodes.ACC_SYNTHETIC | Opcodes.ACC_BRIDGE, "example$default",
 				"(LTarget;Ljava/lang/String;Ijava/lang/Object;)V", null, null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		m.visitInsn(Opcodes.NOP);
 
 		filter.filter(m, context, output);
@@ -97,8 +91,6 @@ public class KotlinSyntheticAccessorsFilterTest extends FilterTestBase {
 				Opcodes.ACC_SYNTHETIC, "<init>",
 				"(IILkotlin/jvm/internal/DefaultConstructorMarker;)V", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		m.visitInsn(Opcodes.NOP);
 
 		filter.filter(m, context, output);
@@ -123,8 +115,6 @@ public class KotlinSyntheticAccessorsFilterTest extends FilterTestBase {
 				Opcodes.ACC_SYNTHETIC | Opcodes.ACC_STATIC, "example",
 				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		m.visitInsn(Opcodes.NOP);
 
 		filter.filter(m, context, output);
@@ -152,8 +142,6 @@ public class KotlinSyntheticAccessorsFilterTest extends FilterTestBase {
 				"access$example",
 				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", null,
 				null);
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		m.visitVarInsn(Opcodes.ALOAD, 0);
 		m.visitMethodInsn(Opcodes.INVOKESTATIC, "ExampleKt", "example",
 				"(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;", false);

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinUnsafeCastOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinUnsafeCastOperatorFilterTest.java
@@ -31,8 +31,6 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_filter() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final Label label = new Label();
 
 		m.visitInsn(Opcodes.DUP);
@@ -54,8 +52,6 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_filter_Kotlin_1_4() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
 		final Label label = new Label();
 
 		m.visitInsn(Opcodes.DUP);
@@ -99,9 +95,6 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 	 */
 	@Test
 	public void should_filter_Kotlin_1_5() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
-
 		final Label label = new Label();
 		m.visitJumpInsn(Opcodes.IFNONNULL, label);
 		final AbstractInsnNode expectedFrom = m.instructions.getLast();
@@ -123,9 +116,6 @@ public class KotlinUnsafeCastOperatorFilterTest extends FilterTestBase {
 
 	@Test
 	public void should_filter_Kotlin_1_6() {
-		context.classAnnotations
-				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
-
 		final Label label = new Label();
 		m.visitInsn(Opcodes.DUP);
 		m.visitJumpInsn(Opcodes.IFNONNULL, label);


### PR DESCRIPTION
This was overlooked 22ead5e845a3db08b0f3051eb9f2fe8e6edcf827.