### PR TITLE
Add links from Ant tests to corresponding code under test

### DIFF
--- a/org.jacoco.ant.test/src/org/jacoco/ant/AgentTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AgentTaskTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link AgentTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class AgentTaskTest {
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/CoverageTaskTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link CoverageTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class CoverageTaskTest {
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link DumpTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class DumpTaskTest {
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskWithServerTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/DumpTaskWithServerTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link DumpTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class DumpTaskWithServerTest {
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.java
@@ -22,6 +22,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link InstrumentTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class InstrumentTaskTest {
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/MergeTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/MergeTaskTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link MergeTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class MergeTaskTest {
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.java
@@ -22,6 +22,9 @@ import org.junit.runner.RunWith;
 
 import junit.framework.TestSuite;
 
+/**
+ * Tests for {@link ReportTask}.
+ */
 @RunWith(AntUnitSuiteRunner.class)
 public class ReportTaskTest {
 


### PR DESCRIPTION
Mainly to ease navigation from tests to code under test, and secondly in consistency with other tests.