### PR TITLE
Use Renovate instead of Dependabot for updates of GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "component: build"
   - package-ecosystem: "maven"
     directory: "/org.jacoco.build"
     schedule:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,8 +14,9 @@
       "enabled": false
     },
     {
-      "description": "Enable updates of GitHub Actions Runner Images",
-      "matchDatasources": ["github-runners"],
+      "description": "Enable updates of GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
       "enabled": true,
       "addLabels": ["component: build"]
     },


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/issues/2041