### PR TITLE
Use Renovate instead of Dependabot for updates of Kotlin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,16 +18,6 @@ updates:
       # It is known that upgrade from current version requires additional changes:
       - dependency-name: "org.apache.maven.plugins:maven-plugin-plugin"
   - package-ecosystem: "maven"
-    directory: "/org.jacoco.core.test.validation.kotlin"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "component: test"
-      - "language: Kotlin"
-    allow:
-      - dependency-name: "org.jetbrains.kotlin:*"
-  - package-ecosystem: "maven"
     directory: "/org.jacoco.core.test.validation.groovy"
     schedule:
       interval: "weekly"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["org.ow2.asm:*"],
       "enabled": true,
       "addLabels": ["component: core"]
+    },
+    {
+      "description": "Enable updates of Kotlin",
+      "matchPackageNames": ["org.jetbrains.kotlin:*"],
+      "enabled": true,
+      "addLabels": ["component: test", "language: Kotlin"]
     }
   ]
 }


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/issues/2041