### PR TITLE
Use cache in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,21 @@ jobs:
           java-version: |
             ${{ matrix.jdk }}
             21
+      - &cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml', '.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: maven-${{ runner.os }}
+      - # Cache will be saved by one job from matrix that completes first,
+        # to maximize number of dependencies in cache
+        # below command resolves statically declared dependencies
+        # (for example misses dynamically downloaded such as formatter for sptoless-maven-plugin)
+        # for modules in active by default profiles
+        # (for example includes dependencies of `org.jacoco.core.test.validation.kotlin`, but misses ecj)
+        run: ./mvnw --quiet dependency:go-offline
       - name: 'Generate toolchains.xml'
         env:
           JDK_VERSION: ${{ matrix.jdk }}
@@ -70,7 +85,7 @@ jobs:
           " > toolchains.xml
       - name: 'Build'
         run: |
-          ./mvnw -V -B -e --no-transfer-progress \
+          ./mvnw -V -B -e \
             verify -Djdk.version=${{ matrix.jdk }} -Dbytecode.version=${{ matrix.jdk }} \
             ${{ matrix.ecj && '-Decj' || ''}} \
             --toolchains=toolchains.xml
@@ -85,6 +100,7 @@ jobs:
           java-version: |
             6
             21
+      - *cache
       - name: 'Generate toolchains.xml'
         env:
           JDK_VERSION: 6
@@ -108,7 +124,7 @@ jobs:
       - name: 'Build'
         shell: bash
         run: |
-          ./mvnw -V -B -e --no-transfer-progress \
+          ./mvnw -V -B -e \
             verify -Djdk.version=6 -Dbytecode.version=5 \
             -f org.jacoco.build \
             ${{ secrets.SONARQUBE_TOKEN && 'sonar:sonar' || '' }} \


### PR DESCRIPTION
Execution of

```
mvn verify -Dmaven.repo.local=$PWD/maven-local
du -hs maven-local
```

provides rough estimation (due to some differences between builds - eg with/without ECJ)
that execution of each build downloads about 300M from Maven Central,
each GitHub Actions CI run contains 27 builds, so about 8G in total.

Better to cache this in GitHub Actions for the following reasons even if size of matrix might be reduced:

To reduce downloads from Maven Central - see https://central.sonatype.org/faq/429-error/

To be less affected by incidents with access of Maven Central (amount of which might increase due to previous point) - one known to me is quite recent https://github.com/orgs/community/discussions/183607

Also on Linux single job takes on average about 4.3 min,
out of which about 30 sec (13%) is downloading dependencies,
while cache restoration takes just 3-5 sec.
Time benefits seem even bigger on Windows.

Total duration of all jobs in GitHub Actions prior to this change is about 11.5 min and after this change is about 8.6 min (about 25% faster).

### Possible future improvements

* single cache entry for both Windows and Linux
* reduce downloads even further - even in presence of cache populated by `dependency:go-offline` there are still few downloads due to slight differences in configurations between builds (eg with/without ECJ) and dynamic dependencies (such as providers downloaded by maven-surefire-plugin, formatter downloaded by spotless-maven-plugin, and scala compiler)
* at first glance saving of cache for PR builds seems unnecessary
* time based (always/weekly/monthly) cache invalidation for default branch to prevent infinite growth - update of dependency causes restore of previous and save of updated, currently size is 250 MB for Linux and 120 MB for Windows