### PR TITLE
Remove from Azure Pipelines all builds except with JDK 5 and JDK EA

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -4,60 +4,6 @@ jobs:
     matrix:
       JDK 5:
         JDK_VERSION: 5
-      JDK 6:
-        JDK_VERSION: 6
-      JDK 7:
-        JDK_VERSION: 7
-      JDK 8:
-        JDK_VERSION: 8
-      JDK 9:
-        JDK_VERSION: 9
-      JDK 10:
-        JDK_VERSION: 10
-      JDK 11:
-        JDK_VERSION: 11
-      JDK 11 with ECJ:
-        JDK_VERSION: 11
-        ECJ: true
-      JDK 12:
-        JDK_VERSION: 12
-      JDK 13:
-        JDK_VERSION: 13
-      JDK 14:
-        JDK_VERSION: 14
-      JDK 15:
-        JDK_VERSION: 15
-      JDK 16:
-        JDK_VERSION: 16
-      JDK 17:
-        JDK_VERSION: 17
-      JDK 17 with ECJ:
-        JDK_VERSION: 17
-        ECJ: true
-      JDK 18:
-        JDK_VERSION: 18
-      JDK 19:
-        JDK_VERSION: 19
-      JDK 20:
-        JDK_VERSION: 20
-      JDK 21:
-        JDK_VERSION: 21
-      JDK 21 with ECJ:
-        JDK_VERSION: 21
-        ECJ: true
-      JDK 22:
-        JDK_VERSION: 22
-      JDK 23:
-        JDK_VERSION: 23
-      JDK 23 with ECJ:
-        JDK_VERSION: 23
-        ECJ: true
-      JDK 24:
-        JDK_VERSION: 24
-      JDK 25:
-        JDK_VERSION: 25
-      JDK 26:
-        JDK_VERSION: 26
       JDK 27:
         JDK_VERSION: 27
   pool:


### PR DESCRIPTION
Average duration of single job
in AzurePipelines is about 5.5 min
in GitHub Actions is about 4.3 min

There is also difference in cap on max parallel jobs
[in AzurePipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/licensing/concurrent-jobs?view=azure-devops&tabs=ms-hosted#:~:text=For%20Microsoft%2Dhosted%20parallel%20jobs%2C%20you%20can%20get%20up%20to%2010%20free%20Microsoft%2Dhosted%20parallel%20jobs) - 10
[in GitHub Actions](https://docs.github.com/en/actions/reference/limits#:~:text=concurrent%20GPU%20jobs-,Standard%20GitHub%2Dhosted%20runner,20,-5) - 20

Both already cross this cap
in AzurePipelines - 29 jobs
in GitHub Actions - 27 jobs (without JDK 5 and EA)

Due to the above for the initially empty queue total duration
in AzurePipelines is about 18 min
in GitHub Actions is about 11.5 min

After this change total duration for AzurePipelines will go down to time of two parallel jobs - about 5.5 min.

Merge of PR requires wait of slowest CI, so prior to this change at least about 18 min, and after will be about 11.5 min (about 36% faster), and after #2146 even down to about 8.6 min (about 52% faster).

Also according to #2146 all removed builds download from Maven Central about 8 G, and so this change saves that without setup of caching in AzurePipelines.
