### PR TITLE
Fix typo

### DIFF
--- a/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
+++ b/org.jacoco.ant/src/org/jacoco/ant/AbstractCoverageTask.java
@@ -138,7 +138,7 @@ public class AbstractCoverageTask extends Task {
 	}
 
 	/**
-	 * Sets the session identifier. Default is a auto-generated id
+	 * Sets the session identifier. Default is an auto-generated id
 	 *
 	 * @param id
 	 *            session identifier


### PR DESCRIPTION
"an" should be used instead of "a" when the
following word starts with a vowel sound.

---

[I did my best last time](https://github.com/jacoco/jacoco/pull/2088), and [before](https://github.com/jacoco/jacoco/pull/1799)... still overlooked this one 😞 so unfortunately doubt that can guarantee that this is the last existing typo of the same kind 😅