### PR TITLE
Use Renovate instead of Dependabot for updates of Maven Plugins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,26 @@
       "addLabels": ["component: build"]
     },
     {
+      "description": "Enable updates of Maven Plugins",
+      "matchManagers": ["maven"],
+      "matchDepTypes": ["build"],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:*",
+        "org.codehaus.plexus:plexus-compiler-eclipse",
+        "org.codehaus.mojo:*",
+        "com.diffplug.spotless:*",
+        "org.apache.felix:*",
+        "org.sonarsource.scanner.maven:*"
+      ],
+      "enabled": true,
+      "addLabels": ["component: build"]
+    },
+    {
+      "description": "It is known that update of maven-plugin-plugin from 3.6.4 to 3.7.0 requires additional changes",
+      "matchPackageNames": ["org.apache.maven.plugins:maven-plugin-plugin"],
+      "allowedVersions": "<3.7.0"
+    },
+    {
       "description": "Enable updates of ASM",
       "matchPackageNames": ["org.ow2.asm:*"],
       "enabled": true,


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/issues/2041