### PR TITLE
Use strict equality in allowAnywhereFoldCaseAndRen

### DIFF
--- a/org.jacoco.report/src/org/jacoco/report/internal/html/resources/prettify.js
+++ b/org.jacoco.report/src/org/jacoco/report/internal/html/resources/prettify.js
@@ -483,7 +483,7 @@ window['_pr_isIE6'] = function () {
               + '|\\\\x[A-Fa-f0-9]{2}'  // a hex escape
               + '|\\\\[0-9]+'  // a back-reference or octal escape
               + '|\\\\[^ux0-9]'  // other escape sequence
-              + '|\\(\\?[:!=]'  // start of a non-capturing group
+              + '|\\(\\?[:!==]'  // start of a non-capturing group
               + '|[\\(\\)\\^]'  // start/emd of a group, or line start
               + '|[^\\x5B\\x5C\\(\\)\\^]+'  // run of other characters
               + ')',


### PR DESCRIPTION
Not sure how often allowAnywhereFoldCaseAndRenumberGroups hits the edge case, but The loose equality here can coerce values in ways that are hard to spot later. this patch tightens it to strict equality. Close this if it’s not worth the noise.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.