### PR TITLE
Fix warning  #2147

### DIFF
--- a/org.jacoco.ant.test/pom.xml
+++ b/org.jacoco.ant.test/pom.xml
@@ -64,9 +64,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <basedir>${project.build.outputDirectory}/org/jacoco/ant</basedir>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/org.jacoco.ant.test/src/org/jacoco/ant/AntUnitSuiteFactory.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AntUnitSuiteFactory.java
@@ -36,8 +36,7 @@ final class AntUnitSuiteFactory {
 	 * @return empty suite for given {@code testClass}
 	 */
 	static AntUnitSuite skip(final Class<?> testClass) {
-		return new AntUnitSuite(getResource(testClass, "empty.xml"),
-				testClass);
+		return new AntUnitSuite(getResource(testClass, "empty.xml"), testClass);
 	}
 
 	/** @return file for classpath resource next to {@code testClass} */
@@ -51,8 +50,8 @@ final class AntUnitSuiteFactory {
 		try {
 			return new File(url.toURI());
 		} catch (final URISyntaxException e) {
-			throw new IllegalArgumentException(
-					"Invalid resource URL: " + url, e);
+			throw new IllegalArgumentException("Invalid resource URL: " + url,
+					e);
 		}
 	}
 

--- a/org.jacoco.ant.test/src/org/jacoco/ant/AntUnitSuiteFactory.java
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/AntUnitSuiteFactory.java
@@ -13,6 +13,8 @@
 package org.jacoco.ant;
 
 import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 import org.apache.ant.antunit.junit3.AntUnitSuite;
 
@@ -25,17 +27,33 @@ final class AntUnitSuiteFactory {
 	 * @return suite for given {@code testClass}
 	 */
 	static AntUnitSuite suiteFor(final Class<?> testClass) {
-		final File file = new File(
-				"src/org/jacoco/ant/" + testClass.getSimpleName() + ".xml");
-		return new AntUnitSuite(file, testClass);
+		return new AntUnitSuite(
+				getResource(testClass, testClass.getSimpleName() + ".xml"),
+				testClass);
 	}
 
 	/**
 	 * @return empty suite for given {@code testClass}
 	 */
 	static AntUnitSuite skip(final Class<?> testClass) {
-		final File file = new File("src/org/jacoco/ant/empty.xml");
-		return new AntUnitSuite(file, testClass);
+		return new AntUnitSuite(getResource(testClass, "empty.xml"),
+				testClass);
+	}
+
+	/** @return file for classpath resource next to {@code testClass} */
+	private static File getResource(final Class<?> testClass,
+			final String resource) {
+		final URL url = testClass.getResource(resource);
+		if (url == null) {
+			throw new IllegalArgumentException(
+					"Resource not found: " + resource);
+		}
+		try {
+			return new File(url.toURI());
+		} catch (final URISyntaxException e) {
+			throw new IllegalArgumentException(
+					"Invalid resource URL: " + url, e);
+		}
 	}
 
 }

--- a/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/InstrumentTaskTest.xml
@@ -15,6 +15,7 @@
 <project name="JaCoCo Instrument Task Tests" xmlns:au="antlib:org.apache.ant.antunit" xmlns:jacoco="antlib:org.jacoco.ant">
 
 	<target name="setUp">
+		<dirname property="org.jacoco.ant.test.basedir" file="${ant.file}"/>
 		<tempfile property="temp.dir" prefix="jacocoTest" destdir="${java.io.tmpdir}" />
 		<mkdir dir="${temp.dir}"/>
 		<property name="exec.file" location="${temp.dir}/exec.file" />
@@ -58,7 +59,7 @@
 		<jar destfile="${lib.dir}/test.jar">
 			<fileset dir="${org.jacoco.ant.instrumentTaskTest.classes.dir}" includes="**/*.class"/>
 		</jar>
-		<signjar jar="${lib.dir}/test.jar" keystore="${basedir}/data/keystore.jks" alias="test" storepass="password"/>
+		<signjar jar="${lib.dir}/test.jar" keystore="${org.jacoco.ant.test.basedir}/data/keystore.jks" alias="test" storepass="password"/>
 
 		<jacoco:instrument destdir="${instr.dir}">
 			<fileset dir="${lib.dir}" includes="*.jar"/>
@@ -79,7 +80,7 @@
 		<jar destfile="${lib.dir}/test.jar">
 			<fileset dir="${org.jacoco.ant.instrumentTaskTest.classes.dir}" includes="**/*.class"/>
 		</jar>
-		<signjar jar="${lib.dir}/test.jar" keystore="${basedir}/data/keystore.jks" alias="test" storepass="password"/>
+		<signjar jar="${lib.dir}/test.jar" keystore="${org.jacoco.ant.test.basedir}/data/keystore.jks" alias="test" storepass="password"/>
 
 		<jacoco:instrument destdir="${instr.dir}" removesignatures="false">
 			<fileset dir="${lib.dir}" includes="*.jar"/>

--- a/org.jacoco.ant.test/src/org/jacoco/ant/MergeTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/MergeTaskTest.xml
@@ -15,6 +15,7 @@
 <project name="JaCoCo Merge Task Tests" xmlns:au="antlib:org.apache.ant.antunit" xmlns:jacoco="antlib:org.jacoco.ant">
 
 	<target name="setUp">
+		<dirname property="org.jacoco.ant.test.basedir" file="${ant.file}"/>
 		<tempfile property="temp.dir" prefix="jacocoTest" destdir="${java.io.tmpdir}" />
 		<mkdir dir="${temp.dir}"/>
 		<property name="exec.file" location="${temp.dir}/exec.file" />
@@ -44,11 +45,11 @@
 
 	<target name="testMergeMultipleFiles">
 		<jacoco:merge destfile="${exec.file}">
-			<fileset dir="${basedir}/data" includes="*.exec"/>
+			<fileset dir="${org.jacoco.ant.test.basedir}/data" includes="*.exec"/>
 		</jacoco:merge>
 
-		<property name="sample1.file" location="${basedir}/data/sample1.exec"/>
-		<property name="sample2.file" location="${basedir}/data/sample2.exec"/>
+		<property name="sample1.file" location="${org.jacoco.ant.test.basedir}/data/sample1.exec"/>
+		<property name="sample2.file" location="${org.jacoco.ant.test.basedir}/data/sample2.exec"/>
 		<au:assertLogContains text="Loading execution data file ${sample1.file}"/>
 		<au:assertLogContains text="Loading execution data file ${sample2.file}"/>
 		<au:assertLogContains text="Writing merged execution data to ${exec.file}"/>
@@ -56,17 +57,17 @@
 	</target>
 
 	<target name="testMergeBadFiles">
-		<property name="bad.file" location="${basedir}/data/sample.bad"/>
+		<property name="bad.file" location="${org.jacoco.ant.test.basedir}/data/sample.bad"/>
 		<au:expectfailure expectedMessage="Unable to read ${bad.file}">
 		<jacoco:merge destfile="${exec.file}">
-			<file file="${basedir}/data/sample.bad"/>
+			<file file="${org.jacoco.ant.test.basedir}/data/sample.bad"/>
 		</jacoco:merge>
 		</au:expectfailure>
 	</target>
 
 	<target name="testMergeDirectory">
 		<jacoco:merge destfile="${exec.file}">
-			<dirset dir="${basedir}/data"/>
+			<dirset dir="${org.jacoco.ant.test.basedir}/data"/>
 		</jacoco:merge>
 
 		<au:assertFileExists file="${exec.file}"/>

--- a/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/ReportTaskTest.xml
@@ -16,6 +16,7 @@
 <project name="JaCoCo Report Task Tests" xmlns:au="antlib:org.apache.ant.antunit" xmlns:jacoco="antlib:org.jacoco.ant">
 
 	<target name="setUp">
+		<dirname property="org.jacoco.ant.test.basedir" file="${ant.file}"/>
 		<tempfile property="temp.dir" prefix="jacocoTest" destdir="${java.io.tmpdir}" />
 		<mkdir dir="${temp.dir}"/>
 	</target>
@@ -52,7 +53,7 @@
 	<target name="testReportWithExecutiondataFiles">
 		<jacoco:report>
 			<executiondata>
-				<fileset dir="${basedir}/data" includes="*.exec"/>
+				<fileset dir="${org.jacoco.ant.test.basedir}/data" includes="*.exec"/>
 			</executiondata>
 			<structure name="root"/>
 		</jacoco:report>
@@ -118,7 +119,7 @@
 	</target>
 
 	<target name="testReportWithNoMatch">
-		<property name="nomatch.file" location="${basedir}/data/nomatch.exec"/>
+		<property name="nomatch.file" location="${org.jacoco.ant.test.basedir}/data/nomatch.exec"/>
 		<jacoco:report>
 			<executiondata>
 				<file file="${nomatch.file}"/>

--- a/org.jacoco.ant.test/src/org/jacoco/ant/SecurityManagerTest.xml
+++ b/org.jacoco.ant.test/src/org/jacoco/ant/SecurityManagerTest.xml
@@ -15,6 +15,7 @@
 <project name="JaCoCo with Java SecurityManager Test" xmlns:au="antlib:org.apache.ant.antunit" xmlns:jacoco="antlib:org.jacoco.ant">
 
 	<target name="setUp">
+		<dirname property="org.jacoco.ant.test.basedir" file="${ant.file}"/>
 		<tempfile property="temp.dir" prefix="jacocoTest" destdir="${java.io.tmpdir}" />
 		<mkdir dir="${temp.dir}"/>
 		<property name="exec.file" location="${temp.dir}/jacoco.exec" />
@@ -32,7 +33,7 @@
 				<jvmarg value="-Djacoco.exec=${exec.file}"/>
 				<jvmarg value="-Djava.security.manager"/>
 				<!-- Note that the use of two equal signs (==) below is not a typo -->
-				<jvmarg value="-Djava.security.policy==${basedir}/data/policy.txt"/>
+				<jvmarg value="-Djava.security.policy==${org.jacoco.ant.test.basedir}/data/policy.txt"/>
 			</java>
 		</jacoco:coverage>
 


### PR DESCRIPTION
Removed the read-only Surefire basedir config and updated AntUnitSuiteFactory to load AntUnit XML files from classpath resources.
Updated affected Ant XML tests to derive their data directory from ${ant.file}