### PR TITLE
Use Renovate instead of Dependabot for updates of Maven Plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "maven"
-    directory: "/org.jacoco.build"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "component: build"
-    allow:
-      - dependency-name: "org.apache.maven.plugins:*"
-      - dependency-name: "org.codehaus.plexus:plexus-compiler-eclipse"
-      - dependency-name: "org.codehaus.mojo:*"
-      - dependency-name: "com.diffplug.spotless:*"
-      - dependency-name: "org.apache.felix:*"
-      - dependency-name: "org.sonarsource.scanner.maven:*"
-    ignore:
-      # It is known that upgrade from current version requires additional changes:
-      - dependency-name: "org.apache.maven.plugins:maven-plugin-plugin"
-  - package-ecosystem: "maven"
     directory: "/org.jacoco.core.test.validation.groovy"
     schedule:
       interval: "weekly"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,26 @@
       "addLabels": ["component: build"]
     },
     {
+      "description": "Enable updates of Maven Plugins",
+      "matchManagers": ["maven"],
+      "matchDepTypes": ["build"],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:*",
+        "org.codehaus.plexus:plexus-compiler-eclipse",
+        "org.codehaus.mojo:*",
+        "com.diffplug.spotless:*",
+        "org.apache.felix:*",
+        "org.sonarsource.scanner.maven:*"
+      ],
+      "enabled": true,
+      "addLabels": ["component: build"]
+    },
+    {
+      "description": "Disable updates of maven-plugin-plugin to 3.7.0 and above, because they require additional changes",
+      "matchPackageNames": ["org.apache.maven.plugins:maven-plugin-plugin"],
+      "allowedVersions": "<3.7.0"
+    },
+    {
       "description": "Enable updates of ASM",
       "matchPackageNames": ["org.ow2.asm:*"],
       "enabled": true,


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/issues/2041