### PR TITLE
Fix MethodReferencesTest for javac >= 24

### DIFF
--- a/org.jacoco.core.test.validation.java8/src/org/jacoco/core/test/validation/java8/MethodReferencesTest.java
+++ b/org.jacoco.core.test.validation.java8/src/org/jacoco/core/test/validation/java8/MethodReferencesTest.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 
 import org.jacoco.core.internal.instr.InstrSupport;
 import org.jacoco.core.test.TargetLoader;
+import org.jacoco.core.test.validation.JavaVersion;
 import org.jacoco.core.test.validation.Source;
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.java8.targets.MethodReferencesTarget;
@@ -107,8 +108,14 @@ public class MethodReferencesTest extends ValidationTestBase {
 				assertEquals(10, names.size());
 				if (bytecodeVersion() < Opcodes.V11) {
 					// accessor methods used by above lambda methods
-					assertTrue(accessors.contains("access$000"));
-					assertTrue(accessors.contains("access$100"));
+					if (JavaVersion.current().isBefore("24")) {
+						assertTrue(accessors.contains("access$000"));
+						assertTrue(accessors.contains("access$100"));
+					} else {
+						// https://github.com/openjdk/jdk/commit/4ce8822b6c53b8bd72713f1bfaf6673b91aabea4
+						assertTrue(accessors.contains("access$100"));
+						assertTrue(accessors.contains("access$200"));
+					}
 					assertEquals(2, accessors.size());
 				} else {
 					// JEP 181: Nest-Based Access Control


### PR DESCRIPTION
Fixes #2111 

---


```
git bisect start '--' 'src/jdk.compiler/'
# status: waiting for both good and bad commits
# good: [054362abe040938b87eb1a1cab8a0a94540e0667] 8332550: [macos] Voice Over: java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location
git bisect good 054362abe040938b87eb1a1cab8a0a94540e0667
# bad: [6705a9255d28f351950e7fbca9d05e73942a4e27] 8345276: Remove EA from the JDK 24 version string with first RC promotion
git bisect bad 6705a9255d28f351950e7fbca9d05e73942a4e27
# bad: [5e822c24bb42e9027c8d9090d498bca7125d1963] 8334870: javac does not accept classfiles with certain permitted RuntimeVisibleParameterAnnotations and RuntimeInvisibleParameterAnnotations attributes
git bisect bad 5e822c24bb42e9027c8d9090d498bca7125d1963
# bad: [4635531950dbcfcd3ee2f13a57f0909af78a94c7] 8335159: Move method reference to lambda desugaring before Lower 8336320: NullPointerException: Cannot invoke Type.getTag because type is null after JDK-8334037
git bisect bad 4635531950dbcfcd3ee2f13a57f0909af78a94c7
# bad: [3796fdfcedc2b2202b72cca062218f840960414c] 8328536: javac - crash on unknown type referenced in yield statement
git bisect bad 3796fdfcedc2b2202b72cca062218f840960414c
# good: [dae0bda9d0096c25d6378561ab2d09df05f381cf] 8334252: Verifier error for lambda declared in early construction context
git bisect good dae0bda9d0096c25d6378561ab2d09df05f381cf
# good: [e227c7e37d4de0656f013f3a936b1acfa56cc2e0] 8334258: Compiler erronousely allows access to instance variable in argument expression of a constructor invocation
git bisect good e227c7e37d4de0656f013f3a936b1acfa56cc2e0
# good: [7b3a96d57023e8a7cf495e2d7c551976f0e5656b] 8334488: Improve error for illegal early access from nested class
git bisect good 7b3a96d57023e8a7cf495e2d7c551976f0e5656b
# bad: [4ce8822b6c53b8bd72713f1bfaf6673b91aabea4] 8334037: Local class creation in lambda in pre-construction context crashes javac 8333313: NullPointerException in lambda instantiating an inner local class in prologue 8333766: Stack overflow with anonymous class in super() parameter 8334679: Wrong bug number in regression test for JDK-8334252
git bisect bad 4ce8822b6c53b8bd72713f1bfaf6673b91aabea4
# first bad commit: [4ce8822b6c53b8bd72713f1bfaf6673b91aabea4] 8334037: Local class creation in lambda in pre-construction context crashes javac 8333313: NullPointerException in lambda instantiating an inner local class in prologue 8333766: Stack overflow with anonymous class in super() parameter 8334679: Wrong bug number in regression test for JDK-8334252
```
