### PR TITLE
Kotlin `@JvmExposeBoxed` should not be applied on private declarations

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.kt
@@ -22,18 +22,18 @@ object KotlinInlineClassExposeTarget {
 
     @JvmExposeBoxed // assertEmpty()
     @JvmInline // assertEmpty()
-    private value class ValueClass(val value: String) // assertEmpty()
+    value class ValueClass(val value: String) // assertEmpty()
 
     @JvmExposeBoxed // assertEmpty()
-    private fun exposeReturnType(): ValueClass = // assertEmpty()
+    fun exposeReturnType(): ValueClass = // assertEmpty()
         ValueClass("")
 
     @JvmExposeBoxed // assertEmpty()
-    private fun exposeParameter(p: ValueClass) = // assertEmpty()
+    fun exposeParameter(p: ValueClass) = // assertEmpty()
         nop(p) // assertFullyCovered()
 
     @JvmExposeBoxed // assertEmpty()
-    private fun exposeUseless() = // assertEmpty()
+    fun exposeUseless() = // assertEmpty()
         nop() // assertFullyCovered()
 
     @JvmStatic


### PR DESCRIPTION
See
* https://youtrack.jetbrains.com/issue/KT-87032
* https://github.com/JetBrains/kotlin/commit/83ec820d7d8595dd7fc4c0f27f607cca6f3c7a61