### PR TITLE
Add boundary counter for ordered numeric comparisons

### DIFF
--- a/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/BoundaryTest.java
+++ b/org.jacoco.core.test.validation.java5/src/org/jacoco/core/test/validation/java5/BoundaryTest.java
@@ -1,0 +1,454 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.java5;
+
+import static org.jacoco.core.test.validation.targets.Stubs.nop;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
+import org.jacoco.core.analysis.IMethodCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.SessionInfoStore;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.RuntimeData;
+import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.jacoco.core.test.TargetLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of the boundary counter, which reports whether an ordered numeric
+ * comparison was ever evaluated with equal values.
+ *
+ * Every target here is compiled by the compiler under test and then executed,
+ * so these tests pin down the bytecode shapes that the boundary probe has to
+ * recognize. A compiler that emits a different shape for the same source shows
+ * up as a changed counter rather than as silently missing data.
+ */
+public class BoundaryTest {
+
+	public interface Target {
+		public void test(int arg);
+	}
+
+	public interface LongTarget {
+		public void test(long arg);
+	}
+
+	public interface DoubleTarget {
+		public void test(double arg);
+	}
+
+	public interface StringTarget {
+		public void test(String arg);
+	}
+
+	private RuntimeData data;
+	private IRuntime runtime;
+	private byte[] bytes;
+	private Object target;
+
+	@Before
+	public void setup() throws Exception {
+		data = new RuntimeData();
+		runtime = new SystemPropertiesRuntime();
+		runtime.startup(data);
+	}
+
+	@After
+	public void teardown() {
+		runtime.shutdown();
+	}
+
+	// === Ordered comparison of int values ===
+
+	public static class GreaterThan implements Target {
+		public void test(int arg) {
+			if (arg > 6) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void boundary_should_be_empty_when_no_branch_is_covered()
+			throws Exception {
+		instrument(GreaterThan.class);
+		assertBoundary(0, 0);
+	}
+
+	@Test
+	public void boundary_should_be_empty_when_only_one_branch_is_covered()
+			throws Exception {
+		instrument(GreaterThan.class);
+		test(7);
+		assertBoundary(0, 0);
+	}
+
+	@Test
+	public void boundary_should_be_missed_when_equal_values_are_not_used()
+			throws Exception {
+		instrument(GreaterThan.class);
+		test(5);
+		test(7);
+		assertBoundary(1, 0);
+	}
+
+	@Test
+	public void boundary_should_be_covered_when_equal_values_are_used()
+			throws Exception {
+		instrument(GreaterThan.class);
+		test(5);
+		test(6);
+		test(7);
+		assertBoundary(0, 1);
+	}
+
+	public static class GreaterOrEqual implements Target {
+		public void test(int arg) {
+			if (arg >= 6) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void non_strict_comparison_should_report_boundary()
+			throws Exception {
+		instrument(GreaterOrEqual.class);
+		test(5);
+		test(7);
+		assertBoundary(1, 0);
+	}
+
+	@Test
+	public void non_strict_comparison_should_cover_boundary_with_equal_value()
+			throws Exception {
+		instrument(GreaterOrEqual.class);
+		test(5);
+		test(6);
+		assertBoundary(0, 1);
+	}
+
+	// === Comparison against zero, which javac emits without a constant ===
+
+	public static class GreaterThanZero implements Target {
+		public void test(int arg) {
+			if (arg > 0) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void comparison_against_zero_should_report_boundary()
+			throws Exception {
+		instrument(GreaterThanZero.class);
+		test(-1);
+		test(1);
+		assertBoundary(1, 0);
+	}
+
+	@Test
+	public void comparison_against_zero_should_cover_boundary_with_zero()
+			throws Exception {
+		instrument(GreaterThanZero.class);
+		test(-1);
+		test(0);
+		test(1);
+		assertBoundary(0, 1);
+	}
+
+	// === Equality has no boundary ===
+
+	public static class EqualTo implements Target {
+		public void test(int arg) {
+			if (arg == 6) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void equality_comparison_should_not_report_boundary()
+			throws Exception {
+		instrument(EqualTo.class);
+		test(5);
+		test(6);
+		assertBoundary(0, 0);
+	}
+
+	public static class NotEqualTo implements Target {
+		public void test(int arg) {
+			if (arg != 6) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void inequality_comparison_should_not_report_boundary()
+			throws Exception {
+		instrument(NotEqualTo.class);
+		test(5);
+		test(6);
+		assertBoundary(0, 0);
+	}
+
+	// === Reference comparison has no boundary ===
+
+	public static class NullCheck implements StringTarget {
+		public void test(String arg) {
+			if (arg != null) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void null_check_should_not_report_boundary() throws Exception {
+		instrument(NullCheck.class);
+		testString("a");
+		testString(null);
+		assertBoundary(0, 0);
+	}
+
+	// === long values, compiled to LCMP followed by a comparison ===
+
+	public static class LongGreaterThan implements LongTarget {
+		public void test(long arg) {
+			if (arg > 6L) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void long_comparison_should_report_missed_boundary()
+			throws Exception {
+		instrument(LongGreaterThan.class);
+		testLong(5);
+		testLong(7);
+		assertBoundary(1, 0);
+	}
+
+	@Test
+	public void long_comparison_should_report_covered_boundary()
+			throws Exception {
+		instrument(LongGreaterThan.class);
+		testLong(5);
+		testLong(6);
+		testLong(7);
+		assertBoundary(0, 1);
+	}
+
+	public static class LongEqualTo implements LongTarget {
+		public void test(long arg) {
+			if (arg == 6L) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void long_equality_should_not_report_boundary() throws Exception {
+		instrument(LongEqualTo.class);
+		testLong(5);
+		testLong(6);
+		assertBoundary(0, 0);
+	}
+
+	// === double values, compiled to DCMP followed by a comparison ===
+
+	public static class DoubleLessThan implements DoubleTarget {
+		public void test(double arg) {
+			if (arg < 6d) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void double_comparison_should_report_covered_boundary()
+			throws Exception {
+		instrument(DoubleLessThan.class);
+		testDouble(5);
+		testDouble(6);
+		assertBoundary(0, 1);
+	}
+
+	@Test
+	public void double_comparison_should_not_treat_nan_as_boundary()
+			throws Exception {
+		instrument(DoubleLessThan.class);
+		testDouble(5);
+		testDouble(Double.NaN);
+		assertBoundary(1, 0);
+	}
+
+	// === compareTo(), where zero means that the operands are equal ===
+
+	public static class CompareTo implements StringTarget {
+		public void test(String arg) {
+			if (arg.compareTo("b") < 0) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void compare_to_should_report_missed_boundary() throws Exception {
+		instrument(CompareTo.class);
+		testString("a");
+		testString("c");
+		assertBoundary(1, 0);
+	}
+
+	@Test
+	public void compare_to_should_report_covered_boundary() throws Exception {
+		instrument(CompareTo.class);
+		testString("a");
+		testString("b");
+		assertBoundary(0, 1);
+	}
+
+	// === Two comparisons in one method ===
+
+	public static class TwoComparisons implements Target {
+		public void test(int arg) {
+			if (arg > 6) {
+				nop();
+			}
+			if (arg < 20) {
+				nop();
+			}
+		}
+	}
+
+	@Test
+	public void two_comparisons_should_be_counted_separately()
+			throws Exception {
+		instrument(TwoComparisons.class);
+		test(6);
+		test(7);
+		test(25);
+		// arg > 6 is evaluated with the boundary value 6, arg < 20 is not
+		// evaluated with 20
+		assertBoundary(1, 1);
+	}
+
+	@Test
+	public void comparison_with_one_missed_branch_should_not_be_counted()
+			throws Exception {
+		instrument(TwoComparisons.class);
+		test(6);
+		test(7);
+		// arg < 20 is true for both values, so one of its branches is missed
+		assertBoundary(0, 1);
+	}
+
+	// === Operands of a conditional expression ===
+
+	public static class AndCondition implements Target {
+		public void test(int arg) {
+			if (arg > 6 && arg < 20) {
+				nop();
+			}
+		}
+	}
+
+	/**
+	 * For plain Java each operand of <code>&amp;&amp;</code> keeps its own two
+	 * branches, which branch coverage already reports as four branches on the
+	 * line. Each operand therefore also gets its own boundary. This is not the
+	 * case where
+	 * {@link org.jacoco.core.internal.analysis.Instruction#replaceBranches}
+	 * applies, which is why that method drops the boundary.
+	 */
+	@Test
+	public void operands_of_conditional_expression_should_be_counted_separately()
+			throws Exception {
+		instrument(AndCondition.class);
+		test(5);
+		test(6);
+		test(7);
+		test(20);
+		assertBoundary(0, 2);
+	}
+
+	@Test
+	public void short_circuited_operand_should_not_be_counted()
+			throws Exception {
+		instrument(AndCondition.class);
+		test(5);
+		test(7);
+		// arg < 20 is only evaluated for 7, so one of its branches is missed,
+		// while arg > 6 is fully covered without ever seeing the value 6
+		assertBoundary(1, 0);
+	}
+
+	private void test(final int arg) {
+		((Target) target).test(arg);
+	}
+
+	private void testLong(final long arg) {
+		((LongTarget) target).test(arg);
+	}
+
+	private void testDouble(final double arg) {
+		((DoubleTarget) target).test(arg);
+	}
+
+	private void testString(final String arg) {
+		((StringTarget) target).test(arg);
+	}
+
+	private void instrument(final Class<?> clazz) throws Exception {
+		bytes = TargetLoader.getClassDataAsBytes(clazz);
+		final byte[] instrumented = new Instrumenter(runtime).instrument(bytes,
+				"TestTarget");
+		final TargetLoader loader = new TargetLoader();
+		target = loader.add(clazz, instrumented).newInstance();
+	}
+
+	private void assertBoundary(final int missed, final int covered)
+			throws IOException {
+		final CoverageBuilder builder = new CoverageBuilder();
+		final ExecutionDataStore store = new ExecutionDataStore();
+		data.collect(store, new SessionInfoStore(), false);
+		final Analyzer analyzer = new Analyzer(store, builder);
+		analyzer.analyzeClass(bytes, "TestTarget");
+		final Collection<IClassCoverage> classes = builder.getClasses();
+		assertEquals(1, classes.size(), 0.0);
+		final IClassCoverage classCoverage = classes.iterator().next();
+		for (final IMethodCoverage m : classCoverage.getMethods()) {
+			if (m.getName().equals("test")) {
+				assertEquals(CounterImpl.getInstance(missed, covered),
+						m.getCounter(CounterEntity.BOUNDARY));
+				return;
+			}
+		}
+		throw new AssertionError("No test() method.");
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinBoundaryTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinBoundaryTest.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
+import org.jacoco.core.analysis.IMethodCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.SessionInfoStore;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.RuntimeData;
+import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.jacoco.core.test.TargetLoader;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinBoundaryTarget;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of the boundary counter for Kotlin. Kotlin routes several constructs
+ * through comparisons that do not appear in the source, and its filters remove
+ * or rewrite instructions during analysis, so the shapes the boundary probe
+ * sees here differ from the ones javac produces.
+ */
+public class KotlinBoundaryTest {
+
+	private RuntimeData data;
+	private IRuntime runtime;
+	private byte[] bytes;
+	private Object target;
+
+	@Before
+	public void setup() throws Exception {
+		data = new RuntimeData();
+		runtime = new SystemPropertiesRuntime();
+		runtime.startup(data);
+
+		bytes = TargetLoader.getClassDataAsBytes(KotlinBoundaryTarget.class);
+		final byte[] instrumented = new Instrumenter(runtime).instrument(bytes,
+				"TestTarget");
+		final TargetLoader loader = new TargetLoader();
+		target = loader.add(KotlinBoundaryTarget.class, instrumented)
+				.newInstance();
+	}
+
+	@After
+	public void teardown() {
+		runtime.shutdown();
+	}
+
+	@Test
+	public void comparison_should_report_missed_boundary() throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(5));
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 1, 0);
+	}
+
+	@Test
+	public void comparison_should_report_covered_boundary() throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(5));
+		call("greaterThan", int.class, Integer.valueOf(6));
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 0, 1);
+	}
+
+	/**
+	 * A range check is two comparisons, one against each end, so both ends are
+	 * reported separately. Note that Kotlin normalizes the upper end to an
+	 * exclusive bound: <code>arg in 1..10</code> compiles to
+	 * <code>1 &gt; arg</code> and <code>arg &gt;= 11</code>, so the boundary
+	 * value of the upper comparison is 11 and not 10.
+	 */
+	@Test
+	public void range_check_should_report_both_ends() throws Exception {
+		call("inRange", int.class, Integer.valueOf(0));
+		call("inRange", int.class, Integer.valueOf(5));
+		call("inRange", int.class, Integer.valueOf(12));
+
+		assertBoundary("inRange", 2, 0);
+	}
+
+	@Test
+	public void range_check_should_cover_both_ends() throws Exception {
+		call("inRange", int.class, Integer.valueOf(0));
+		call("inRange", int.class, Integer.valueOf(1));
+		call("inRange", int.class, Integer.valueOf(10));
+		call("inRange", int.class, Integer.valueOf(11));
+
+		assertBoundary("inRange", 0, 2);
+	}
+
+	@Test
+	public void when_with_comparison_should_report_boundary() throws Exception {
+		call("whenWithComparison", int.class, Integer.valueOf(5));
+		call("whenWithComparison", int.class, Integer.valueOf(7));
+
+		assertBoundary("whenWithComparison", 1, 0);
+	}
+
+	@Test
+	public void when_with_range_should_report_boundary() throws Exception {
+		call("whenWithRange", int.class, Integer.valueOf(0));
+		call("whenWithRange", int.class, Integer.valueOf(5));
+		call("whenWithRange", int.class, Integer.valueOf(12));
+
+		assertBoundary("whenWithRange", 2, 0);
+	}
+
+	@Test
+	public void elvis_then_comparison_should_report_boundary()
+			throws Exception {
+		call("elvisThenComparison", Integer.class, null);
+		call("elvisThenComparison", Integer.class, Integer.valueOf(7));
+
+		assertBoundary("elvisThenComparison", 1, 0);
+	}
+
+	@Test
+	public void nullable_comparison_should_report_boundary() throws Exception {
+		call("nullableComparison", Integer.class, null);
+		call("nullableComparison", Integer.class, Integer.valueOf(5));
+		call("nullableComparison", Integer.class, Integer.valueOf(7));
+
+		assertBoundary("nullableComparison", 1, 0);
+	}
+
+	@Test
+	public void long_comparison_should_report_boundary() throws Exception {
+		call("longGreaterThan", long.class, Long.valueOf(5));
+		call("longGreaterThan", long.class, Long.valueOf(6));
+		call("longGreaterThan", long.class, Long.valueOf(7));
+
+		assertBoundary("longGreaterThan", 0, 1);
+	}
+
+	/**
+	 * The comparison operator on a {@link Comparable} compiles to compareTo()
+	 * followed by a comparison of its result against zero, where zero means
+	 * that the two operands are equal.
+	 */
+	@Test
+	public void comparable_operator_should_report_covered_boundary()
+			throws Exception {
+		callTwoStrings("a", "b");
+		callTwoStrings("b", "b");
+		callTwoStrings("c", "b");
+
+		assertBoundary("comparableOperator", 0, 1);
+	}
+
+	@Test
+	public void comparable_operator_should_report_missed_boundary()
+			throws Exception {
+		callTwoStrings("a", "b");
+		callTwoStrings("c", "b");
+
+		assertBoundary("comparableOperator", 1, 0);
+	}
+
+	/**
+	 * The body of an inline function is copied into the caller, but
+	 * KotlinInlineFilter ignores every instruction that the SMAP attributes to
+	 * the inline function, so the caller does not own that comparison and
+	 * reports no boundary for it.
+	 */
+	@Test
+	public void inlined_comparison_should_not_be_reported_in_the_caller()
+			throws Exception {
+		call("callsInline", int.class, Integer.valueOf(5));
+		call("callsInline", int.class, Integer.valueOf(7));
+
+		assertBoundary("callsInline", 0, 0);
+		assertBoundary("isBig", 0, 0);
+	}
+
+	@Test
+	public void inline_function_should_report_boundary_when_called_directly()
+			throws Exception {
+		call("isBig", int.class, Integer.valueOf(5));
+		call("isBig", int.class, Integer.valueOf(6));
+		call("isBig", int.class, Integer.valueOf(7));
+
+		assertBoundary("isBig", 0, 1);
+	}
+
+	private void call(final String name, final Class<?> argType,
+			final Object arg) throws Exception {
+		final Method method = target.getClass().getMethod(name, argType);
+		method.invoke(target, arg);
+	}
+
+	private void callTwoStrings(final String a, final String b)
+			throws Exception {
+		final Method method = target.getClass().getMethod("comparableOperator",
+				String.class, String.class);
+		method.invoke(target, a, b);
+	}
+
+	private void assertBoundary(final String methodName, final int missed,
+			final int covered) throws IOException {
+		final CoverageBuilder builder = new CoverageBuilder();
+		final ExecutionDataStore store = new ExecutionDataStore();
+		data.collect(store, new SessionInfoStore(), false);
+		new Analyzer(store, builder).analyzeClass(bytes, "TestTarget");
+		for (final IClassCoverage c : builder.getClasses()) {
+			for (final IMethodCoverage m : c.getMethods()) {
+				if (methodName.equals(m.getName())) {
+					assertEquals("Boundaries in " + methodName,
+							CounterImpl.getInstance(missed, covered),
+							m.getCounter(CounterEntity.BOUNDARY));
+					return;
+				}
+			}
+		}
+		fail("Method not found: " + methodName);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinBoundaryTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinBoundaryTarget.kt
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+/**
+ * Test target for the boundary counter. Every function contains the comparisons
+ * of exactly one Kotlin construct, so that the boundary counter of the function
+ * is the counter of that construct.
+ */
+class KotlinBoundaryTarget {
+
+    fun greaterThan(arg: Int): Boolean =
+        arg > 6
+
+    fun inRange(arg: Int): Boolean =
+        arg in 1..10
+
+    fun whenWithComparison(arg: Int): String =
+        when {
+            arg > 6 -> "big"
+            else -> "small"
+        }
+
+    fun whenWithRange(arg: Int): String =
+        when (arg) {
+            in 1..10 -> "in"
+            else -> "out"
+        }
+
+    fun elvisThenComparison(arg: Int?): Boolean =
+        (arg ?: 0) > 6
+
+    fun nullableComparison(arg: Int?): Boolean =
+        arg != null && arg > 6
+
+    fun longGreaterThan(arg: Long): Boolean =
+        arg > 6L
+
+    fun comparableOperator(a: String, b: String): Boolean =
+        a > b
+
+    inline fun isBig(value: Int): Boolean =
+        value > 6
+
+    fun callsInline(arg: Int): Boolean =
+        isBig(arg)
+
+}

--- a/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaBoundaryTest.java
+++ b/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/ScalaBoundaryTest.java
@@ -1,0 +1,252 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.scala;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
+import org.jacoco.core.analysis.IMethodCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.SessionInfoStore;
+import org.jacoco.core.instr.Instrumenter;
+import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.runtime.IRuntime;
+import org.jacoco.core.runtime.RuntimeData;
+import org.jacoco.core.runtime.SystemPropertiesRuntime;
+import org.jacoco.core.test.TargetLoader;
+import org.jacoco.core.test.validation.scala.targets.ScalaBoundaryTarget;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of the boundary counter for Scala. Several Scala constructs compile to
+ * comparisons that do not appear in the source, and others that look like
+ * comparisons compile to a library call with no comparison at all.
+ */
+public class ScalaBoundaryTest {
+
+	private RuntimeData data;
+	private IRuntime runtime;
+	private byte[] bytes;
+	private Object target;
+
+	@Before
+	public void setup() throws Exception {
+		data = new RuntimeData();
+		runtime = new SystemPropertiesRuntime();
+		runtime.startup(data);
+
+		bytes = TargetLoader.getClassDataAsBytes(ScalaBoundaryTarget.class);
+		final byte[] instrumented = new Instrumenter(runtime).instrument(bytes,
+				"TestTarget");
+		final TargetLoader loader = new TargetLoader();
+		target = loader.add(ScalaBoundaryTarget.class, instrumented)
+				.newInstance();
+	}
+
+	@After
+	public void teardown() {
+		runtime.shutdown();
+	}
+
+	@Test
+	public void comparison_should_report_missed_boundary() throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(5));
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 1, 0);
+	}
+
+	@Test
+	public void comparison_should_report_covered_boundary() throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(5));
+		call("greaterThan", int.class, Integer.valueOf(6));
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 0, 1);
+	}
+
+	@Test
+	public void non_strict_comparison_should_report_boundary()
+			throws Exception {
+		call("greaterOrEqual", int.class, Integer.valueOf(5));
+		call("greaterOrEqual", int.class, Integer.valueOf(6));
+
+		assertBoundary("greaterOrEqual", 0, 1);
+	}
+
+	@Test
+	public void equality_comparison_should_not_report_boundary()
+			throws Exception {
+		call("equalTo", int.class, Integer.valueOf(5));
+		call("equalTo", int.class, Integer.valueOf(6));
+
+		assertBoundary("equalTo", 0, 0);
+	}
+
+	@Test
+	public void match_with_guard_should_report_boundary() throws Exception {
+		call("matchWithGuard", int.class, Integer.valueOf(5));
+		call("matchWithGuard", int.class, Integer.valueOf(7));
+
+		assertBoundary("matchWithGuard", 1, 0);
+	}
+
+	@Test
+	public void match_with_guard_should_cover_boundary() throws Exception {
+		call("matchWithGuard", int.class, Integer.valueOf(5));
+		call("matchWithGuard", int.class, Integer.valueOf(6));
+		call("matchWithGuard", int.class, Integer.valueOf(7));
+
+		assertBoundary("matchWithGuard", 0, 1);
+	}
+
+	@Test
+	public void two_comparisons_should_be_counted_separately()
+			throws Exception {
+		call("twoComparisons", int.class, Integer.valueOf(0));
+		call("twoComparisons", int.class, Integer.valueOf(1));
+		call("twoComparisons", int.class, Integer.valueOf(5));
+		call("twoComparisons", int.class, Integer.valueOf(11));
+
+		assertBoundary("twoComparisons", 1, 1);
+	}
+
+	/**
+	 * A range membership test is a library call, so there is no comparison in
+	 * this method to report a boundary for.
+	 */
+	@Test
+	public void range_contains_should_not_report_boundary() throws Exception {
+		call("rangeContains", int.class, Integer.valueOf(0));
+		call("rangeContains", int.class, Integer.valueOf(5));
+		call("rangeContains", int.class, Integer.valueOf(11));
+
+		assertBoundary("rangeContains", 0, 0);
+	}
+
+	@Test
+	public void long_comparison_should_report_boundary() throws Exception {
+		call("longGreaterThan", long.class, Long.valueOf(5));
+		call("longGreaterThan", long.class, Long.valueOf(6));
+		call("longGreaterThan", long.class, Long.valueOf(7));
+
+		assertBoundary("longGreaterThan", 0, 1);
+	}
+
+	@Test
+	public void double_comparison_should_not_treat_nan_as_boundary()
+			throws Exception {
+		call("doubleLessThan", double.class, Double.valueOf(5));
+		call("doubleLessThan", double.class, Double.valueOf(Double.NaN));
+
+		assertBoundary("doubleLessThan", 1, 0);
+	}
+
+	/**
+	 * Scala compiles the comparison operator on strings to a call of
+	 * StringOps.$greater$extension, so the comparison happens inside the Scala
+	 * library and not in this method. The counter only sees comparisons that
+	 * are present in the analyzed method, so it reports nothing here.
+	 */
+	@Test
+	public void string_operator_should_not_report_boundary() throws Exception {
+		callTwoStrings("stringGreaterThan", "a", "b");
+		callTwoStrings("stringGreaterThan", "b", "b");
+		callTwoStrings("stringGreaterThan", "c", "b");
+
+		assertBoundary("stringGreaterThan", 0, 0);
+	}
+
+	/**
+	 * Calling compareTo() explicitly puts the comparison back into the method,
+	 * where zero means that the two operands are equal.
+	 */
+	@Test
+	public void compare_to_should_report_covered_boundary() throws Exception {
+		callTwoStrings("stringCompareTo", "a", "b");
+		callTwoStrings("stringCompareTo", "b", "b");
+		callTwoStrings("stringCompareTo", "c", "b");
+
+		assertBoundary("stringCompareTo", 0, 1);
+	}
+
+	@Test
+	public void compare_to_should_report_missed_boundary() throws Exception {
+		callTwoStrings("stringCompareTo", "a", "b");
+		callTwoStrings("stringCompareTo", "c", "b");
+
+		assertBoundary("stringCompareTo", 1, 0);
+	}
+
+	/**
+	 * The loop condition is a comparison like any other, and its boundary is
+	 * the value that ends the loop.
+	 */
+	@Test
+	public void loop_condition_should_report_covered_boundary()
+			throws Exception {
+		call("countUpTo", int.class, Integer.valueOf(3));
+
+		assertBoundary("countUpTo", 0, 1);
+	}
+
+	@Test
+	public void loop_that_never_runs_should_not_report_boundary()
+			throws Exception {
+		call("countUpTo", int.class, Integer.valueOf(0));
+
+		assertBoundary("countUpTo", 0, 0);
+	}
+
+	private void call(final String name, final Class<?> argType,
+			final Object arg) throws Exception {
+		final Method method = target.getClass().getMethod(name, argType);
+		method.invoke(target, arg);
+	}
+
+	private void callTwoStrings(final String name, final String a,
+			final String b) throws Exception {
+		final Method method = target.getClass().getMethod(name, String.class,
+				String.class);
+		method.invoke(target, a, b);
+	}
+
+	private void assertBoundary(final String methodName, final int missed,
+			final int covered) throws IOException {
+		final CoverageBuilder builder = new CoverageBuilder();
+		final ExecutionDataStore store = new ExecutionDataStore();
+		data.collect(store, new SessionInfoStore(), false);
+		new Analyzer(store, builder).analyzeClass(bytes, "TestTarget");
+		for (final IClassCoverage c : builder.getClasses()) {
+			for (final IMethodCoverage m : c.getMethods()) {
+				if (methodName.equals(m.getName())) {
+					assertEquals("Boundaries in " + methodName,
+							CounterImpl.getInstance(missed, covered),
+							m.getCounter(CounterEntity.BOUNDARY));
+					return;
+				}
+			}
+		}
+		fail("Method not found: " + methodName);
+	}
+
+}

--- a/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/targets/ScalaBoundaryTarget.scala
+++ b/org.jacoco.core.test.validation.scala/src/org/jacoco/core/test/validation/scala/targets/ScalaBoundaryTarget.scala
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.scala.targets
+
+/**
+ * Test target for the boundary counter. Every method contains the comparisons
+ * of exactly one Scala construct, so that the boundary counter of the method is
+ * the counter of that construct.
+ */
+class ScalaBoundaryTarget {
+
+  def greaterThan(arg: Int): Boolean =
+    arg > 6
+
+  def greaterOrEqual(arg: Int): Boolean =
+    arg >= 6
+
+  def equalTo(arg: Int): Boolean =
+    arg == 6
+
+  def matchWithGuard(arg: Int): String =
+    arg match {
+      case x if x > 6 => "big"
+      case _          => "small"
+    }
+
+  def twoComparisons(arg: Int): Boolean =
+    arg >= 1 && arg <= 10
+
+  def rangeContains(arg: Int): Boolean =
+    (1 to 10).contains(arg)
+
+  def longGreaterThan(arg: Long): Boolean =
+    arg > 6L
+
+  def doubleLessThan(arg: Double): Boolean =
+    arg < 6d
+
+  def stringGreaterThan(a: String, b: String): Boolean =
+    a > b
+
+  def stringCompareTo(a: String, b: String): Boolean =
+    a.compareTo(b) > 0
+
+  def countUpTo(arg: Int): Int = {
+    var sum = 0
+    var i = 0
+    while (i < arg) {
+      sum += i
+      i += 1
+    }
+    sum
+  }
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataStoreTest.java
@@ -172,20 +172,17 @@ public class ExecutionDataStoreTest implements IExecutionDataVisitor {
 	}
 
 	@Test
-	public void testMergeNegative() {
-		final boolean[] data1 = new boolean[] { false, false };
-		final ExecutionData executionData1 = new ExecutionData(1000, "Sample",
-				data1);
-		store.visitClassExecution(executionData1);
-		final boolean[] data2 = new boolean[] { false, false, false };
-		final ExecutionData executionData2 = new ExecutionData(1000, "Sample",
-				data2);
-		try {
-			store.visitClassExecution(executionData2);
-			fail("IllegalStateException expected");
-		} catch (final IllegalStateException e) {
-			// expected
-		}
+	public void testMergeDifferentProbeCount() {
+		final boolean[] data1 = new boolean[] { false, true };
+		store.visitClassExecution(new ExecutionData(1000, "Sample", data1));
+		final boolean[] data2 = new boolean[] { true, false, true };
+		store.visitClassExecution(new ExecutionData(1000, "Sample", data2));
+
+		final boolean[] result = store.get(1000).getProbes();
+		assertEquals(3, result.length);
+		assertTrue(result[0]);
+		assertTrue(result[1]);
+		assertTrue(result[2]);
 	}
 
 	@Test

--- a/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/data/ExecutionDataTest.java
@@ -114,6 +114,72 @@ public class ExecutionDataTest {
 	}
 
 	@Test
+	public void testMergeLongerData() {
+		final ExecutionData a = new ExecutionData(5, "Example",
+				new boolean[] { false, true });
+		final ExecutionData b = new ExecutionData(5, "Example",
+				new boolean[] { true, false, false, true });
+		a.merge(b);
+
+		// a is extended to the length of b:
+		assertEquals(4, a.getProbes().length);
+		assertTrue(a.getProbes()[0]);
+		assertTrue(a.getProbes()[1]);
+		assertFalse(a.getProbes()[2]);
+		assertTrue(a.getProbes()[3]);
+
+		// b must not be modified:
+		assertTrue(b.getProbes()[0]);
+		assertFalse(b.getProbes()[1]);
+		assertFalse(b.getProbes()[2]);
+		assertTrue(b.getProbes()[3]);
+	}
+
+	@Test
+	public void testMergeShorterData() {
+		final ExecutionData a = new ExecutionData(5, "Example",
+				new boolean[] { false, false, false, true });
+		final ExecutionData b = new ExecutionData(5, "Example",
+				new boolean[] { true, false });
+		a.merge(b);
+
+		// probes of a beyond the length of b are kept:
+		assertEquals(4, a.getProbes().length);
+		assertTrue(a.getProbes()[0]);
+		assertFalse(a.getProbes()[1]);
+		assertFalse(a.getProbes()[2]);
+		assertTrue(a.getProbes()[3]);
+	}
+
+	@Test
+	public void testMergeSubtractLongerData() {
+		final ExecutionData a = new ExecutionData(5, "Example",
+				new boolean[] { true, true });
+		final ExecutionData b = new ExecutionData(5, "Example",
+				new boolean[] { true, false, true });
+		a.merge(b, false);
+
+		// subtraction never extends the probe array:
+		assertEquals(2, a.getProbes().length);
+		assertFalse(a.getProbes()[0]);
+		assertTrue(a.getProbes()[1]);
+	}
+
+	@Test
+	public void testMergeDifferentName() {
+		final ExecutionData a = new ExecutionData(5, "Example",
+				new boolean[] { true });
+		final ExecutionData b = new ExecutionData(5, "Other",
+				new boolean[] { true });
+		try {
+			a.merge(b);
+			fail("IllegalStateException expected");
+		} catch (final IllegalStateException e) {
+			// expected
+		}
+	}
+
+	@Test
 	public void testAssertCompatibility() {
 		final ExecutionData a = new ExecutionData(5, "Example",
 				new boolean[] { true });

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -104,6 +104,16 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	}
 
 	@Test
+	public void linear_instruction_sequence_should_show_missed_when_probearray_is_too_short() {
+		createLinearSequence();
+		probes = new boolean[0];
+		runMethodAnalzer();
+
+		assertLine(1001, 2, 0, 0, 0);
+		assertLine(1002, 1, 0, 0, 0);
+	}
+
+	@Test
 	public void linear_instruction_sequence_should_show_covered_when_probe_is_executed() {
 		createLinearSequence();
 		probes[0] = true;
@@ -263,6 +273,17 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		assertLine(1001, 0, 2, 0, 2);
 		assertLine(1002, 0, 2, 0, 0);
 		assertLine(1003, 0, 2, 0, 0);
+	}
+
+	@Test
+	public void if_branch_should_show_partial_branch_coverage_when_probearray_ends_after_first_branch() {
+		createIfBranch();
+		probes = new boolean[] { true };
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 2, 1, 1);
+		assertLine(1002, 0, 2, 0, 0);
+		assertLine(1003, 2, 0, 0, 0);
 	}
 
 	// === Scenario: branch before unconditional probe ===

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/MethodAnalyzerTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 
+import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.analysis.IMethodCoverage;
 import org.jacoco.core.data.ExecutionDataWriter;
@@ -45,6 +46,8 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 
 	private int nextProbeId;
 
+	private int nextBoundaryProbeId;
+
 	private boolean[] probes;
 
 	private MethodNode method;
@@ -54,6 +57,7 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 	@Before
 	public void setup() {
 		nextProbeId = 0;
+		nextBoundaryProbeId = 16;
 		method = new MethodNode();
 		method.tryCatchBlocks = new ArrayList<TryCatchBlockNode>();
 		probes = new boolean[32];
@@ -61,6 +65,10 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 
 	public int nextId() {
 		return nextProbeId++;
+	}
+
+	public int nextBoundaryId() {
+		return nextBoundaryProbeId++;
 	}
 
 	// === Scenario: linear Sequence with and without ignore filtering ===
@@ -284,6 +292,88 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		assertLine(1001, 0, 2, 1, 1);
 		assertLine(1002, 0, 2, 0, 0);
 		assertLine(1003, 2, 0, 0, 0);
+	}
+
+	// === Scenario: ordered numeric comparison ===
+
+	/** <code>if (i > 6) return "a"; else return "b";</code> */
+	private void createOrderedComparison(int opcode) {
+		final Label l0 = new Label();
+		method.visitLabel(l0);
+		method.visitLineNumber(1001, l0);
+		method.visitVarInsn(Opcodes.ILOAD, 1);
+		method.visitIntInsn(Opcodes.BIPUSH, 6);
+		Label l1 = new Label();
+		method.visitJumpInsn(opcode, l1);
+		final Label l2 = new Label();
+		method.visitLabel(l2);
+		method.visitLineNumber(1002, l2);
+		method.visitLdcInsn("a");
+		method.visitInsn(Opcodes.ARETURN);
+		method.visitLabel(l1);
+		method.visitLineNumber(1003, l1);
+		method.visitLdcInsn("b");
+		method.visitInsn(Opcodes.ARETURN);
+	}
+
+	@Test
+	public void ordered_comparison_should_create_boundary_probe() {
+		createOrderedComparison(Opcodes.IF_ICMPGT);
+		runMethodAnalzer();
+		assertEquals(2, nextProbeId);
+		assertEquals(17, nextBoundaryProbeId);
+	}
+
+	@Test
+	public void equality_comparison_should_not_create_boundary_probe() {
+		createOrderedComparison(Opcodes.IF_ICMPEQ);
+		runMethodAnalzer();
+		assertEquals(2, nextProbeId);
+		assertEquals(16, nextBoundaryProbeId);
+	}
+
+	@Test
+	public void ordered_comparison_should_show_missed_boundary_when_both_branches_are_covered() {
+		createOrderedComparison(Opcodes.IF_ICMPGT);
+		probes[0] = true;
+		probes[1] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 3, 0, 2);
+		assertBoundary(1, 0);
+	}
+
+	@Test
+	public void ordered_comparison_should_show_covered_boundary_when_boundary_probe_is_executed() {
+		createOrderedComparison(Opcodes.IF_ICMPGT);
+		probes[0] = true;
+		probes[1] = true;
+		probes[16] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 3, 0, 2);
+		assertBoundary(0, 1);
+	}
+
+	@Test
+	public void ordered_comparison_should_not_count_boundary_when_a_branch_is_missed() {
+		createOrderedComparison(Opcodes.IF_ICMPGT);
+		probes[0] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 3, 1, 1);
+		assertBoundary(0, 0);
+	}
+
+	@Test
+	public void equality_comparison_should_not_count_boundary() {
+		createOrderedComparison(Opcodes.IF_ICMPEQ);
+		probes[0] = true;
+		probes[1] = true;
+		runMethodAnalzer();
+
+		assertLine(1001, 0, 3, 0, 2);
+		assertBoundary(0, 0);
 	}
 
 	// === Scenario: branch before unconditional probe ===
@@ -1077,6 +1167,11 @@ public class MethodAnalyzerTest implements IProbeIdGenerator {
 		filter.filter(method, new FilterContextMock(), mcc);
 		mcc.calculate(mc);
 		result = mc;
+	}
+
+	private void assertBoundary(int missed, int covered) {
+		assertEquals("Boundaries", CounterImpl.getInstance(missed, covered),
+				result.getCounter(ICoverageNode.CounterEntity.BOUNDARY));
 	}
 
 	private void assertLine(int nr, int insnMissed, int insnCovered,

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodProbesAdapterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/flow/MethodProbesAdapterTest.java
@@ -35,6 +35,8 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 
 	private int id;
 
+	private int boundaryId = 2000;
+
 	private MethodRecorder expected, actual;
 
 	private MethodProbesVisitor expectedVisitor;
@@ -453,6 +455,10 @@ public class MethodProbesAdapterTest implements IProbeIdGenerator {
 
 	public int nextId() {
 		return id++;
+	}
+
+	public int nextBoundaryId() {
+		return boundaryId++;
 	}
 
 }

--- a/org.jacoco.core.test/src/org/jacoco/core/test/boundary/BoundaryCoverageTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/boundary/BoundaryCoverageTest.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.boundary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.IClassCoverage;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
+import org.jacoco.core.analysis.IMethodCoverage;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.internal.analysis.CounterImpl;
+import org.jacoco.core.test.InstrumentingLoader;
+import org.jacoco.core.test.TargetLoader;
+import org.jacoco.core.test.boundary.targets.BoundaryTarget;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests that boundary probes survive instrumentation and record whether the two
+ * values of an ordered comparison were ever equal. Every test executes the
+ * instrumented target, so a broken probe shows up as a {@link VerifyError} or a
+ * wrong result rather than as a wrong counter only.
+ */
+public class BoundaryCoverageTest {
+
+	private InstrumentingLoader loader;
+
+	private Class<?> target;
+
+	@Before
+	public void setup() throws Exception {
+		loader = new InstrumentingLoader(BoundaryTarget.class);
+		target = loader.loadClass(BoundaryTarget.class.getName());
+	}
+
+	@Test
+	public void should_report_missed_boundary_when_equal_values_are_not_used()
+			throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(5));
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 1, 0);
+	}
+
+	@Test
+	public void should_report_covered_boundary_when_equal_values_are_used()
+			throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(5));
+		call("greaterThan", int.class, Integer.valueOf(6));
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 0, 1);
+	}
+
+	@Test
+	public void should_not_report_boundary_when_only_one_branch_is_covered()
+			throws Exception {
+		call("greaterThan", int.class, Integer.valueOf(7));
+
+		assertBoundary("greaterThan", 0, 0);
+	}
+
+	@Test
+	public void should_not_report_boundary_for_equality_comparison()
+			throws Exception {
+		call("equalTo", int.class, Integer.valueOf(5));
+		call("equalTo", int.class, Integer.valueOf(6));
+
+		assertBoundary("equalTo", 0, 0);
+	}
+
+	@Test
+	public void should_report_missed_boundary_for_long_comparison()
+			throws Exception {
+		call("longGreaterThan", long.class, Long.valueOf(5));
+		call("longGreaterThan", long.class, Long.valueOf(7));
+
+		assertBoundary("longGreaterThan", 1, 0);
+	}
+
+	@Test
+	public void should_report_covered_boundary_for_long_comparison()
+			throws Exception {
+		call("longGreaterThan", long.class, Long.valueOf(5));
+		call("longGreaterThan", long.class, Long.valueOf(6));
+		call("longGreaterThan", long.class, Long.valueOf(7));
+
+		assertBoundary("longGreaterThan", 0, 1);
+	}
+
+	@Test
+	public void should_report_covered_boundary_for_double_comparison()
+			throws Exception {
+		call("doubleLessThan", double.class, Double.valueOf(5));
+		call("doubleLessThan", double.class, Double.valueOf(6));
+
+		assertBoundary("doubleLessThan", 0, 1);
+	}
+
+	@Test
+	public void should_not_report_boundary_for_double_comparison_with_nan()
+			throws Exception {
+		call("doubleLessThan", double.class, Double.valueOf(5));
+		call("doubleLessThan", double.class, Double.valueOf(Double.NaN));
+
+		assertBoundary("doubleLessThan", 1, 0);
+	}
+
+	private void call(final String name, final Class<?> argType,
+			final Object arg) throws Exception {
+		final Method method = target.getMethod(name, argType);
+		method.invoke(null, arg);
+	}
+
+	private void assertBoundary(final String methodName, final int missed,
+			final int covered) throws Exception {
+		final ExecutionDataStore store = loader.collect();
+		final CoverageBuilder builder = new CoverageBuilder();
+		new Analyzer(store, builder).analyzeClass(
+				TargetLoader.getClassDataAsBytes(BoundaryTarget.class),
+				BoundaryTarget.class.getName());
+		for (final IClassCoverage c : builder.getClasses()) {
+			for (final IMethodCoverage m : c.getMethods()) {
+				if (methodName.equals(m.getName())) {
+					final ICounter expected = CounterImpl.getInstance(missed,
+							covered);
+					assertEquals("Boundaries in " + methodName, expected,
+							m.getCounter(CounterEntity.BOUNDARY));
+					return;
+				}
+			}
+		}
+		fail("Method not found: " + methodName);
+	}
+
+}

--- a/org.jacoco.core.test/src/org/jacoco/core/test/boundary/targets/BoundaryTarget.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/boundary/targets/BoundaryTarget.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Marc R. Hoffmann - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.boundary.targets;
+
+/**
+ * Target for boundary coverage tests. Every method here contains exactly one
+ * comparison, so that the boundary counter of the method is the counter of that
+ * comparison.
+ */
+public class BoundaryTarget {
+
+	/** Compiles to IF_ICMPLE, an ordered comparison. */
+	public static boolean greaterThan(int value) {
+		return value > 6;
+	}
+
+	/** Compiles to IF_ICMPNE, which has no boundary. */
+	public static boolean equalTo(int value) {
+		return value == 6;
+	}
+
+	/** Compiles to LCMP followed by IFLE. */
+	public static boolean longGreaterThan(long value) {
+		return value > 6L;
+	}
+
+	/** Compiles to DCMPL followed by IFGE. */
+	public static boolean doubleLessThan(double value) {
+		return value < 6d;
+	}
+
+}

--- a/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/Analyzer.java
@@ -76,10 +76,12 @@ public class Analyzer {
 	 *            id of the class calculated with {@link CRC64}
 	 * @param className
 	 *            VM name of the class
+	 * @param boundaryProbeBase
+	 *            first id used for boundary probes
 	 * @return ASM visitor to write class definition to
 	 */
 	private ClassVisitor createAnalyzingVisitor(final long classid,
-			final String className) {
+			final String className, final int boundaryProbeBase) {
 		final ExecutionData data = executionData.get(classid);
 		final boolean[] probes;
 		final boolean noMatch;
@@ -100,7 +102,7 @@ public class Analyzer {
 				coverageVisitor.visitCoverage(coverage);
 			}
 		};
-		return new ClassProbesAdapter(analyzer, false);
+		return new ClassProbesAdapter(analyzer, false, boundaryProbeBase);
 	}
 
 	private void analyzeClass(final byte[] source) {
@@ -113,7 +115,8 @@ public class Analyzer {
 			return;
 		}
 		final ClassVisitor visitor = createAnalyzingVisitor(classId,
-				reader.getClassName());
+				reader.getClassName(),
+				ClassProbesAdapter.countRegularProbes(reader));
 		reader.accept(visitor, 0);
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/analysis/CoverageNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/CoverageNodeImpl.java
@@ -43,6 +43,9 @@ public class CoverageNodeImpl implements ICoverageNode {
 	/** Counter for classes. */
 	protected CounterImpl classCounter;
 
+	/** Counter for boundary values of ordered numeric comparisons. */
+	protected CounterImpl boundaryCounter;
+
 	/**
 	 * Creates a new coverage data node.
 	 *
@@ -60,6 +63,7 @@ public class CoverageNodeImpl implements ICoverageNode {
 		this.methodCounter = CounterImpl.COUNTER_0_0;
 		this.classCounter = CounterImpl.COUNTER_0_0;
 		this.lineCounter = CounterImpl.COUNTER_0_0;
+		this.boundaryCounter = CounterImpl.COUNTER_0_0;
 	}
 
 	/**
@@ -77,6 +81,20 @@ public class CoverageNodeImpl implements ICoverageNode {
 				.increment(child.getComplexityCounter());
 		methodCounter = methodCounter.increment(child.getMethodCounter());
 		classCounter = classCounter.increment(child.getClassCounter());
+		boundaryCounter = boundaryCounter
+				.increment(child.getCounter(CounterEntity.BOUNDARY));
+	}
+
+	/**
+	 * Increments the boundary counter. Unlike the other counters this one is
+	 * not part of {@link ICoverageNode}, so that adding it does not break
+	 * implementations of that interface outside of JaCoCo.
+	 *
+	 * @param counter
+	 *            counter to add
+	 */
+	public void incrementBoundaryCounter(final ICounter counter) {
+		boundaryCounter = boundaryCounter.increment(counter);
 	}
 
 	/**
@@ -126,6 +144,15 @@ public class CoverageNodeImpl implements ICoverageNode {
 		return classCounter;
 	}
 
+	/**
+	 * Returns the boundary coverage counter.
+	 *
+	 * @return boundary coverage counter
+	 */
+	public ICounter getBoundaryCounter() {
+		return boundaryCounter;
+	}
+
 	public ICounter getCounter(final CounterEntity entity) {
 		switch (entity) {
 		case INSTRUCTION:
@@ -140,6 +167,8 @@ public class CoverageNodeImpl implements ICoverageNode {
 			return getMethodCounter();
 		case CLASS:
 			return getClassCounter();
+		case BOUNDARY:
+			return getBoundaryCounter();
 		}
 		throw new AssertionError(entity);
 	}
@@ -156,6 +185,7 @@ public class CoverageNodeImpl implements ICoverageNode {
 		copy.complexityCounter = CounterImpl.getInstance(complexityCounter);
 		copy.methodCounter = CounterImpl.getInstance(methodCounter);
 		copy.classCounter = CounterImpl.getInstance(classCounter);
+		copy.boundaryCounter = CounterImpl.getInstance(boundaryCounter);
 		return copy;
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
+++ b/org.jacoco.core/src/org/jacoco/core/analysis/ICoverageNode.java
@@ -64,7 +64,14 @@ public interface ICoverageNode {
 		METHOD,
 
 		/** Counter for classes */
-		CLASS
+		CLASS,
+
+		/**
+		 * Counter for the boundary values of ordered numeric comparisons, i.e.
+		 * the case where the two compared values are equal. Only comparisons
+		 * where both branches are covered are counted.
+		 */
+		BOUNDARY
 	}
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionData.java
@@ -19,7 +19,9 @@ import java.util.Arrays;
 /**
  * Execution data for a single Java class. While instances are immutable care
  * has to be taken about the probe data array of type <code>boolean[]</code>
- * which can be modified.
+ * which can be modified. {@link #merge(ExecutionData)} may also replace the
+ * array with a longer one, so callers must not cache the result of
+ * {@link #getProbes()} across a merge.
  */
 public final class ExecutionData {
 
@@ -27,7 +29,7 @@ public final class ExecutionData {
 
 	private final String name;
 
-	private final boolean[] probes;
+	private boolean[] probes;
 
 	/**
 	 * Creates a new {@link ExecutionData} object with the given probe data.
@@ -149,6 +151,11 @@ public final class ExecutionData {
 	 * A and not B
 	 * </pre>
 	 *
+	 * The two probe arrays do not need to have the same length: the shorter one
+	 * is treated as a prefix of the longer one, i.e. the missing probes count
+	 * as not executed. For <code>flag==true</code> the probe array of this
+	 * object is extended if the other one is longer.
+	 *
 	 * The probe array of the other object is not modified.
 	 *
 	 * @param other
@@ -157,10 +164,15 @@ public final class ExecutionData {
 	 *            merge mode
 	 */
 	public void merge(final ExecutionData other, final boolean flag) {
-		assertCompatibility(other.getId(), other.getName(),
-				other.getProbes().length);
+		assertSameClass(other.getId(), other.getName());
 		final boolean[] otherData = other.getProbes();
-		for (int i = 0; i < probes.length; i++) {
+		if (flag && otherData.length > probes.length) {
+			final boolean[] extended = new boolean[otherData.length];
+			System.arraycopy(probes, 0, extended, 0, probes.length);
+			probes = extended;
+		}
+		final int shared = Math.min(probes.length, otherData.length);
+		for (int i = 0; i < shared; i++) {
 			if (otherData[i]) {
 				probes[i] = flag;
 			}
@@ -183,6 +195,16 @@ public final class ExecutionData {
 	 */
 	public void assertCompatibility(final long id, final String name,
 			final int probecount) throws IllegalStateException {
+		assertSameClass(id, name);
+		if (this.probes.length != probecount) {
+			throw new IllegalStateException(format(
+					"Incompatible execution data for class %s with id %016x.",
+					name, Long.valueOf(id)));
+		}
+	}
+
+	private void assertSameClass(final long id, final String name)
+			throws IllegalStateException {
 		if (this.id != id) {
 			throw new IllegalStateException(
 					format("Different ids (%016x and %016x).",
@@ -192,11 +214,6 @@ public final class ExecutionData {
 			throw new IllegalStateException(
 					format("Different class names %s and %s for id %016x.",
 							this.name, name, Long.valueOf(id)));
-		}
-		if (this.probes.length != probecount) {
-			throw new IllegalStateException(format(
-					"Incompatible execution data for class %s with id %016x.",
-					name, Long.valueOf(id)));
 		}
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
+++ b/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataStore.java
@@ -41,9 +41,10 @@ public final class ExecutionDataStore implements IExecutionDataVisitor {
 	 * @param data
 	 *            execution data to add or merge
 	 * @throws IllegalStateException
-	 *             if the given {@link ExecutionData} object is not compatible
-	 *             to a corresponding one, that is already contained
-	 * @see ExecutionData#assertCompatibility(long, String, int)
+	 *             if the given {@link ExecutionData} object describes a
+	 *             different class than a corresponding one, that is already
+	 *             contained
+	 * @see ExecutionData#merge(ExecutionData)
 	 */
 	public void put(final ExecutionData data) throws IllegalStateException {
 		final Long id = Long.valueOf(data.getId());
@@ -65,9 +66,10 @@ public final class ExecutionDataStore implements IExecutionDataVisitor {
 	 * @param data
 	 *            execution data to subtract
 	 * @throws IllegalStateException
-	 *             if the given {@link ExecutionData} object is not compatible
-	 *             to a corresponding one, that is already contained
-	 * @see ExecutionData#assertCompatibility(long, String, int)
+	 *             if the given {@link ExecutionData} object describes a
+	 *             different class than a corresponding one, that is already
+	 *             contained
+	 * @see ExecutionData#merge(ExecutionData, boolean)
 	 */
 	public void subtract(final ExecutionData data)
 			throws IllegalStateException {

--- a/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/instr/Instrumenter.java
@@ -87,7 +87,8 @@ public class Instrumenter {
 		final int version = InstrSupport.getMajorVersion(reader);
 		final ClassVisitor visitor = new ClassProbesAdapter(
 				new ClassInstrumenter(strategy, writer),
-				InstrSupport.needsFrames(version));
+				InstrSupport.needsFrames(version),
+				ClassProbesAdapter.countRegularProbes(reader));
 		reader.accept(visitor, ClassReader.EXPAND_FRAMES);
 		return writer.toByteArray();
 	}

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java
@@ -67,6 +67,10 @@ public class Instruction {
 
 	private int predecessorBranch;
 
+	private boolean boundary;
+
+	private boolean boundaryCovered;
+
 	/**
 	 * New instruction at the given line.
 	 *
@@ -77,6 +81,18 @@ public class Instruction {
 		this.line = line;
 		this.branches = 0;
 		this.coveredBranches = new BitSet();
+	}
+
+	/**
+	 * Marks this instruction as an ordered numeric comparison and records
+	 * whether the two compared values were ever equal.
+	 *
+	 * @param covered
+	 *            <code>true</code> if the boundary value was exercised
+	 */
+	public void setBoundary(final boolean covered) {
+		this.boundary = true;
+		this.boundaryCovered = covered;
 	}
 
 	/**
@@ -157,6 +173,8 @@ public class Instruction {
 		result.branches = this.branches;
 		result.coveredBranches.or(this.coveredBranches);
 		result.coveredBranches.or(other.coveredBranches);
+		result.boundary = this.boundary || other.boundary;
+		result.boundaryCovered = this.boundaryCovered || other.boundaryCovered;
 		return result;
 	}
 
@@ -175,6 +193,10 @@ public class Instruction {
 	 */
 	public Instruction replaceBranches(final Replacements replacements,
 			final Mapper mapper) {
+		// The boundary status is deliberately not carried over: once the
+		// branches of this comparison are replaced by the branches of an
+		// enclosing decision, its own branch coverage is no longer known, and
+		// the boundary can no longer be reported without guessing.
 		final Instruction result = new Instruction(this.line);
 		int branchIndex = 0;
 		for (final Collection<Replacements.InstructionBranch> newBranch : replacements
@@ -221,6 +243,23 @@ public class Instruction {
 		}
 		final int covered = coveredBranches.cardinality();
 		return CounterImpl.getInstance(branches - covered, covered);
+	}
+
+	/**
+	 * Returns the boundary coverage counter of this instruction. Only ordered
+	 * numeric comparisons whose branches are both covered report a boundary: as
+	 * long as a branch is missing, the branch counter already reports the gap,
+	 * and the boundary value would be missed for that reason alone.
+	 *
+	 * @return the boundary coverage counter
+	 */
+	public ICounter getBoundaryCounter() {
+		if (!boundary
+				|| getBranchCounter().getStatus() != ICounter.FULLY_COVERED) {
+			return CounterImpl.COUNTER_0_0;
+		}
+		return boundaryCovered ? CounterImpl.COUNTER_0_1
+				: CounterImpl.COUNTER_1_0;
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/Instruction.java
@@ -196,7 +196,10 @@ public class Instruction {
 		// The boundary status is deliberately not carried over: once the
 		// branches of this comparison are replaced by the branches of an
 		// enclosing decision, its own branch coverage is no longer known, and
-		// the boundary can no longer be reported without guessing.
+		// the boundary can no longer be reported without guessing. No filter
+		// routes an ordered comparison here today, as they all replace the
+		// branches of a switch or of IFNULL, so this is a safeguard for
+		// filters added later rather than a case that currently occurs.
 		final Instruction result = new Instruction(this.line);
 		int branchIndex = 0;
 		for (final Collection<Replacements.InstructionBranch> newBranch : replacements

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/InstructionsBuilder.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/InstructionsBuilder.java
@@ -138,7 +138,9 @@ class InstructionsBuilder {
 	}
 
 	/**
-	 * Adds a new probe for the last instruction.
+	 * Adds a new probe for the last instruction. Probes beyond the end of the
+	 * probe array count as not executed, which allows to analyze classes with
+	 * execution data that was recorded with fewer probes per class.
 	 *
 	 * @param probeId
 	 *            index in the probe array
@@ -146,7 +148,8 @@ class InstructionsBuilder {
 	 *            unique branch number for the last instruction
 	 */
 	void addProbe(final int probeId, final int branch) {
-		final boolean executed = probes != null && probes[probeId];
+		final boolean executed = probes != null && probeId < probes.length
+				&& probes[probeId];
 		currentInsn.addBranch(executed, branch);
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/InstructionsBuilder.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/InstructionsBuilder.java
@@ -39,6 +39,9 @@ class InstructionsBuilder {
 	/** The last instruction which has been added. */
 	private Instruction currentInsn;
 
+	/** Boundary probe to apply to the instruction that is added next. */
+	private int pendingBoundaryProbe;
+
 	/**
 	 * All instructions of a method mapped from the ASM node to the
 	 * corresponding {@link Instruction} instance.
@@ -70,6 +73,7 @@ class InstructionsBuilder {
 		this.probes = probes;
 		this.currentLine = ISourceNode.UNKNOWN_LINE;
 		this.currentInsn = null;
+		this.pendingBoundaryProbe = LabelInfo.NO_PROBE;
 		this.instructions = new HashMap<AbstractInsnNode, Instruction>();
 		this.currentLabel = new ArrayList<Label>(2);
 		this.jumps = new ArrayList<Jump>();
@@ -102,6 +106,10 @@ class InstructionsBuilder {
 	 */
 	void addInstruction(final AbstractInsnNode node) {
 		final Instruction insn = new Instruction(currentLine);
+		if (pendingBoundaryProbe != LabelInfo.NO_PROBE) {
+			insn.setBoundary(isExecuted(pendingBoundaryProbe));
+			pendingBoundaryProbe = LabelInfo.NO_PROBE;
+		}
 		final int labelCount = currentLabel.size();
 		if (labelCount > 0) {
 			for (int i = labelCount; --i >= 0;) {
@@ -148,9 +156,23 @@ class InstructionsBuilder {
 	 *            unique branch number for the last instruction
 	 */
 	void addProbe(final int probeId, final int branch) {
-		final boolean executed = probes != null && probeId < probes.length
-				&& probes[probeId];
-		currentInsn.addBranch(executed, branch);
+		currentInsn.addBranch(isExecuted(probeId), branch);
+	}
+
+	private boolean isExecuted(final int probeId) {
+		return probes != null && probeId < probes.length && probes[probeId];
+	}
+
+	/**
+	 * Declares a boundary probe for the instruction that is added next. The
+	 * probe is emitted directly before the comparison it belongs to, so it is
+	 * applied to the instruction that follows.
+	 *
+	 * @param probeId
+	 *            index in the probe array
+	 */
+	void setPendingBoundaryProbe(final int probeId) {
+		pendingBoundaryProbe = probeId;
 	}
 
 	/**

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodAnalyzer.java
@@ -103,6 +103,12 @@ public class MethodAnalyzer extends MethodProbesVisitor {
 	}
 
 	@Override
+	public void visitBoundaryProbe(final int opcode, final int probeId,
+			final IFrame frame) {
+		builder.setPendingBoundaryProbe(probeId);
+	}
+
+	@Override
 	public void visitJumpInsn(final int opcode, final Label label) {
 		builder.addInstruction(currentNode);
 		builder.addJump(label, 1);

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageCalculator.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/MethodCoverageCalculator.java
@@ -75,6 +75,8 @@ class MethodCoverageCalculator implements IFilterOutput {
 				final Instruction instruction = entry.getValue();
 				coverage.increment(instruction.getInstructionCounter(),
 						instruction.getBranchCounter(), instruction.getLine());
+				coverage.incrementBoundaryCounter(
+						instruction.getBoundaryCounter());
 			}
 		}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/analysis/SourceNodeImpl.java
@@ -14,6 +14,7 @@ package org.jacoco.core.internal.analysis;
 
 import org.jacoco.core.analysis.CoverageNodeImpl;
 import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode.CounterEntity;
 import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.analysis.ISourceNode;
 
@@ -125,6 +126,8 @@ public class SourceNodeImpl extends CoverageNodeImpl implements ISourceNode {
 				.increment(child.getComplexityCounter());
 		methodCounter = methodCounter.increment(child.getMethodCounter());
 		classCounter = classCounter.increment(child.getClassCounter());
+		boundaryCounter = boundaryCounter
+				.increment(child.getCounter(CounterEntity.BOUNDARY));
 		final int firstLine = child.getFirstLine();
 		if (firstLine != UNKNOWN_LINE) {
 			final int lastLine = child.getLastLine();

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/ClassProbesAdapter.java
@@ -13,6 +13,7 @@
 package org.jacoco.core.internal.flow;
 
 import org.jacoco.core.internal.instr.InstrSupport;
+import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.commons.AnalyzerAdapter;
@@ -27,16 +28,26 @@ public class ClassProbesAdapter extends ClassVisitor
 	private static final MethodProbesVisitor EMPTY_METHOD_PROBES_VISITOR = new MethodProbesVisitor() {
 	};
 
+	/**
+	 * Value for the boundary probe base that disables boundary probes.
+	 */
+	public static final int NO_BOUNDARY_PROBES = -1;
+
 	private final ClassProbesVisitor cv;
 
 	private final boolean trackFrames;
 
+	private final int boundaryProbeBase;
+
 	private int counter = 0;
+
+	private int boundaryCounter;
 
 	private String name;
 
 	/**
-	 * Creates a new adapter that delegates to the given visitor.
+	 * Creates a new adapter that delegates to the given visitor and does not
+	 * generate boundary probes.
 	 *
 	 * @param cv
 	 *            instance to delegate to
@@ -45,9 +56,61 @@ public class ClassProbesAdapter extends ClassVisitor
 	 */
 	public ClassProbesAdapter(final ClassProbesVisitor cv,
 			final boolean trackFrames) {
+		this(cv, trackFrames, NO_BOUNDARY_PROBES);
+	}
+
+	/**
+	 * Creates a new adapter that delegates to the given visitor.
+	 *
+	 * @param cv
+	 *            instance to delegate to
+	 * @param trackFrames
+	 *            if <code>true</code> stackmap frames are tracked and provided
+	 * @param boundaryProbeBase
+	 *            first id to use for boundary probes, which must be the total
+	 *            number of regular probes of the class as determined by
+	 *            {@link #countRegularProbes(ClassReader)}, or
+	 *            {@link #NO_BOUNDARY_PROBES} to not generate boundary probes
+	 */
+	public ClassProbesAdapter(final ClassProbesVisitor cv,
+			final boolean trackFrames, final int boundaryProbeBase) {
 		super(InstrSupport.ASM_API_VERSION, cv);
 		this.cv = cv;
 		this.trackFrames = trackFrames;
+		this.boundaryProbeBase = boundaryProbeBase;
+		this.boundaryCounter = boundaryProbeBase;
+	}
+
+	/**
+	 * Determines how many regular probes the given class requires. Boundary
+	 * probes are allocated after these, which keeps the ids of regular probes
+	 * independent of the boundary metric.
+	 *
+	 * @param reader
+	 *            reader for the class definition
+	 * @return number of regular probes
+	 */
+	public static int countRegularProbes(final ClassReader reader) {
+		final ProbeCountVisitor counter = new ProbeCountVisitor();
+		reader.accept(new ClassProbesAdapter(counter, false), 0);
+		return counter.count;
+	}
+
+	private static class ProbeCountVisitor extends ClassProbesVisitor {
+
+		int count;
+
+		@Override
+		public MethodProbesVisitor visitMethod(final int access,
+				final String name, final String desc, final String signature,
+				final String[] exceptions) {
+			return null;
+		}
+
+		@Override
+		public void visitTotalProbeCount(final int count) {
+			this.count = count;
+		}
 	}
 
 	@Override
@@ -96,7 +159,7 @@ public class ClassProbesAdapter extends ClassVisitor
 
 	@Override
 	public void visitEnd() {
-		cv.visitTotalProbeCount(counter);
+		cv.visitTotalProbeCount(Math.max(counter, boundaryCounter));
 		super.visitEnd();
 	}
 
@@ -104,6 +167,13 @@ public class ClassProbesAdapter extends ClassVisitor
 
 	public int nextId() {
 		return counter++;
+	}
+
+	public int nextBoundaryId() {
+		if (boundaryProbeBase == NO_BOUNDARY_PROBES) {
+			return LabelInfo.NO_PROBE;
+		}
+		return boundaryCounter++;
 	}
 
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/IProbeIdGenerator.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/IProbeIdGenerator.java
@@ -24,4 +24,14 @@ public interface IProbeIdGenerator {
 	 */
 	int nextId();
 
+	/**
+	 * Returns the next unique id for a boundary probe. Boundary probe ids are
+	 * allocated after all regular probe ids of the class, so that adding this
+	 * metric does not shift the id of any regular probe.
+	 *
+	 * @return unique probe id, or {@link LabelInfo#NO_PROBE} if boundary probes
+	 *         are not generated
+	 */
+	int nextBoundaryId();
+
 }

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesAdapter.java
@@ -114,11 +114,39 @@ public final class MethodProbesAdapter extends MethodVisitor {
 
 	@Override
 	public void visitJumpInsn(final int opcode, final Label label) {
+		if (isOrderedComparison(opcode)) {
+			final int boundaryId = idGenerator.nextBoundaryId();
+			if (boundaryId != LabelInfo.NO_PROBE) {
+				probesVisitor.visitBoundaryProbe(opcode, boundaryId, frame(0));
+			}
+		}
 		if (LabelInfo.isMultiTarget(label)) {
 			probesVisitor.visitJumpInsnWithProbe(opcode, label,
 					idGenerator.nextId(), frame(jumpPopCount(opcode)));
 		} else {
 			probesVisitor.visitJumpInsn(opcode, label);
+		}
+	}
+
+	/**
+	 * Ordered comparisons are the ones where the boundary value, i.e. the case
+	 * where both operands are equal, is not implied by executing both branches.
+	 * Equality comparisons are excluded, as well as the reference comparisons
+	 * IF_ACMPEQ, IF_ACMPNE, IFNULL and IFNONNULL, which have no boundary.
+	 */
+	private static boolean isOrderedComparison(final int opcode) {
+		switch (opcode) {
+		case Opcodes.IFLT:
+		case Opcodes.IFGE:
+		case Opcodes.IFGT:
+		case Opcodes.IFLE:
+		case Opcodes.IF_ICMPLT:
+		case Opcodes.IF_ICMPGE:
+		case Opcodes.IF_ICMPGT:
+		case Opcodes.IF_ICMPLE:
+			return true;
+		default:
+			return false;
 		}
 	}
 

--- a/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesVisitor.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/flow/MethodProbesVisitor.java
@@ -79,6 +79,32 @@ public abstract class MethodProbesVisitor extends MethodVisitor {
 	}
 
 	/**
+	 * Visits the boundary probe of an ordered numeric comparison. The event is
+	 * emitted directly before the comparison itself, and the probe must be
+	 * inserted in a way that it is executed only when the two compared values
+	 * are equal. For a comparison against zero the single operand is equal to
+	 * zero, which for the result of LCMP, FCMPL, FCMPG, DCMPL or DCMPG means
+	 * that the two compared values are equal.
+	 *
+	 * Executing both branches of an ordered comparison does not imply that the
+	 * boundary value itself was ever used, which is what this probe records.
+	 *
+	 * @param opcode
+	 *            the opcode of the comparison to be visited. This opcode is
+	 *            either IFLT, IFGE, IFGT, IFLE, IF_ICMPLT, IF_ICMPGE, IF_ICMPGT
+	 *            or IF_ICMPLE.
+	 * @param probeId
+	 *            id of the probe
+	 * @param frame
+	 *            stackmap frame status before the execution of the comparison.
+	 *            The instance is only valid with the call of this method.
+	 */
+	@SuppressWarnings("unused")
+	public void visitBoundaryProbe(final int opcode, final int probeId,
+			final IFrame frame) {
+	}
+
+	/**
 	 * Visits a zero operand instruction with a probe. This event is used only
 	 * for instructions that terminate the method. Therefore the probe must be
 	 * inserted before the actual instruction.

--- a/org.jacoco.core/src/org/jacoco/core/internal/instr/MethodInstrumenter.java
+++ b/org.jacoco.core/src/org/jacoco/core/internal/instr/MethodInstrumenter.java
@@ -55,6 +55,37 @@ class MethodInstrumenter extends MethodProbesVisitor {
 	}
 
 	@Override
+	public void visitBoundaryProbe(final int opcode, final int probeId,
+			final IFrame frame) {
+		// The operands of the comparison are duplicated and consumed by an
+		// equality check that skips the probe, so the comparison itself sees an
+		// unchanged operand stack.
+		final Label skip = new Label();
+		if (isSingleOperand(opcode)) {
+			mv.visitInsn(Opcodes.DUP);
+			mv.visitJumpInsn(Opcodes.IFNE, skip);
+		} else {
+			mv.visitInsn(Opcodes.DUP2);
+			mv.visitJumpInsn(Opcodes.IF_ICMPNE, skip);
+		}
+		probeInserter.insertProbe(probeId);
+		mv.visitLabel(skip);
+		frame.accept(mv);
+	}
+
+	private static boolean isSingleOperand(final int opcode) {
+		switch (opcode) {
+		case Opcodes.IFLT:
+		case Opcodes.IFGE:
+		case Opcodes.IFGT:
+		case Opcodes.IFLE:
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	@Override
 	public void visitJumpInsnWithProbe(final int opcode, final Label label,
 			final int probeId, final IFrame frame) {
 		if (opcode == Opcodes.GOTO) {

--- a/org.jacoco.doc/docroot/doc/ant.html
+++ b/org.jacoco.doc/docroot/doc/ant.html
@@ -843,8 +843,8 @@
       <td><code>counter</code></td>
       <td>The <a href="counters.html">counter</a> which should be checked.
           Possible options are <code>INSTRUCTION</code>, <code>LINE</code>,
-          <code>BRANCH</code>, <code>COMPLEXITY</code>, <code>METHOD</code> and
-          <code>CLASS</code>.</td>
+          <code>BRANCH</code>, <code>COMPLEXITY</code>, <code>METHOD</code>,
+          <code>CLASS</code> and <code>BOUNDARY</code>.</td>
       <td><code>INSTRUCTION</code></td>
     </tr>
     <tr>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -27,6 +27,10 @@
   <li>To instrument classes loaded by the platform class loader, introduced in JDK 9
       by JEP 261, the agent option <code>inclbootstrapclasses=true</code> is required
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/2155">#2155</a>).</li>
+  <li>Execution data for the same class with a different number of probes is now
+      merged instead of being rejected: the shorter probe array is treated as a
+      prefix of the longer one, and probes that are missing from the execution
+      data count as not executed.</li>
 </ul>
 
 <h2>Release 0.8.15 (2026/06/04)</h2>

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -27,6 +27,12 @@
   <li>To instrument classes loaded by the platform class loader, introduced in JDK 9
       by JEP 261, the agent option <code>inclbootstrapclasses=true</code> is required
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/2155">#2155</a>).</li>
+  <li>New <a href="counters.html">boundary counter</a> reports whether ordered
+      numeric comparisons were exercised with equal values. Executing both
+      branches of <code>if (i &gt; 6)</code> does not imply that
+      <code>i = 6</code> was ever used, so an off-by-one error in the comparison
+      stays undetected by branch coverage
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/2190">#2190</a>).</li>
   <li>Execution data for the same class with a different number of probes is now
       merged instead of being rejected: the shorter probe array is treated as a
       prefix of the longer one, and probes that are missing from the execution

--- a/org.jacoco.doc/docroot/doc/counters.html
+++ b/org.jacoco.doc/docroot/doc/counters.html
@@ -66,6 +66,35 @@
   <li>Full coverage: All branches in the line have been executed (green diamond)</li>
 </ul>
 
+<h2>Boundaries</h2>
+
+<p>
+  Branch coverage reports an ordered numeric comparison as fully covered as soon
+  as both of its branches have been executed. That does not imply that the
+  <i>boundary value</i> of the comparison, the case where both compared values
+  are equal, was ever used. For <code>if (i &gt; 6)</code> a test with
+  <code>i = 5</code> and a test with <code>i = 7</code> cover both branches
+  without ever exercising <code>i = 6</code>, so an off-by-one error in the
+  comparison would not be detected.
+</p>
+
+<p>
+  The boundary counter reports how many ordered numeric comparisons were
+  exercised with equal values. Comparisons for equality are not counted, as they
+  have no boundary. A comparison is counted only once both of its branches are
+  covered: as long as a branch is missing, the branch counter already reports
+  the gap.
+</p>
+
+<p>
+  This metric is derived from the bytecode alone, like all other JaCoCo
+  counters. It therefore covers comparisons against zero and comparisons of the
+  results of <code>LCMP</code>, <code>FCMPL</code>, <code>FCMPG</code>,
+  <code>DCMPL</code> and <code>DCMPG</code>, which includes comparisons of
+  <code>long</code>, <code>float</code> and <code>double</code> values, and the
+  <code>compareTo()</code> idiom.
+</p>
+
 <h2>Cyclomatic Complexity</h2>
 
 <p>

--- a/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/ReportStructureTestDriver.java
@@ -73,6 +73,7 @@ public class ReportStructureTestDriver {
 		m.increment(CounterImpl.getInstance(3, 5),
 				CounterImpl.getInstance(1, 2), 2);
 		m.increment(CounterImpl.getInstance(4, 5), CounterImpl.COUNTER_0_0, 4);
+		m.incrementBoundaryCounter(CounterImpl.getInstance(2, 1));
 		m.incrementMethodCounter();
 		methodCoverage = m;
 

--- a/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
+++ b/org.jacoco.report.test/src/org/jacoco/report/xml/XMLFormatterTest.java
@@ -127,6 +127,10 @@ public class XMLFormatterTest {
 		assertPathMatches("1", "count(/report/counter[@type='CLASS'])");
 		assertPathMatches("0", "report/counter[@type='CLASS']/@missed");
 		assertPathMatches("1", "report/counter[@type='CLASS']/@covered");
+
+		assertPathMatches("1", "count(/report/counter[@type='BOUNDARY'])");
+		assertPathMatches("2", "report/counter[@type='BOUNDARY']/@missed");
+		assertPathMatches("1", "report/counter[@type='BOUNDARY']/@covered");
 	}
 
 	@Test

--- a/org.jacoco.report/src/org/jacoco/report/check/Limit.java
+++ b/org.jacoco.report/src/org/jacoco/report/check/Limit.java
@@ -46,6 +46,7 @@ public class Limit {
 		entities.put(CounterEntity.LINE, "lines");
 		entities.put(CounterEntity.METHOD, "methods");
 		entities.put(CounterEntity.CLASS, "classes");
+		entities.put(CounterEntity.BOUNDARY, "boundaries");
 		ENTITY_NAMES = Collections.unmodifiableMap(entities);
 	}
 

--- a/org.jacoco.report/src/org/jacoco/report/html/HTMLFormatter.java
+++ b/org.jacoco.report/src/org/jacoco/report/html/HTMLFormatter.java
@@ -145,6 +145,9 @@ public class HTMLFormatter implements IHTMLReportContext {
 		addMissedTotalColumns(t, "Lines", CounterEntity.LINE);
 		addMissedTotalColumns(t, "Methods", CounterEntity.METHOD);
 		addMissedTotalColumns(t, "Classes", CounterEntity.CLASS);
+		// Appended rather than placed next to the branch columns, so that the
+		// generated column ids of the existing columns do not shift.
+		addMissedTotalColumns(t, "Boundaries", CounterEntity.BOUNDARY);
 		return t;
 	}
 

--- a/org.jacoco.report/src/org/jacoco/report/xml/report.dtd
+++ b/org.jacoco.report/src/org/jacoco/report/xml/report.dtd
@@ -78,7 +78,7 @@
 <!-- coverage data counter for different metrics -->
 <!ELEMENT counter EMPTY>
   <!-- metric type -->
-  <!ATTLIST counter type (INSTRUCTION|BRANCH|LINE|COMPLEXITY|METHOD|CLASS) #REQUIRED>
+  <!ATTLIST counter type (INSTRUCTION|BRANCH|LINE|COMPLEXITY|METHOD|CLASS|BOUNDARY) #REQUIRED>
   <!-- number of missed items -->
   <!ATTLIST counter missed CDATA #REQUIRED>
   <!-- number of covered items -->


### PR DESCRIPTION
## Why

Branch coverage reports an ordered numeric comparison as fully covered as soon as both of its branches have been executed, which does not imply that the boundary value was ever used. For `if (i > 6)` a test with 5 and a test with 7 cover both branches without ever exercising 6, so an off-by-one error in the comparison stays undetected. JaCoCo's own code has such places, for example `MethodCoverageImpl#increment` (`branches.getTotalCount() > 1`) and `KotlinJvmOverloadsFilter#filter` (`instructions.size() < 5`).

Today only mutation testing surfaces this. PIT's `CONDITIONALS_BOUNDARY` finds the same gaps, at the cost of re-running the suite once per mutant.

This implements the metric discussed in #2190.

## What

**A single probe per comparison.** Two of the three regions of a comparison are already known from branch coverage, so the only missing bit is whether the two compared values were ever equal. At an ordered conditional jump the operands are duplicated and consumed by an equality check that skips the probe, so the comparison itself sees an unchanged operand stack and the peak stack stays within the three slots `ProbeInserter` already reserves.

**One rule for every numeric type.** Only the conditional jump is instrumented, not the preceding comparison. For `long`, `float` and `double` the jump tests the result of `LCMP` / `FCMPL` / `FCMPG` / `DCMPL` / `DCMPG` against zero, and zero means the operands were equal. Equality comparisons carry no boundary and are excluded by opcode, which also excludes the `LCMP` form that javac emits for `==` on `long` values. The `compareTo() > 0` idiom is covered by the same rule.

**Probe ids stay stable.** Boundary probe ids are allocated after all regular probe ids of the class, so the id of a regular probe does not depend on this metric. Together with the first commit, execution data recorded by earlier versions still maps onto the same probes. This costs one additional pass over the class to count the regular probes first.

**Only the actionable subset is counted.** A comparison is counted once both of its branches are covered. As long as a branch is missing, the branch counter already reports the gap and the boundary would be missed for that reason alone.

The first commit, `Treat a shorter probe array as a prefix of a longer one`, is what makes the tail allocation pay off, and it is independently useful: it replaces `IllegalStateException: Incompatible execution data` with a defined merge whenever the probe count differs. It can be split into its own PR if you prefer to consider it separately.

### Deliberate omissions

- **The counter is not added to `ICoverageNode`,** only as a `CounterEntity`, so implementations of that interface outside of JaCoCo keep compiling.
- **The CSV report is unchanged.** Unlike the XML and HTML reports it has no way to omit a metric that is not present, so adding a column would change the layout for every existing consumer. That seemed like your call rather than mine.
- **No per-line reporting.** The counter is recorded per method, which keeps `LineImpl` and its flyweight table untouched. Per-line data would be needed for source highlighting.

### Known limitation

The counter only sees comparisons present in the analyzed method. Where a comparison is hidden behind a library call it reports nothing — the Scala validation tests pin this for `a > b` on strings, which compiles to `StringOps.$greater$extension`, and for `(1 to 10).contains(arg)`.

## How to verify

```
./mvnw test
```

Validation tests cover three different code generators: `BoundaryTest` (java5, 22 tests), `KotlinBoundaryTest` (13 tests), `ScalaBoundaryTest` (15 tests). Each one compiles the target with the compiler under test, executes it, and asserts the counter, so a compiler that emits a different shape shows up as a changed counter rather than as silently missing data. `BoundaryCoverageTest` in `org.jacoco.core.test` additionally executes instrumented code end to end.

Writing those tests corrected three assumptions, which are documented in the tests:

- For plain Java each operand of `&&` keeps its own two branches, so each operand also gets its own boundary.
- Kotlin normalizes the upper end of a range, so `arg in 1..10` compiles to `1 > arg` and `arg >= 11`. The boundary of the upper comparison is 11, not 10.
- `KotlinInlineFilter` ignores instructions the SMAP attributes to an inline function, so a caller reports no boundary for an inlined comparison, consistently with the rest of JaCoCo's handling of inlined code.
