### PR TITLE
Add jacoco.additionalIncludes / jacoco.additionalExcludes to check and report mojo (#1075)

### DIFF
--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   https://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Clemens Loebbert - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-includes-excludes-property-implicit</artifactId>
+
+  <properties>
+    <jacoco.additionalExcludes>**/Excluded*,**/AlsoExcluded*</jacoco.additionalExcludes>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <limits>
+                    <limit>
+                      <minimum>0%</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/main/java/org/project/AlsoExcluded.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/main/java/org/project/AlsoExcluded.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+public class AlsoExcluded {
+	public void doStuff() {
+		System.out.println("AlsoExcluded");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/main/java/org/project/Excluded.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/main/java/org/project/Excluded.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+public class Excluded {
+	public void doStuff() {
+		System.out.println("Excluded");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/main/java/org/project/Included.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/main/java/org/project/Included.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+public class Included {
+	public void doStuff() {
+		System.out.println("Included");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/test/java/org/project/IncludedTest.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/src/test/java/org/project/IncludedTest.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+import org.junit.Test;
+
+public class IncludedTest {
+	@Test
+	public void testDoStuff() {
+		new Included().doStuff();
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property-implicit/verify.bsh
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+File includedReportFile = new File( basedir, "target/site/jacoco/org.project/Included.html" );
+if ( !includedReportFile.isFile() )
+{
+    throw new FileNotFoundException( "Included should NOT be excluded: " + includedReportFile );
+}
+
+File excludedReportFile = new File( basedir, "target/site/jacoco/org.project/Excluded.html" );
+if ( excludedReportFile.isFile() )
+{
+    throw new RuntimeException( "Excluded SHOULD be excluded: " + excludedReportFile );
+}
+
+File alsoExcludedReportFile = new File( basedir, "target/site/jacoco/org.project/AlsoExcluded.html" );
+if ( alsoExcludedReportFile.isFile() )
+{
+    throw new RuntimeException( "AlsoExcluded SHOULD be excluded: " + alsoExcludedReportFile );
+}
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+if ( buildLog.indexOf( "All coverage checks have been met." ) < 0 )
+{
+    throw new RuntimeException( "Coverage check should have passed" );
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property/pom.xml
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License 2.0 which is available at
+   https://www.eclipse.org/legal/epl-2.0
+
+   SPDX-License-Identifier: EPL-2.0
+
+   Contributors:
+      Clemens Loebbert - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>jacoco</groupId>
+    <artifactId>setup-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it-includes-excludes-property</artifactId>
+
+  <properties>
+    <coverage.exclusions>**/Excluded*,**/AlsoExcluded*</coverage.exclusions>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <additionalExcludes>${coverage.exclusions}</additionalExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <additionalExcludes>${coverage.exclusions}</additionalExcludes>
+              <rules>
+                <rule>
+                  <limits>
+                    <limit>
+                      <minimum>0%</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/main/java/org/project/AlsoExcluded.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/main/java/org/project/AlsoExcluded.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+public class AlsoExcluded {
+	public void doStuff() {
+		System.out.println("AlsoExcluded");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/main/java/org/project/Excluded.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/main/java/org/project/Excluded.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+public class Excluded {
+	public void doStuff() {
+		System.out.println("Excluded");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/main/java/org/project/Included.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/main/java/org/project/Included.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+public class Included {
+	public void doStuff() {
+		System.out.println("Included");
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/test/java/org/project/IncludedTest.java
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property/src/test/java/org/project/IncludedTest.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+package org.project;
+
+import org.junit.Test;
+
+public class IncludedTest {
+	@Test
+	public void testDoStuff() {
+		new Included().doStuff();
+	}
+}

--- a/jacoco-maven-plugin.test/it/it-includes-excludes-property/verify.bsh
+++ b/jacoco-maven-plugin.test/it/it-includes-excludes-property/verify.bsh
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Clemens Loebbert - initial API and implementation
+ *
+ *******************************************************************************/
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+File includedReportFile = new File( basedir, "target/site/jacoco/org.project/Included.html" );
+if ( !includedReportFile.isFile() )
+{
+    throw new FileNotFoundException( "Included should NOT be excluded: " + includedReportFile );
+}
+
+File excludedReportFile = new File( basedir, "target/site/jacoco/org.project/Excluded.html" );
+if ( excludedReportFile.isFile() )
+{
+    throw new RuntimeException( "Excluded SHOULD be excluded: " + excludedReportFile );
+}
+
+File alsoExcludedReportFile = new File( basedir, "target/site/jacoco/org.project/AlsoExcluded.html" );
+if ( alsoExcludedReportFile.isFile() )
+{
+    throw new RuntimeException( "AlsoExcluded SHOULD be excluded: " + alsoExcludedReportFile );
+}
+
+String buildLog = FileUtils.fileRead( new File( basedir, "build.log" ) );
+if ( buildLog.indexOf( "All coverage checks have been met." ) < 0 )
+{
+    throw new RuntimeException( "Coverage check should have passed" );
+}

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractReportMojo.java
@@ -80,11 +80,29 @@ public abstract class AbstractReportMojo extends AbstractMojo
 	List<String> includes;
 
 	/**
+	 * A comma-separated list of class-file patterns to include in the report,
+	 * as an alternative to {@link #includes} that can be supplied from a single
+	 * (shared) property. May use wildcard characters (* and ?). Patterns given
+	 * here are combined with any {@link #includes} entries.
+	 */
+	@Parameter(property = "jacoco.additionalIncludes")
+	String additionalIncludes;
+
+	/**
 	 * A list of class files to exclude from the report. May use wildcard
 	 * characters (* and ?). When not specified nothing will be excluded.
 	 */
 	@Parameter
 	List<String> excludes;
+
+	/**
+	 * A comma-separated list of class-file patterns to exclude from the report,
+	 * as an alternative to {@link #excludes} that can be supplied from a single
+	 * (shared) property. May use wildcard characters (* and ?). Patterns given
+	 * here are combined with any {@link #excludes} entries.
+	 */
+	@Parameter(property = "jacoco.additionalExcludes")
+	String additionalExcludes;
 
 	/**
 	 * Flag used to suppress execution.
@@ -116,7 +134,7 @@ public abstract class AbstractReportMojo extends AbstractMojo
 	 * @return class files to include, may contain wildcard characters
 	 */
 	List<String> getIncludes() {
-		return includes;
+		return FileFilter.combine(includes, additionalIncludes);
 	}
 
 	/**
@@ -125,7 +143,7 @@ public abstract class AbstractReportMojo extends AbstractMojo
 	 * @return class files to exclude, may contain wildcard characters
 	 */
 	List<String> getExcludes() {
-		return excludes;
+		return FileFilter.combine(excludes, additionalExcludes);
 	}
 
 	public boolean canGenerateReport() {

--- a/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/CheckMojo.java
@@ -137,11 +137,29 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 	private List<String> includes;
 
 	/**
+	 * A comma-separated list of class-file patterns to include in analysis, as
+	 * an alternative to {@link #includes} that can be supplied from a single
+	 * (shared) property. May use wildcard characters (* and ?). Patterns given
+	 * here are combined with any {@link #includes} entries.
+	 */
+	@Parameter(property = "jacoco.additionalIncludes")
+	private String additionalIncludes;
+
+	/**
 	 * A list of class files to exclude from analysis. May use wildcard
 	 * characters (* and ?). When not specified nothing will be excluded.
 	 */
 	@Parameter
 	private List<String> excludes;
+
+	/**
+	 * A comma-separated list of class-file patterns to exclude from analysis,
+	 * as an alternative to {@link #excludes} that can be supplied from a single
+	 * (shared) property. May use wildcard characters (* and ?). Patterns given
+	 * here are combined with any {@link #excludes} entries.
+	 */
+	@Parameter(property = "jacoco.additionalExcludes")
+	private String additionalExcludes;
 
 	private boolean violations;
 
@@ -183,7 +201,9 @@ public class CheckMojo extends AbstractJacocoMojo implements IViolationsOutput {
 		try {
 			final IReportVisitor visitor = support.initRootVisitor();
 			support.loadExecutionData(dataFile);
-			support.processProject(visitor, getProject(), includes, excludes);
+			support.processProject(visitor, getProject(),
+					FileFilter.combine(includes, additionalIncludes),
+					FileFilter.combine(excludes, additionalExcludes));
 			visitor.visitEnd();
 		} catch (final IOException e) {
 			throw new MojoExecutionException(

--- a/jacoco-maven-plugin/src/org/jacoco/maven/FileFilter.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/FileFilter.java
@@ -15,6 +15,7 @@ package org.jacoco.maven;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.codehaus.plexus.util.FileUtils;
@@ -88,6 +89,29 @@ public class FileFilter {
 	 */
 	public String getExcludes() {
 		return this.buildPattern(this.excludes, DEFAULT_EXCLUDES);
+	}
+
+	/**
+	 * Combines a list of patterns with an additional comma-separated pattern
+	 * string. Either argument may be {@code null} or empty.
+	 *
+	 * @param patterns
+	 *            list of patterns, may be {@code null}
+	 * @param additional
+	 *            comma-separated pattern string, may be {@code null} or empty
+	 * @return combined list
+	 */
+	public static List<String> combine(final List<String> patterns,
+			final String additional) {
+		if (additional == null || additional.trim().length() == 0) {
+			return patterns;
+		}
+		final List<String> result = new ArrayList<String>();
+		if (patterns != null) {
+			result.addAll(patterns);
+		}
+		result.add(additional.trim());
+		return result;
 	}
 
 	private String buildPattern(final List<String> patterns,

--- a/org.jacoco.doc/docroot/doc/changes.html
+++ b/org.jacoco.doc/docroot/doc/changes.html
@@ -22,6 +22,12 @@
 
 <h3>New Features</h3>
 <ul>
+  <li>Maven <code>report</code>, <code>report-aggregate</code> and
+      <code>check</code> goals now accept includes/excludes as a comma-separated
+      string via the <code>jacoco.additionalIncludes</code> and <code>jacoco.additionalExcludes</code>
+      properties, so a single (shared) property can drive both reporting and
+      coverage enforcement
+      (GitHub <a href="https://github.com/jacoco/jacoco/issues/1075">#1075</a>).</li>
   <li>Experimental support for Java 28 class files
       (GitHub <a href="https://github.com/jacoco/jacoco/issues/2170">#2170</a>).</li>
   <li>To instrument classes loaded by the platform class loader, introduced in JDK 9


### PR DESCRIPTION
I ran into a very similar problem as described here: https://github.com/jacoco/jacoco/issues/1075

While using fileset exclusions on the check goal I also had to use the same block on the reporting configuration, to prevent the site from showing a lower test coverage than actually measured / enforced.

```xml
<!-- in the configuration block of both the check / report goals -->
<excludes>
    <exclude>**/*AutoConfiguration.class</exclude>
    <exclude>**/*Properties.class</exclude>
    <!-- ... -->
</excludes>
```

Having these blocks duplicated multiple times (and keeping them consistent) is annoying.

My proposed change would add two additional parameter properties that allow specifying comma-separated class-name-patterns to be included / excluded in the check and report mojo:

```xml
<jacoco.additionalExcludes>**/Excluded*,**/AlsoExcluded*</jacoco.additionalExcludes>
<jacoco.additionalIncludes>**/ExplicitlyIncluded*</jacoco.additionalIncludes>
```

They can also be set directly in the configuration blocks (and then affect only check or report): 

```xml
<configuration>
  <additionalExcludes>...</additionalExcludes>
</configuration>
```

They are combined with the already specified file-sets (if any), hence the name `additional`.

I feel like this small non-breaking change would be a genuine enhancement, allow users to use the same exclusion property for sonar and jacoco and remove the need for duplicated exclusion lists, without breaking any patterns.
