### PR TITLE
Add validation test for ranges in Kotlin `when`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenRangeTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenRangeTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenRangeTarget;
+
+/**
+ * Test of code coverage in {@link KotlinWhenRangeTarget}.
+ */
+public class KotlinWhenRangeTest extends ValidationTestBase {
+
+	public KotlinWhenRangeTest() {
+		super(KotlinWhenRangeTarget.class);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenRangeTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenRangeTarget.kt
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+import org.jacoco.core.test.validation.targets.Stubs.nop
+
+/**
+ * Test target with `when` expressions and statements whose conditions are
+ * ranges.
+ *
+ * Unlike cases with constants, that are compiled into a single `tableswitch`
+ * or `lookupswitch` instruction, every range case is compiled into a
+ * comparison of the subject with both bounds, whose result is materialized as
+ * a boolean value that is then compared with zero, so that a single case
+ * produces six branches:
+ *
+ * <pre>
+ * ICONST_1
+ * ILOAD 2
+ * IF_ICMPGT out_of_range
+ * ILOAD 2
+ * BIPUSH 6
+ * IF_ICMPGE out_of_range
+ * ...
+ * IFEQ next_case
+ * </pre>
+ *
+ * @see <a href="https://youtrack.jetbrains.com/issue/KT-19162">KT-19162</a>
+ */
+object KotlinWhenRangeTarget {
+
+    private fun whenRange(p: Int): Int = when (p) { // assertFullyCovered()
+        in 1..5 -> 1 // assertFullyCovered(0, 6)
+        in 6..10 -> 2 // assertFullyCovered(0, 6)
+        else -> 3 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    private fun whenRangeNotIn(p: Int): Int = when (p) { // assertFullyCovered()
+        !in 1..10 -> 1 // assertFullyCovered(0, 6)
+        else -> 2 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    private fun whenRangeStatement(p: Int) { // assertEmpty()
+        when (p) { // assertFullyCovered()
+            in 1..5 -> nop("1..5") // assertFullyCovered(0, 6)
+            in 6..10 -> nop("6..10") // assertFullyCovered(0, 6)
+        } // assertEmpty()
+    } // assertFullyCovered()
+
+    /**
+     * A case with a constant is compiled into a comparison with a single
+     * branch, unlike the range case that follows it.
+     */
+    private fun whenRangeAndConstant(p: Int): Int = when (p) { // assertFullyCovered()
+        0 -> 1 // assertFullyCovered(0, 2)
+        in 1..5 -> 2 // assertFullyCovered(0, 6)
+        else -> 3 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    /**
+     * Unlike [whenRange] this example has no subject.
+     */
+    private fun whenWithoutSubject(p: Int): Int = when { // assertFullyCovered()
+        p in 1..5 -> 1 // assertFullyCovered(0, 6)
+        p in 6..10 -> 2 // assertFullyCovered(0, 6)
+        else -> 3 // assertFullyCovered()
+    } // assertFullyCovered()
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        whenRange(0)
+        whenRange(1)
+        whenRange(6)
+        whenRange(11)
+
+        whenRangeNotIn(0)
+        whenRangeNotIn(1)
+        whenRangeNotIn(11)
+
+        whenRangeStatement(0)
+        whenRangeStatement(1)
+        whenRangeStatement(6)
+        whenRangeStatement(11)
+
+        whenRangeAndConstant(-1)
+        whenRangeAndConstant(0)
+        whenRangeAndConstant(1)
+        whenRangeAndConstant(6)
+
+        whenWithoutSubject(0)
+        whenWithoutSubject(1)
+        whenWithoutSubject(6)
+        whenWithoutSubject(11)
+    }
+
+}


### PR DESCRIPTION
Closes #2140

Adds `KotlinWhenRangeTarget` / `KotlinWhenRangeTest`. No production code is touched — the test documents the coverage that JaCoCo currently produces for range conditions in `when`.

What the new target pins down:

* a range case is **not** compiled into a `tableswitch` / `lookupswitch` like a case with constants. Each `in a..b` case is compiled into a comparison with both bounds whose result is materialized as a boolean, which is then compared with zero:

  ```
  ICONST_1
  ILOAD 2
  IF_ICMPGT out_of_range
  ILOAD 2
  BIPUSH 6
  IF_ICMPGE out_of_range
  ...
  IFEQ next_case
  ```

  so a **single range case carries six branches**, of which the last pair duplicates the outcome of the two comparisons. `assertFullyCovered(0, 6)` in the target records exactly that.

* covering those six branches requires a subject below the lower bound, not only one above the upper bound — the `main` method is written accordingly (for example `whenRangeAndConstant(-1)`, because the preceding `0 ->` case would otherwise hide that branch).

* the same shape appears for `!in`, for a `when` statement without `else`, for a range case that follows a constant case (2 branches for the constant, 6 for the range), and for a `when` without a subject.

Verified with the Kotlin version currently used by the module (2.4.10):

```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0 -- KotlinWhenRangeTest
[INFO] Tests run: 288, Failures: 0, Errors: 0, Skipped: 0 -- org.jacoco.core.test.validation.kotlin
[INFO] BUILD SUCCESS
```

See also https://youtrack.jetbrains.com/issue/KT-19162, referenced in the issue.

---
Written with AI assistance; reviewed, built and tested by me.