### PR TITLE
Add bytecode snapshots for `KotlinSafeCallOperatorTarget`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinSafeCallOperatorTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinSafeCallOperatorTest.java
@@ -14,6 +14,7 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinSafeCallOperatorTarget;
+import org.junit.Test;
 
 /**
  * Test of code coverage in {@link KotlinSafeCallOperatorTarget}.
@@ -22,6 +23,32 @@ public class KotlinSafeCallOperatorTest extends ValidationTestBase {
 
 	public KotlinSafeCallOperatorTest() {
 		super(KotlinSafeCallOperatorTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCall$fullCoverage", "safe_call.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallChain$fullCoverage", "safe_call_chain.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallChainMultiline$fullCoverage",
+				"safe_call_chain_multiline.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallChainMultiline2$fullCoverage",
+				"safe_call_chain_multiline2.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallFollowedByElvis$fullCoverage",
+				"safe_call_followed_by_elvis.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallFollowedByElvisMultiline$fullCoverage",
+				"safe_call_followed_by_elvis_multiline.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallChainFollowedByElvis$fullCoverage",
+				"safe_call_chain_followed_by_elvis.txt");
+		assertSnapshot(KotlinSafeCallOperatorTarget.class,
+				"safeCallChainFollowedByElvisMultiline$fullCoverage",
+				"safe_call_chain_followed_by_elvis_multiline.txt");
 	}
 
 }

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call.txt
@@ -1,0 +1,16 @@
+   L0
+    ALOAD 0
+    DUP
+    IFNULL L1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+    GOTO L2
+   L1
+    POP
+    ACONST_NULL
+   L2
+    ARETURN
+   L3
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L3 0
+    LINENUMBER 5 L0
+    MAXSTACK = 2
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call.txt
@@ -1,16 +1,16 @@
-   L0
+   L_method_start
     ALOAD 0
     DUP
-    IFNULL L1
+    IFNULL L_null
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-    GOTO L2
-   L1
+    GOTO L_after
+   L_null
     POP
     ACONST_NULL
-   L2
+   L_after
     ARETURN
-   L3
-    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L3 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     MAXSTACK = 2
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt
@@ -1,19 +1,19 @@
-   L0
+   L_method_start
     ALOAD 0
     DUP
-    IFNULL L1
+    IFNULL L_null
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     DUP
-    IFNULL L1
+    IFNULL L_null
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-    GOTO L2
-   L1
+    GOTO L_after
+   L_null
     POP
     ACONST_NULL
-   L2
+   L_after
     ARETURN
-   L3
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L3 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     MAXSTACK = 2
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt
@@ -1,0 +1,19 @@
+   L0
+    ALOAD 0
+    DUP
+    IFNULL L1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
+    DUP
+    IFNULL L1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+    GOTO L2
+   L1
+    POP
+    ACONST_NULL
+   L2
+    ARETURN
+   L3
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L3 0
+    LINENUMBER 5 L0
+    MAXSTACK = 2
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt
@@ -1,0 +1,20 @@
+   L0
+    ALOAD 0
+    DUP
+    IFNULL L1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
+    DUP
+    IFNULL L1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+    DUP
+    IFNONNULL L2
+   L1
+    POP
+    LDC ""
+   L2
+    ARETURN
+   L3
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L3 0
+    LINENUMBER 5 L0
+    MAXSTACK = 2
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt
@@ -1,20 +1,20 @@
-   L0
+   L_method_start
     ALOAD 0
     DUP
-    IFNULL L1
+    IFNULL L_null
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     DUP
-    IFNULL L1
+    IFNULL L_null
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
     DUP
-    IFNONNULL L2
-   L1
+    IFNONNULL L_after
+   L_null
     POP
     LDC ""
-   L2
+   L_after
     ARETURN
-   L3
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L3 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     MAXSTACK = 2
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
@@ -1,37 +1,37 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
-   L2
+    IFNULL L_null
+   L_getB_before
     ALOAD 0
-   L3
+   L_getB
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     ASTORE 1
-   L4
+   L_getB_after
     ALOAD 1
-    IFNULL L1
-   L5
+    IFNULL L_null
+   L_getC_before
     ALOAD 1
-   L6
+   L_getC
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-   L7
+   L_getC_after
     ASTORE 2
     ALOAD 2
-    IFNULL L1
+    IFNULL L_null
     ALOAD 2
-    GOTO L8
-   L1
+    GOTO L_after
+   L_null
     LDC ""
-   L8
+   L_after
     ARETURN
-   L9
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L9 0
-    LINENUMBER 6 L0
-    LINENUMBER 5 L2
-    LINENUMBER 6 L3
-    LINENUMBER 7 L4
-    LINENUMBER 5 L5
-    LINENUMBER 7 L6
-    LINENUMBER 5 L7
-    LINENUMBER 8 L1
+   L_method_end
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 6 L_method_start
+    LINENUMBER 5 L_getB_before
+    LINENUMBER 6 L_getB
+    LINENUMBER 7 L_getB_after
+    LINENUMBER 5 L_getC_before
+    LINENUMBER 7 L_getC
+    LINENUMBER 5 L_getC_after
+    LINENUMBER 8 L_null
     MAXSTACK = 1
     MAXLOCALS = 3

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
@@ -1,6 +1,6 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
+    IFNULL L_null
    L2
     ALOAD 0
    L3
@@ -8,7 +8,7 @@
     ASTORE 1
    L4
     ALOAD 1
-    IFNULL L1
+    IFNULL L_null
    L5
     ALOAD 1
    L6
@@ -16,22 +16,22 @@
    L7
     ASTORE 2
     ALOAD 2
-    IFNULL L1
+    IFNULL L_null
     ALOAD 2
-    GOTO L8
-   L1
+    GOTO L_after
+   L_null
     LDC ""
-   L8
+   L_after
     ARETURN
-   L9
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L9 0
-    LINENUMBER 6 L0
+   L_method_end
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 6 L_method_start
     LINENUMBER 5 L2
     LINENUMBER 6 L3
     LINENUMBER 7 L4
     LINENUMBER 5 L5
     LINENUMBER 7 L6
     LINENUMBER 5 L7
-    LINENUMBER 8 L1
+    LINENUMBER 8 L_null
     MAXSTACK = 1
     MAXLOCALS = 3

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
@@ -1,0 +1,37 @@
+   L0
+    ALOAD 0
+    IFNULL L1
+   L2
+    ALOAD 0
+   L3
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
+    ASTORE 1
+   L4
+    ALOAD 1
+    IFNULL L1
+   L5
+    ALOAD 1
+   L6
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+   L7
+    ASTORE 2
+    ALOAD 2
+    IFNULL L1
+    ALOAD 2
+    GOTO L8
+   L1
+    LDC ""
+   L8
+    ARETURN
+   L9
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L9 0
+    LINENUMBER 6 L0
+    LINENUMBER 5 L2
+    LINENUMBER 6 L3
+    LINENUMBER 7 L4
+    LINENUMBER 5 L5
+    LINENUMBER 7 L6
+    LINENUMBER 5 L7
+    LINENUMBER 8 L1
+    MAXSTACK = 1
+    MAXLOCALS = 3

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
@@ -1,0 +1,32 @@
+   L0
+    ALOAD 0
+    IFNULL L1
+   L2
+    ALOAD 0
+   L3
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
+    ASTORE 1
+   L4
+    ALOAD 1
+    IFNULL L1
+   L5
+    ALOAD 1
+   L6
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+    GOTO L7
+   L1
+    ACONST_NULL
+   L7
+    ARETURN
+   L8
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L8 0
+    LINENUMBER 6 L0
+    LINENUMBER 5 L2
+    LINENUMBER 6 L3
+    LINENUMBER 7 L4
+    LINENUMBER 5 L5
+    LINENUMBER 7 L6
+    LINENUMBER 6 L1
+    LINENUMBER 7 L7
+    MAXSTACK = 1
+    MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
@@ -1,6 +1,6 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
+    IFNULL L_null
    L2
     ALOAD 0
    L3
@@ -8,25 +8,25 @@
     ASTORE 1
    L4
     ALOAD 1
-    IFNULL L1
+    IFNULL L_null
    L5
     ALOAD 1
    L6
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-    GOTO L7
-   L1
+    GOTO L_after
+   L_null
     ACONST_NULL
-   L7
+   L_after
     ARETURN
-   L8
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L8 0
-    LINENUMBER 6 L0
+   L_method_end
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 6 L_method_start
     LINENUMBER 5 L2
     LINENUMBER 6 L3
     LINENUMBER 7 L4
     LINENUMBER 5 L5
     LINENUMBER 7 L6
-    LINENUMBER 6 L1
-    LINENUMBER 7 L7
+    LINENUMBER 6 L_null
+    LINENUMBER 7 L_after
     MAXSTACK = 1
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
@@ -1,32 +1,32 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
-   L2
+    IFNULL L_null
+   L_getB_before
     ALOAD 0
-   L3
+   L_getB
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     ASTORE 1
-   L4
+   L_getB_after
     ALOAD 1
-    IFNULL L1
-   L5
+    IFNULL L_null
+   L_getC_before
     ALOAD 1
-   L6
+   L_getC
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-    GOTO L7
-   L1
+    GOTO L_after
+   L_null
     ACONST_NULL
-   L7
+   L_after
     ARETURN
-   L8
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L8 0
-    LINENUMBER 6 L0
-    LINENUMBER 5 L2
-    LINENUMBER 6 L3
-    LINENUMBER 7 L4
-    LINENUMBER 5 L5
-    LINENUMBER 7 L6
-    LINENUMBER 6 L1
-    LINENUMBER 7 L7
+   L_method_end
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 6 L_method_start
+    LINENUMBER 5 L_getB_before
+    LINENUMBER 6 L_getB
+    LINENUMBER 7 L_getB_after
+    LINENUMBER 5 L_getC_before
+    LINENUMBER 7 L_getC
+    LINENUMBER 6 L_null
+    LINENUMBER 7 L_after
     MAXSTACK = 1
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline2.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline2.txt
@@ -1,46 +1,46 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
+    IFNULL L_null
     ALOAD 0
     ASTORE 1
     ALOAD 1
     ASTORE 2
-   L2
+   L_before_inline
     ICONST_0
     ISTORE 3
-   L3
+   L_inline
     ALOAD 2
     INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (Ljava/lang/Object;)V
-   L4
+   L_after_inline
     NOP
-   L5
+   L_getB_before
     ALOAD 1
-   L6
+   L_getB
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     ASTORE 1
     ALOAD 1
-    IFNULL L1
-   L7
+    IFNULL L_null
+   L_getC_before
     ALOAD 1
-   L8
+   L_getC
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-    GOTO L9
-   L1
+    GOTO L_after
+   L_null
     ACONST_NULL
-   L9
+   L_after
     ARETURN
-   L10
-    LOCALVARIABLE $i$a$-also-KotlinSafeCallOperatorTarget$safeCallChainMultiline2$fullCoverage$1 I L3 L5 3
-    LOCALVARIABLE it Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L2 L5 2
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L10 0
-    LINENUMBER 5 L0
-    LINENUMBER 6 L3
-    LINENUMBER 7 L4
-    LINENUMBER 5 L5
-    LINENUMBER 7 L6
-    LINENUMBER 5 L7
-    LINENUMBER 7 L8
-    LINENUMBER 5 L1
-    LINENUMBER 7 L9
+   L_method_end
+    LOCALVARIABLE $i$a$-also-KotlinSafeCallOperatorTarget$safeCallChainMultiline2$fullCoverage$1 I L_inline L_getB_before 3
+    LOCALVARIABLE it Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_before_inline L_getB_before 2
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
+    LINENUMBER 6 L_inline
+    LINENUMBER 7 L_after_inline
+    LINENUMBER 5 L_getB_before
+    LINENUMBER 7 L_getB
+    LINENUMBER 5 L_getC_before
+    LINENUMBER 7 L_getC
+    LINENUMBER 5 L_null
+    LINENUMBER 7 L_after
     MAXSTACK = 1
     MAXLOCALS = 4

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline2.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline2.txt
@@ -1,0 +1,46 @@
+   L0
+    ALOAD 0
+    IFNULL L1
+    ALOAD 0
+    ASTORE 1
+    ALOAD 1
+    ASTORE 2
+   L2
+    ICONST_0
+    ISTORE 3
+   L3
+    ALOAD 2
+    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (Ljava/lang/Object;)V
+   L4
+    NOP
+   L5
+    ALOAD 1
+   L6
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
+    ASTORE 1
+    ALOAD 1
+    IFNULL L1
+   L7
+    ALOAD 1
+   L8
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+    GOTO L9
+   L1
+    ACONST_NULL
+   L9
+    ARETURN
+   L10
+    LOCALVARIABLE $i$a$-also-KotlinSafeCallOperatorTarget$safeCallChainMultiline2$fullCoverage$1 I L3 L5 3
+    LOCALVARIABLE it Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L2 L5 2
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L10 0
+    LINENUMBER 5 L0
+    LINENUMBER 6 L3
+    LINENUMBER 7 L4
+    LINENUMBER 5 L5
+    LINENUMBER 7 L6
+    LINENUMBER 5 L7
+    LINENUMBER 7 L8
+    LINENUMBER 5 L1
+    LINENUMBER 7 L9
+    MAXSTACK = 1
+    MAXLOCALS = 4

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline2.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline2.txt
@@ -1,6 +1,6 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
+    IFNULL L_null
     ALOAD 0
     ASTORE 1
     ALOAD 1
@@ -19,28 +19,28 @@
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     ASTORE 1
     ALOAD 1
-    IFNULL L1
+    IFNULL L_null
    L7
     ALOAD 1
    L8
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-    GOTO L9
-   L1
+    GOTO L_after
+   L_null
     ACONST_NULL
-   L9
+   L_after
     ARETURN
-   L10
+   L_method_end
     LOCALVARIABLE $i$a$-also-KotlinSafeCallOperatorTarget$safeCallChainMultiline2$fullCoverage$1 I L3 L5 3
     LOCALVARIABLE it Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L2 L5 2
-    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L0 L10 0
-    LINENUMBER 5 L0
+    LOCALVARIABLE a Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     LINENUMBER 6 L3
     LINENUMBER 7 L4
     LINENUMBER 5 L5
     LINENUMBER 7 L6
     LINENUMBER 5 L7
     LINENUMBER 7 L8
-    LINENUMBER 5 L1
-    LINENUMBER 7 L9
+    LINENUMBER 5 L_null
+    LINENUMBER 7 L_after
     MAXSTACK = 1
     MAXLOCALS = 4

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt
@@ -1,17 +1,17 @@
-   L0
+   L_method_start
     ALOAD 0
     DUP
-    IFNULL L1
+    IFNULL L_null
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
     DUP
-    IFNONNULL L2
-   L1
+    IFNONNULL L_after
+   L_null
     POP
     LDC ""
-   L2
+   L_after
     ARETURN
-   L3
-    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L3 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     MAXSTACK = 2
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt
@@ -1,0 +1,17 @@
+   L0
+    ALOAD 0
+    DUP
+    IFNULL L1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+    DUP
+    IFNONNULL L2
+   L1
+    POP
+    LDC ""
+   L2
+    ARETURN
+   L3
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L3 0
+    LINENUMBER 5 L0
+    MAXSTACK = 2
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
@@ -1,26 +1,26 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
-   L2
+    IFNULL L_null
+   L_getC_before
     ALOAD 0
-   L3
+   L_getC
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
-   L4
+   L_getC_after
     ASTORE 1
     ALOAD 1
-    IFNULL L1
+    IFNULL L_null
     ALOAD 1
-    GOTO L5
-   L1
+    GOTO L_after
+   L_null
     LDC ""
-   L5
+   L_after
     ARETURN
-   L6
-    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L6 0
-    LINENUMBER 6 L0
-    LINENUMBER 5 L2
-    LINENUMBER 6 L3
-    LINENUMBER 5 L4
-    LINENUMBER 7 L1
+   L_method_end
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L_method_start L_method_end 0
+    LINENUMBER 6 L_method_start
+    LINENUMBER 5 L_getC_before
+    LINENUMBER 6 L_getC
+    LINENUMBER 5 L_getC_after
+    LINENUMBER 7 L_null
     MAXSTACK = 1
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
@@ -1,0 +1,26 @@
+   L0
+    ALOAD 0
+    IFNULL L1
+   L2
+    ALOAD 0
+   L3
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
+   L4
+    ASTORE 1
+    ALOAD 1
+    IFNULL L1
+    ALOAD 1
+    GOTO L5
+   L1
+    LDC ""
+   L5
+    ARETURN
+   L6
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L6 0
+    LINENUMBER 6 L0
+    LINENUMBER 5 L2
+    LINENUMBER 6 L3
+    LINENUMBER 5 L4
+    LINENUMBER 7 L1
+    MAXSTACK = 1
+    MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
@@ -1,6 +1,6 @@
-   L0
+   L_method_start
     ALOAD 0
-    IFNULL L1
+    IFNULL L_null
    L2
     ALOAD 0
    L3
@@ -8,19 +8,19 @@
    L4
     ASTORE 1
     ALOAD 1
-    IFNULL L1
+    IFNULL L_null
     ALOAD 1
-    GOTO L5
-   L1
+    GOTO L_after
+   L_null
     LDC ""
-   L5
+   L_after
     ARETURN
-   L6
-    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L0 L6 0
-    LINENUMBER 6 L0
+   L_method_end
+    LOCALVARIABLE b Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B; L_method_start L_method_end 0
+    LINENUMBER 6 L_method_start
     LINENUMBER 5 L2
     LINENUMBER 6 L3
     LINENUMBER 5 L4
-    LINENUMBER 7 L1
+    LINENUMBER 7 L_null
     MAXSTACK = 1
     MAXLOCALS = 2


### PR DESCRIPTION
In continuation of #2192

- [x] rename labels
