### PR TITLE
Add bytecode snapshots for `KotlinWhenSealedTarget`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenSealedTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenSealedTest.java
@@ -14,6 +14,7 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenSealedTarget;
+import org.junit.Test;
 
 /**
  * Test of code coverage in {@link KotlinWhenSealedTarget}.
@@ -22,6 +23,14 @@ public class KotlinWhenSealedTest extends ValidationTestBase {
 
 	public KotlinWhenSealedTest() {
 		super(KotlinWhenSealedTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		assertSnapshot(KotlinWhenSealedTarget.class, "expression",
+				"expression.txt");
+		assertSnapshot(KotlinWhenSealedTarget.class, "statement",
+				"statement.txt");
 	}
 
 }

--- a/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/expression.txt
+++ b/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/expression.txt
@@ -1,32 +1,32 @@
-   L0
+   L_method_start
     ALOAD 1
     ASTORE 2
-   L1
+   L_case_1
     ALOAD 2
     INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed1
-    IFEQ L2
+    IFEQ L_case_2
     LDC "case 1"
-    GOTO L3
-   L2
+    GOTO L_after
+   L_case_2
     ALOAD 2
     INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed2
-    IFEQ L4
+    IFEQ L_else
     LDC "case 2"
-    GOTO L3
-   L4
+    GOTO L_after
+   L_else
     NEW kotlin/NoWhenBranchMatchedException
     DUP
     INVOKESPECIAL kotlin/NoWhenBranchMatchedException.<init> ()V
     ATHROW
-   L3
+   L_after
     ARETURN
-   L5
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget; L0 L5 0
-    LOCALVARIABLE sealed Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed; L0 L5 1
-    LINENUMBER 5 L0
-    LINENUMBER 6 L1
-    LINENUMBER 7 L2
-    LINENUMBER 5 L4
-    LINENUMBER 8 L3
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget; L_method_start L_method_end 0
+    LOCALVARIABLE sealed Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed; L_method_start L_method_end 1
+    LINENUMBER 5 L_method_start
+    LINENUMBER 6 L_case_1
+    LINENUMBER 7 L_case_2
+    LINENUMBER 5 L_else
+    LINENUMBER 8 L_after
     MAXSTACK = 2
     MAXLOCALS = 3

--- a/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/expression.txt
+++ b/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/expression.txt
@@ -1,0 +1,32 @@
+   L0
+    ALOAD 1
+    ASTORE 2
+   L1
+    ALOAD 2
+    INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed1
+    IFEQ L2
+    LDC "case 1"
+    GOTO L3
+   L2
+    ALOAD 2
+    INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed2
+    IFEQ L4
+    LDC "case 2"
+    GOTO L3
+   L4
+    NEW kotlin/NoWhenBranchMatchedException
+    DUP
+    INVOKESPECIAL kotlin/NoWhenBranchMatchedException.<init> ()V
+    ATHROW
+   L3
+    ARETURN
+   L5
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget; L0 L5 0
+    LOCALVARIABLE sealed Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed; L0 L5 1
+    LINENUMBER 5 L0
+    LINENUMBER 6 L1
+    LINENUMBER 7 L2
+    LINENUMBER 5 L4
+    LINENUMBER 8 L3
+    MAXSTACK = 2
+    MAXLOCALS = 3

--- a/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/statement.txt
+++ b/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/statement.txt
@@ -1,34 +1,34 @@
-   L0
+   L_method_start
     ALOAD 1
     ASTORE 2
-   L1
+   L_case_1
     ALOAD 2
     INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed1
-    IFEQ L2
+    IFEQ L_case_2
     LDC "case 1"
     INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (Ljava/lang/Object;)V
-    GOTO L3
-   L2
+    GOTO L_after
+   L_case_2
     ALOAD 2
     INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed2
-    IFEQ L4
+    IFEQ L_else
     LDC "case 2"
     INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (Ljava/lang/Object;)V
-    GOTO L3
-   L4
+    GOTO L_after
+   L_else
     NEW kotlin/NoWhenBranchMatchedException
     DUP
     INVOKESPECIAL kotlin/NoWhenBranchMatchedException.<init> ()V
     ATHROW
-   L3
+   L_after
     RETURN
-   L5
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget; L0 L5 0
-    LOCALVARIABLE sealed Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed; L0 L5 1
-    LINENUMBER 5 L0
-    LINENUMBER 6 L1
-    LINENUMBER 7 L2
-    LINENUMBER 5 L4
-    LINENUMBER 9 L3
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget; L_method_start L_method_end 0
+    LOCALVARIABLE sealed Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed; L_method_start L_method_end 1
+    LINENUMBER 5 L_method_start
+    LINENUMBER 6 L_case_1
+    LINENUMBER 7 L_case_2
+    LINENUMBER 5 L_else
+    LINENUMBER 9 L_after
     MAXSTACK = 2
     MAXLOCALS = 3

--- a/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/statement.txt
+++ b/org.jacoco.core.test/snapshots/KotlinWhenSealedTarget/statement.txt
@@ -1,0 +1,34 @@
+   L0
+    ALOAD 1
+    ASTORE 2
+   L1
+    ALOAD 2
+    INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed1
+    IFEQ L2
+    LDC "case 1"
+    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (Ljava/lang/Object;)V
+    GOTO L3
+   L2
+    ALOAD 2
+    INSTANCEOF org/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed$Sealed2
+    IFEQ L4
+    LDC "case 2"
+    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (Ljava/lang/Object;)V
+    GOTO L3
+   L4
+    NEW kotlin/NoWhenBranchMatchedException
+    DUP
+    INVOKESPECIAL kotlin/NoWhenBranchMatchedException.<init> ()V
+    ATHROW
+   L3
+    RETURN
+   L5
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget; L0 L5 0
+    LOCALVARIABLE sealed Lorg/jacoco/core/test/validation/kotlin/targets/KotlinWhenSealedTarget$Sealed; L0 L5 1
+    LINENUMBER 5 L0
+    LINENUMBER 6 L1
+    LINENUMBER 7 L2
+    LINENUMBER 5 L4
+    LINENUMBER 9 L3
+    MAXSTACK = 2
+    MAXLOCALS = 3


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/pull/2192