### PR TITLE
Add bytecode snapshots for `KotlinNotNullOperatorTarget`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinNotNullOperatorTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinNotNullOperatorTest.java
@@ -14,6 +14,9 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinNotNullOperatorTarget;
+import org.junit.Test;
+
+import kotlin.KotlinVersion;
 
 /**
  * Test of not-null assertion operator.
@@ -22,6 +25,18 @@ public class KotlinNotNullOperatorTest extends ValidationTestBase {
 
 	public KotlinNotNullOperatorTest() {
 		super(KotlinNotNullOperatorTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		if (KotlinVersion.CURRENT.isAtLeast(1, 4)) {
+			// https://github.com/JetBrains/kotlin/commit/a7c8fdcbe2e260e5265aaf5121c5987206a676c9
+			assertSnapshot(KotlinNotNullOperatorTarget.class, "example",
+					"not_null_assertion_operator.txt");
+		} else {
+			assertSnapshot(KotlinNotNullOperatorTarget.class, "example",
+					"1.3/not_null_assertion_operator.txt");
+		}
 	}
 
 }

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinNotNullOperatorTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinNotNullOperatorTest.java
@@ -14,6 +14,7 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinNotNullOperatorTarget;
+import org.junit.Test;
 
 /**
  * Test of not-null assertion operator.
@@ -22,6 +23,12 @@ public class KotlinNotNullOperatorTest extends ValidationTestBase {
 
 	public KotlinNotNullOperatorTest() {
 		super(KotlinNotNullOperatorTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		assertSnapshot(KotlinNotNullOperatorTarget.class, "example",
+				"not_null_assertion_operator.txt");
 	}
 
 }

--- a/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/1.3/not_null_assertion_operator.txt
+++ b/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/1.3/not_null_assertion_operator.txt
@@ -1,0 +1,14 @@
+   L0
+    ALOAD 1
+    DUP
+    IFNONNULL L1
+    INVOKESTATIC kotlin/jvm/internal/Intrinsics.throwNpe ()V
+   L1
+    INVOKEVIRTUAL java/lang/String.length ()I
+    IRETURN
+   L2
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinNotNullOperatorTarget; L0 L2 0
+    LOCALVARIABLE x Ljava/lang/String; L0 L2 1
+    LINENUMBER 5 L0
+    MAXSTACK = 2
+    MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/1.3/not_null_assertion_operator.txt
+++ b/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/1.3/not_null_assertion_operator.txt
@@ -1,14 +1,14 @@
-   L0
+   L_method_start
     ALOAD 1
     DUP
-    IFNONNULL L1
+    IFNONNULL L_nonnull
     INVOKESTATIC kotlin/jvm/internal/Intrinsics.throwNpe ()V
-   L1
+   L_nonnull
     INVOKEVIRTUAL java/lang/String.length ()I
     IRETURN
-   L2
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinNotNullOperatorTarget; L0 L2 0
-    LOCALVARIABLE x Ljava/lang/String; L0 L2 1
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinNotNullOperatorTarget; L_method_start L_method_end 0
+    LOCALVARIABLE x Ljava/lang/String; L_method_start L_method_end 1
+    LINENUMBER 5 L_method_start
     MAXSTACK = 2
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/not_null_assertion_operator.txt
+++ b/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/not_null_assertion_operator.txt
@@ -1,12 +1,12 @@
-   L0
+   L_method_start
     ALOAD 1
     DUP
     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNull (Ljava/lang/Object;)V
     INVOKEVIRTUAL java/lang/String.length ()I
     IRETURN
-   L1
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinNotNullOperatorTarget; L0 L1 0
-    LOCALVARIABLE x Ljava/lang/String; L0 L1 1
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinNotNullOperatorTarget; L_method_start L_method_end 0
+    LOCALVARIABLE x Ljava/lang/String; L_method_start L_method_end 1
+    LINENUMBER 5 L_method_start
     MAXSTACK = 2
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/not_null_assertion_operator.txt
+++ b/org.jacoco.core.test/snapshots/KotlinNotNullOperatorTarget/not_null_assertion_operator.txt
@@ -1,0 +1,12 @@
+   L0
+    ALOAD 1
+    DUP
+    INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNull (Ljava/lang/Object;)V
+    INVOKEVIRTUAL java/lang/String.length ()I
+    IRETURN
+   L1
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinNotNullOperatorTarget; L0 L1 0
+    LOCALVARIABLE x Ljava/lang/String; L0 L1 1
+    LINENUMBER 5 L0
+    MAXSTACK = 2
+    MAXLOCALS = 2


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/pull/2192

- [x] find Kotlin version when bytecode was changed