### PR TITLE
Add bytecode snapshots for `KotlinInlineClassExposeTarget`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineClassExposeTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineClassExposeTest.java
@@ -14,7 +14,7 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineClassExposeTarget;
-import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineClassTarget;
+import org.junit.Test;
 
 /**
  * Test of code coverage in {@link KotlinInlineClassExposeTarget}.
@@ -23,6 +23,16 @@ public class KotlinInlineClassExposeTest extends ValidationTestBase {
 
 	public KotlinInlineClassExposeTest() {
 		super(KotlinInlineClassExposeTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		assertSnapshot(KotlinInlineClassExposeTarget.class, "exposeReturnType",
+				"expose_return_type.txt");
+		assertSnapshot(KotlinInlineClassExposeTarget.class, "exposeParameter",
+				"expose_parameter.txt");
+		assertSnapshot(KotlinInlineClassExposeTarget.class, "exposeUseless",
+				"expose_useless.txt");
 	}
 
 }

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,0 +1,19 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+   L0
+    ALOAD 1
+    LDC "p"
+    INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
+   L1
+    ALOAD 0
+    ALOAD 1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.unbox-impl ()Ljava/lang/String;
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeParameter-iNKR5zA (Ljava/lang/String;)V
+   L2
+    RETURN
+   L3
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L3 0
+    LOCALVARIABLE p Ljava/lang/String; L0 L3 1
+    LINENUMBER 5 L1
+    LINENUMBER 6 L2
+    MAXSTACK = 2
+    MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,0 +1,21 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+    // annotable parameter count: 1 (invisible)
+    @Lorg/jetbrains/annotations/NotNull;() // invisible, parameter 0
+   L0
+    ALOAD 1
+    LDC "p"
+    INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
+   L1
+    ALOAD 0
+    ALOAD 1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.unbox-impl ()Ljava/lang/String;
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeParameter-iNKR5zA (Ljava/lang/String;)V
+   L2
+    RETURN
+   L3
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L3 0
+    LOCALVARIABLE p Ljava/lang/String; L0 L3 1
+    LINENUMBER 5 L1
+    LINENUMBER 6 L2
+    MAXSTACK = 2
+    MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,7 +1,7 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
     // annotable parameter count: 1 (invisible)
     @Lorg/jetbrains/annotations/NotNull;() // invisible, parameter 0
-   L0
+   L_method_start
     ALOAD 1
     LDC "p"
     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
@@ -12,9 +12,9 @@
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeParameter-iNKR5zA (Ljava/lang/String;)V
    L2
     RETURN
-   L3
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L3 0
-    LOCALVARIABLE p Ljava/lang/String; L0 L3 1
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LOCALVARIABLE p Ljava/lang/String; L_method_start L_method_end 1
     LINENUMBER 5 L1
     LINENUMBER 6 L2
     MAXSTACK = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,19 +1,19 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
-   L0
+   L_method_start
     ALOAD 1
     LDC "p"
     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
-   L1
+   L_unbox
     ALOAD 0
     ALOAD 1
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.unbox-impl ()Ljava/lang/String;
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeParameter-iNKR5zA (Ljava/lang/String;)V
-   L2
+   L_return
     RETURN
-   L3
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L3 0
-    LOCALVARIABLE p Ljava/lang/String; L0 L3 1
-    LINENUMBER 5 L1
-    LINENUMBER 6 L2
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LOCALVARIABLE p Ljava/lang/String; L_method_start L_method_end 1
+    LINENUMBER 5 L_unbox
+    LINENUMBER 6 L_return
     MAXSTACK = 2
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
@@ -1,14 +1,14 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
   @Lorg/jetbrains/annotations/NotNull;() // invisible
-   L0
+   L_method_start
     ALOAD 0
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeReturnType-WF2O7EA ()Ljava/lang/String;
-   L1
+   L_box
     INVOKESTATIC org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.box-impl (Ljava/lang/String;)Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass;
     ARETURN
-   L2
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L2 0
-    LINENUMBER 5 L0
-    LINENUMBER 6 L1
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
+    LINENUMBER 6 L_box
     MAXSTACK = 1
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
@@ -1,14 +1,14 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
   @Lorg/jetbrains/annotations/NotNull;() // invisible
-   L0
+   L_method_start
     ALOAD 0
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeReturnType-WF2O7EA ()Ljava/lang/String;
    L1
     INVOKESTATIC org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.box-impl (Ljava/lang/String;)Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass;
     ARETURN
-   L2
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L2 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     LINENUMBER 6 L1
     MAXSTACK = 1
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
@@ -1,0 +1,14 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+  @Lorg/jetbrains/annotations/NotNull;() // invisible
+   L0
+    ALOAD 0
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeReturnType-WF2O7EA ()Ljava/lang/String;
+   L1
+    INVOKESTATIC org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.box-impl (Ljava/lang/String;)Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass;
+    ARETURN
+   L2
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L2 0
+    LINENUMBER 5 L0
+    LINENUMBER 6 L1
+    MAXSTACK = 1
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
@@ -1,9 +1,9 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
-   L0
+   L_method_start
     INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop ()V
     RETURN
-   L1
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L1 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     MAXSTACK = 0
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
@@ -1,0 +1,9 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+   L0
+    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop ()V
+    RETURN
+   L1
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L1 0
+    LINENUMBER 5 L0
+    MAXSTACK = 0
+    MAXLOCALS = 1


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/pull/2192

- [x] requires parsing of annotations - https://github.com/jacoco/jacoco/pull/2251
- [x] rename labels