### PR TITLE
Add bytecode snapshots for `KotlinDefaultArgumentsTarget`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinDefaultArgumentsTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinDefaultArgumentsTest.java
@@ -14,6 +14,7 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinDefaultArgumentsTarget;
+import org.junit.Test;
 
 /**
  * Test of functions with default arguments.
@@ -22,6 +23,19 @@ public class KotlinDefaultArgumentsTest extends ValidationTestBase {
 
 	public KotlinDefaultArgumentsTest() {
 		super(KotlinDefaultArgumentsTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		assertSnapshot(KotlinDefaultArgumentsTarget.class,
+				"longParameter$default", "long_parameter.txt");
+		assertSnapshot(KotlinDefaultArgumentsTarget.class, "branch$default",
+				"branch.txt");
+		assertSnapshot(KotlinDefaultArgumentsTarget.Open.class, "f$default",
+				"open_function.txt");
+		// TODO multiple methods
+		// assertSnapshot(KotlinDefaultArgumentsTarget.MoreThan32Parameters.class,
+		// "<init>", "more_than_32_parameters.txt");
 	}
 
 }

--- a/org.jacoco.core.test/snapshots/KotlinDefaultArgumentsTarget/branch.txt
+++ b/org.jacoco.core.test/snapshots/KotlinDefaultArgumentsTarget/branch.txt
@@ -1,0 +1,22 @@
+   L0
+    ILOAD 3
+    ICONST_2
+    IAND
+    IFEQ L1
+    ILOAD 1
+    IFEQ L2
+    LDC "a"
+    GOTO L3
+   L2
+    LDC "b"
+   L3
+    ASTORE 2
+   L1
+    ALOAD 0
+    ILOAD 1
+    ALOAD 2
+    INVOKESPECIAL org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget.branch (ZLjava/lang/String;)V
+    RETURN
+    LINENUMBER 5 L0
+    MAXSTACK = 3
+    MAXLOCALS = 5

--- a/org.jacoco.core.test/snapshots/KotlinDefaultArgumentsTarget/long_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinDefaultArgumentsTarget/long_parameter.txt
@@ -1,0 +1,15 @@
+   L0
+    ILOAD 3
+    ICONST_1
+    IAND
+    IFEQ L1
+    LCONST_0
+    LSTORE 1
+   L1
+    ALOAD 0
+    LLOAD 1
+    INVOKESPECIAL org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget.longParameter (J)V
+    RETURN
+    LINENUMBER 5 L0
+    MAXSTACK = 3
+    MAXLOCALS = 5

--- a/org.jacoco.core.test/snapshots/KotlinDefaultArgumentsTarget/open_function.txt
+++ b/org.jacoco.core.test/snapshots/KotlinDefaultArgumentsTarget/open_function.txt
@@ -1,0 +1,23 @@
+   L0
+    ALOAD 3
+    IFNULL L1
+    NEW java/lang/UnsupportedOperationException
+    DUP
+    LDC "Super calls with default arguments not supported in this target, function: f"
+    INVOKESPECIAL java/lang/UnsupportedOperationException.<init> (Ljava/lang/String;)V
+    ATHROW
+   L1
+    ILOAD 2
+    ICONST_1
+    IAND
+    IFEQ L2
+    LDC "a"
+    ASTORE 1
+   L2
+    ALOAD 0
+    ALOAD 1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinDefaultArgumentsTarget$Open.f (Ljava/lang/String;)V
+    RETURN
+    LINENUMBER 5 L0
+    MAXSTACK = 3
+    MAXLOCALS = 4

--- a/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/validation/ValidationTestBase.java
@@ -156,7 +156,7 @@ public abstract class ValidationTestBase {
 	 */
 	protected final void assertSnapshot(final Class<?> targetClass,
 			final String targetMethod, String name) throws Exception {
-		name = targetClass.getSimpleName() + "/" + name;
+		name = target.getSimpleName() + "/" + name;
 		final String expected = "../org.jacoco.core.test/snapshots/" + name;
 		final String actual = "target/snapshots/" + name;
 		MethodSnapshot.assertSnapshot(targetClass, targetMethod,


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/pull/2192

- [ ] rename labels
- [ ] multiple methods with same name
