### PR TITLE
Add validation test for Kotlin empty `when`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenEmptyTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinWhenEmptyTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin;
+
+import org.jacoco.core.test.validation.ValidationTestBase;
+import org.jacoco.core.test.validation.kotlin.targets.KotlinWhenEmptyTarget;
+
+/**
+ * Test of code coverage in {@link KotlinWhenEmptyTarget}.
+ */
+public class KotlinWhenEmptyTest extends ValidationTestBase {
+
+	public KotlinWhenEmptyTest() {
+		super(KotlinWhenEmptyTarget.class);
+	}
+
+}

--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenEmptyTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinWhenEmptyTarget.kt
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2026 Mountainminds GmbH & Co. KG and Contributors
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Evgeny Mandrikov - initial API and implementation
+ *
+ *******************************************************************************/
+package org.jacoco.core.test.validation.kotlin.targets
+
+import org.jacoco.core.test.validation.targets.Stubs.nop
+
+/**
+ * Test target with empty `when`.
+ */
+object KotlinWhenEmptyTarget {
+
+    /**
+     * Since Kotlin 2.3.20 subject of empty `when` is evaluated, see
+     * [KT-82844](https://youtrack.jetbrains.com/issue/KT-82844).
+     */
+    private fun emptyWhenWithSideEffectInSubject() {
+        var a = 1 // assertFullyCovered()
+        when (a++) {} // assertFullyCovered()
+        nop(a) // assertFullyCovered()
+    }
+
+    private fun emptyWhenWithoutSideEffectInSubject(a: Int) {
+        when (a) {} // assertFullyCovered()
+        nop(a) // assertFullyCovered()
+    }
+
+    private fun emptyWhenWithoutSubject() {
+        when {} // assertEmpty()
+        nop() // assertFullyCovered()
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        emptyWhenWithSideEffectInSubject()
+        emptyWhenWithoutSideEffectInSubject(1)
+        emptyWhenWithoutSubject()
+    }
+
+}


### PR DESCRIPTION
Closes #2039

Adds a validation test for empty `when`.

Kotlin in this module is 2.4.10, i.e. after [KT-82844](https://youtrack.jetbrains.com/issue/KT-82844),
so the subject of an empty `when` is evaluated. The test pins down three distinct cases:

| source | bytecode emitted for the line | JaCoCo |
|---|---|---|
| `when (a++) {}` | `IINC 1 1` | `assertFullyCovered()` |
| `when (a) {}` | `NOP` | `assertFullyCovered()` |
| `when {}` (no subject) | nothing, no line number entry | `assertEmpty()` |

The second row is the non-obvious one: even when the subject has no side effect, the
compiler still emits a single `NOP` attributed to that line, so the line is reported as
covered rather than empty.

Bytecode of the two subject cases (`javap`-style dump produced by the validation harness):

```
  private final emptyWhenWithSideEffectInSubject()V
   L0
    LINENUMBER 27 L0
    ICONST_1
    ISTORE 1
   L1
    LINENUMBER 28 L1      // when (a++) {}
    IINC 1 1
   L2
    LINENUMBER 29 L2
    ILOAD 1
    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (I)V

  private final emptyWhenWithoutSideEffectInSubject(I)V
   L0
    LINENUMBER 33 L0      // when (a) {}
    NOP
   L1
    LINENUMBER 34 L1
    ILOAD 1
    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop (I)V
```

`when {}` produces no line number entry at all, hence `assertEmpty()`.

### Verification

The naive expectation — that an empty `when` executes nothing — fails on two of the three
lines, which is what makes the test worth having:

```
Instructions (KotlinWhenEmptyTarget.kt:24) expected:<[EMPTY]> but was:<[FULLY_COVERED]>
Instructions (KotlinWhenEmptyTarget.kt:29) expected:<[EMPTY]> but was:<[FULLY_COVERED]>
```

With the assertions as committed: `Tests run: 6, Failures: 0`.
Full module run for regressions: `Tests run: 293, Failures: 0, Errors: 0, Skipped: 0`
(`mvn -pl org.jacoco.core.test.validation.kotlin test -Djdk.version=21 -Dbytecode.version=21`,
Temurin 21.0.11, Maven 3.9.16 — same version as `.mvn/wrapper`).
`spotless:apply` leaves both new files unchanged.
