### PR TITLE
Fix handling of CRLF (Windows-style EOL) in `MethodSnapshotParser.Lexer`

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/test/snapshot/MethodSnapshotLexerTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/snapshot/MethodSnapshotLexerTest.java
@@ -35,9 +35,10 @@ public class MethodSnapshotLexerTest {
 	@Test
 	public void comment() throws Exception {
 		final MethodSnapshotParser.Lexer lexer = newLexer(
-				"// comment 1\n// comment 2");
+				"// comment 1\n// comment 2\r\n// comment 3");
 		assertEquals("// comment 1", lexer.nextToken());
 		assertEquals("// comment 2", lexer.nextToken());
+		assertEquals("// comment 3", lexer.nextToken());
 		assertNull(lexer.nextToken());
 	}
 

--- a/org.jacoco.core.test/src/org/jacoco/core/test/snapshot/MethodSnapshotParser.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/test/snapshot/MethodSnapshotParser.java
@@ -658,7 +658,7 @@ final class MethodSnapshotParser {
 			do {
 				s.append((char) c);
 				c = reader.read();
-			} while (c != -1 && c != '\n');
+			} while (c != -1 && c != '\r' && c != '\n');
 			return s.toString();
 		}
 	}


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/pull/2192