### PR TITLE
Use bytecode snapshots for `KotlinSafeCallOperatorFilterTest`

### DIFF
--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt
@@ -2,13 +2,19 @@
     ALOAD 0
     DUP
     IFNULL L_null
+// previous instruction replaced by R1
+// previous instruction branch 0 creates branch 0 for R1
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     DUP
     IFNULL L_null
+// previous instruction replaced by R2
+// previous instruction branch 0 creates branch 0 for R2
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
     GOTO L_after
    L_null
     POP
+// previous instruction branch 0 creates branch 1 for R1
+// previous instruction branch 0 creates branch 1 for R2
     ACONST_NULL
    L_after
     ARETURN

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt
@@ -2,14 +2,23 @@
     ALOAD 0
     DUP
     IFNULL L_null
+// previous instruction replaced by R1
+// previous instruction branch 0 creates branch 0 for R1
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$A.getB ()Lorg/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B;
     DUP
     IFNULL L_null
+// previous instruction replaced by R2
+// previous instruction branch 0 creates branch 0 for R2
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
     DUP
     IFNONNULL L_after
+// previous instruction replaced by R3
+// previous instruction branch 1 creates branch 1 for R3
    L_null
     POP
+// previous instruction branch 0 creates branch 1 for R1
+// previous instruction branch 0 creates branch 1 for R2
+// previous instruction branch 0 creates branch 0 for R3
     LDC ""
    L_after
     ARETURN

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt
@@ -1,6 +1,8 @@
    L_method_start
     ALOAD 0
     IFNULL L_null
+// previous instruction replaced by R1
+// previous instruction branch 0 creates branch 0 for R1
    L_getB_before
     ALOAD 0
    L_getB
@@ -9,6 +11,8 @@
    L_getB_after
     ALOAD 1
     IFNULL L_null
+// previous instruction replaced by R2
+// previous instruction branch 0 creates branch 0 for R2
    L_getC_before
     ALOAD 1
    L_getC
@@ -17,10 +21,15 @@
     ASTORE 2
     ALOAD 2
     IFNULL L_null
+// previous instruction replaced by R3
+// previous instruction branch 0 creates branch 0 for R3
     ALOAD 2
     GOTO L_after
    L_null
     LDC ""
+// previous instruction branch 0 creates branch 1 for R1
+// previous instruction branch 0 creates branch 1 for R2
+// previous instruction branch 0 creates branch 1 for R3
    L_after
     ARETURN
    L_method_end

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt
@@ -1,6 +1,8 @@
    L_method_start
     ALOAD 0
     IFNULL L_null
+// previous instruction replaced by R1
+// previous instruction branch 0 creates branch 0 for R1
    L_getB_before
     ALOAD 0
    L_getB
@@ -9,6 +11,8 @@
    L_getB_after
     ALOAD 1
     IFNULL L_null
+// previous instruction replaced by R2
+// previous instruction branch 0 creates branch 0 for R2
    L_getC_before
     ALOAD 1
    L_getC
@@ -16,6 +20,8 @@
     GOTO L_after
    L_null
     ACONST_NULL
+// previous instruction branch 0 creates branch 1 for R1
+// previous instruction branch 0 creates branch 1 for R2
    L_after
     ARETURN
    L_method_end

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt
@@ -2,11 +2,17 @@
     ALOAD 0
     DUP
     IFNULL L_null
+// previous instruction replaced by R1
+// previous instruction branch 0 creates branch 0 for R1
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinSafeCallOperatorTarget$B.getC ()Ljava/lang/String;
     DUP
     IFNONNULL L_after
+// previous instruction replaced by R2
+// previous instruction branch 1 creates branch 1 for R2
    L_null
     POP
+// previous instruction branch 0 creates branch 1 for R1
+// previous instruction branch 0 creates branch 0 for R2
     LDC ""
    L_after
     ARETURN

--- a/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
+++ b/org.jacoco.core.test/snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt
@@ -1,6 +1,8 @@
    L_method_start
     ALOAD 0
     IFNULL L_null
+// previous instruction replaced by R1
+// previous instruction branch 0 creates branch 0 for R1
    L_getC_before
     ALOAD 0
    L_getC
@@ -9,10 +11,14 @@
     ASTORE 1
     ALOAD 1
     IFNULL L_null
+// previous instruction replaced by R2
+// previous instruction branch 0 creates branch 0 for R2
     ALOAD 1
     GOTO L_after
    L_null
     LDC ""
+// previous instruction branch 0 creates branch 1 for R1
+// previous instruction branch 0 creates branch 1 for R2
    L_after
     ARETURN
    L_method_end

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/FilterTestBase.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/FilterTestBase.java
@@ -16,7 +16,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,16 +67,23 @@ public abstract class FilterTestBase {
 		}
 	};
 
-	final void assertSnapshot(final IFilter filter, final String snapshotPath)
-			throws Exception {
-		final FileReader reader = new FileReader(snapshotPath);
+	final void assertSnapshot(final IFilter filter, final String snapshotPath) {
+		final FileReader reader;
+		try {
+			reader = new FileReader(snapshotPath);
+		} catch (final FileNotFoundException e) {
+			throw new RuntimeException(e);
+		}
 		assertSnapshot(filter, context, reader);
-		reader.close();
+		try {
+			reader.close();
+		} catch (final IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	static void assertSnapshot(final IFilter filter,
-			final IFilterContext context, final Reader snapshot)
-			throws Exception {
+			final IFilterContext context, final Reader snapshot) {
 		final TreeMap<String, Range> rangesByName = new TreeMap<String, Range>();
 		final HashMap<String, ArrayList<Replacement>> replacementsByName = new HashMap<String, ArrayList<Replacement>>();
 		final HashMap<String, AbstractInsnNode> replacedInstructionsByName = new HashMap<String, AbstractInsnNode>();
@@ -136,8 +145,12 @@ public abstract class FilterTestBase {
 				}
 			}
 		};
-		final MethodNode methodNode = MethodSnapshot.parse(snapshot,
-				commentsHandler);
+		final MethodNode methodNode;
+		try {
+			methodNode = MethodSnapshot.parse(snapshot, commentsHandler);
+		} catch (final IOException e) {
+			throw new RuntimeException(e);
+		}
 		for (final Map.Entry<String, Range> e : rangesByName.entrySet()) {
 			if (e.getValue().toInclusive == null) {
 				throw new IllegalStateException(

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinSafeCallOperatorFilterTest.java
@@ -12,16 +12,7 @@
  *******************************************************************************/
 package org.jacoco.core.internal.analysis.filter;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-
-import org.jacoco.core.internal.instr.InstrSupport;
 import org.junit.Test;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.MethodNode;
 
 /**
  * Unit tests for {@link KotlinSafeCallOperatorFilter}.
@@ -31,305 +22,42 @@ public class KotlinSafeCallOperatorFilterTest extends FilterTestBase {
 	private final IFilter filter = new KotlinSafeCallOperatorFilter();
 
 	/**
-	 * <pre>
-	 * data class A(val b: B)
-	 * data class B(val c: String)
-	 * fun example(a: A?): String? =
-	 *     a?.b?.c
-	 * </pre>
-	 *
 	 * https://github.com/JetBrains/kotlin/commit/0a67ab54fec635f82e0507cbdd4299ae0dbe71b0
 	 */
 	@Test
 	public void should_filter_optimized_safe_call_chain() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "(LA;)Ljava/lang/String;", null, null);
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		final Label label1 = new Label();
-		final Label label2 = new Label();
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction1 = m.instructions.getLast();
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "A", "getB", "()LB;", false);
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction2 = m.instructions.getLast();
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "B", "getC",
-				"()Ljava/lang/String;", false);
-
-		m.visitJumpInsn(Opcodes.GOTO, label2);
-
-		m.visitLabel(label1);
-		m.visitInsn(Opcodes.POP);
-		final AbstractInsnNode popInstruction = m.instructions.getLast();
-		m.visitInsn(Opcodes.ACONST_NULL);
-		m.visitLabel(label2);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
-		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
-		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction1, 0),
-				new Replacement(1, popInstruction, 0)));
-		replacements.put(ifNullInstruction2, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
-				new Replacement(1, popInstruction, 0)));
-		assertReplacedBranches(m, replacements);
+		assertSnapshot(filter,
+				"snapshots/KotlinSafeCallOperatorTarget/safe_call_chain.txt");
 	}
 
-	/**
-	 * <pre>
-	 * data class A(val b: B)
-	 * data class B(val c: String)
-	 * fun example(a: A?): String? =
-	 *     a
-	 *         ?.b
-	 *         ?.c // line 6
-	 * </pre>
-	 */
 	@Test
 	public void should_filter_unoptimized_safe_call_chain() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "(LA;)Ljava/lang/String;", null, null);
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		final Label label1 = new Label();
-		final Label label2 = new Label();
-
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction1 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "A", "getB", "()LB;", false);
-
-		m.visitVarInsn(Opcodes.ASTORE, 1);
-		final Label lineNumberLabel = new Label();
-		m.visitLabel(lineNumberLabel);
-		m.visitLineNumber(6, lineNumberLabel);
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction2 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "B", "getC",
-				"()Ljava/lang/String;", false);
-
-		m.visitJumpInsn(Opcodes.GOTO, label2);
-
-		m.visitLabel(label1);
-		m.visitInsn(Opcodes.ACONST_NULL);
-		final AbstractInsnNode aconstNullInstruction = m.instructions.getLast();
-		m.visitLabel(label2);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
-		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
-		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction1, 0),
-				new Replacement(1, aconstNullInstruction, 0)));
-		replacements.put(ifNullInstruction2, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
-				new Replacement(1, aconstNullInstruction, 0)));
-		assertReplacedBranches(m, replacements);
+		assertSnapshot(filter,
+				"snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_multiline.txt");
 	}
 
-	/**
-	 * <pre>
-	 * data class B(val c: String)
-	 * fun example(b: B?): String =
-	 *     b?.c ?: ""
-	 * </pre>
-	 */
 	@Test
 	public void should_filter_safe_call_followed_by_elvis() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "(LB;)Ljava/lang/String;", null, null);
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		final Label label1 = new Label();
-		final Label label2 = new Label();
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction = m.instructions.getLast();
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "B", "getC",
-				"()Ljava/lang/String;", false);
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNONNULL, label2);
-		final AbstractInsnNode ifNonNullInstruction = m.instructions.getLast();
-		m.visitLabel(label1);
-		m.visitInsn(Opcodes.POP);
-		final AbstractInsnNode popInstruction = m.instructions.getLast();
-		m.visitLdcInsn("");
-		m.visitLabel(label2);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
-		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
-		replacements.put(ifNullInstruction, Arrays.asList( //
-				new Replacement(0, ifNullInstruction, 0),
-				new Replacement(1, popInstruction, 0)));
-		replacements.put(ifNonNullInstruction, Arrays.asList( //
-				new Replacement(0, popInstruction, 0),
-				new Replacement(1, ifNonNullInstruction, 1)));
-		assertReplacedBranches(m, replacements);
+		assertSnapshot(filter,
+				"snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis.txt");
 	}
 
-	/**
-	 * <pre>
-	 * data class A(val b: B)
-	 * data class B(val c: String)
-	 * fun example(a: A?): String =
-	 *     a?.b?.c ?: ""
-	 * </pre>
-	 */
 	@Test
 	public void should_filter_safe_call_chain_followed_by_elvis() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "(LA;)Ljava/lang/String;", null, null);
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		final Label label1 = new Label();
-		final Label label2 = new Label();
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction1 = m.instructions.getLast();
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "A", "getB", "()LB;", false);
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNULL, label1);
-		final AbstractInsnNode ifNullInstruction2 = m.instructions.getLast();
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "B", "getC",
-				"()Ljava/lang/String;", false);
-
-		m.visitInsn(Opcodes.DUP);
-		m.visitJumpInsn(Opcodes.IFNONNULL, label2);
-		final AbstractInsnNode ifNonNullInstruction = m.instructions.getLast();
-		m.visitLabel(label1);
-		m.visitInsn(Opcodes.POP);
-		final AbstractInsnNode popInstruction = m.instructions.getLast();
-		m.visitLdcInsn("");
-		m.visitLabel(label2);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
-		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
-		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction1, 0),
-				new Replacement(1, popInstruction, 0)));
-		replacements.put(ifNullInstruction2, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
-				new Replacement(1, popInstruction, 0)));
-		replacements.put(ifNonNullInstruction, Arrays.asList( //
-				new Replacement(0, popInstruction, 0),
-				new Replacement(1, ifNonNullInstruction, 1)));
-		assertReplacedBranches(m, replacements);
+		assertSnapshot(filter,
+				"snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis.txt");
 	}
 
-	/**
-	 * <pre>
-	 * data class B(val c: String)
-	 * fun example(b: B?): String =
-	 *     b
-	 *       ?.c
-	 *       ?: ""
-	 * </pre>
-	 */
 	@Test
 	public void should_filter_unoptimized_safe_call_followed_by_elvis() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "(LB;)Ljava/lang/String;", null, null);
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		final Label label = new Label();
-		m.visitJumpInsn(Opcodes.IFNULL, label);
-		final AbstractInsnNode ifNullInstruction1 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "B", "getC",
-				"()Ljava/lang/String;", false);
-		m.visitVarInsn(Opcodes.ASTORE, 1);
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		m.visitJumpInsn(Opcodes.IFNULL, label);
-		final AbstractInsnNode ifNullInstruction2 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		final Label next = new Label();
-		m.visitJumpInsn(Opcodes.GOTO, next);
-		m.visitLabel(label);
-		m.visitLdcInsn("");
-		final AbstractInsnNode nullTarget = m.instructions.getLast();
-		m.visitLabel(next);
-		m.visitInsn(Opcodes.ARETURN);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
-		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
-		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction1, 0),
-				new Replacement(1, nullTarget, 0)));
-		replacements.put(ifNullInstruction2, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
-				new Replacement(1, nullTarget, 0)));
-		assertReplacedBranches(m, replacements);
+		assertSnapshot(filter,
+				"snapshots/KotlinSafeCallOperatorTarget/safe_call_followed_by_elvis_multiline.txt");
 	}
 
-	/**
-	 * <pre>
-	 * data class A(val b: B)
-	 * data class B(val c: String)
-	 * fun example(a: A?): String? =
-	 *     a
-	 *         ?.b
-	 *         ?.c
-	 *         ?: ""
-	 * </pre>
-	 */
 	@Test
 	public void should_filter_unoptimized_safe_call_chain_followed_by_elvis() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "(LA;)Ljava/lang/String;", null, null);
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		final Label label = new Label();
-		m.visitJumpInsn(Opcodes.IFNULL, label);
-		final AbstractInsnNode ifNullInstruction1 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "A", "getB", "()LB;", false);
-		m.visitVarInsn(Opcodes.ASTORE, 1);
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		m.visitJumpInsn(Opcodes.IFNULL, label);
-		final AbstractInsnNode ifNullInstruction2 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 1);
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "B", "getC",
-				"()Ljava/lang/String;", false);
-		m.visitVarInsn(Opcodes.ASTORE, 2);
-		m.visitVarInsn(Opcodes.ALOAD, 2);
-		m.visitJumpInsn(Opcodes.IFNULL, label);
-		final AbstractInsnNode ifNullInstruction3 = m.instructions.getLast();
-		m.visitVarInsn(Opcodes.ALOAD, 2);
-		final Label next = new Label();
-		m.visitJumpInsn(Opcodes.GOTO, next);
-		m.visitLabel(label);
-		m.visitLdcInsn("");
-		final AbstractInsnNode nullTarget = m.instructions.getLast();
-		m.visitLabel(next);
-		m.visitInsn(Opcodes.ARETURN);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
-		final HashMap<AbstractInsnNode, List<Replacement>> replacements = new HashMap<AbstractInsnNode, List<Replacement>>();
-		replacements.put(ifNullInstruction1, Arrays.asList( //
-				new Replacement(0, ifNullInstruction1, 0),
-				new Replacement(1, nullTarget, 0)));
-		replacements.put(ifNullInstruction2, Arrays.asList( //
-				new Replacement(0, ifNullInstruction2, 0),
-				new Replacement(1, nullTarget, 0)));
-		replacements.put(ifNullInstruction3, Arrays.asList( //
-				new Replacement(0, ifNullInstruction3, 0),
-				new Replacement(1, nullTarget, 0)));
-		assertReplacedBranches(m, replacements);
+		assertSnapshot(filter,
+				"snapshots/KotlinSafeCallOperatorTarget/safe_call_chain_followed_by_elvis_multiline.txt");
 	}
 
 }


### PR DESCRIPTION
In continuation of https://github.com/jacoco/jacoco/pull/2192