### PR TITLE
Use bytecode snapshots for `KotlinExposeBoxedFilterTest`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineClassExposeTest.java
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/KotlinInlineClassExposeTest.java
@@ -14,7 +14,7 @@ package org.jacoco.core.test.validation.kotlin;
 
 import org.jacoco.core.test.validation.ValidationTestBase;
 import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineClassExposeTarget;
-import org.jacoco.core.test.validation.kotlin.targets.KotlinInlineClassTarget;
+import org.junit.Test;
 
 /**
  * Test of code coverage in {@link KotlinInlineClassExposeTarget}.
@@ -23,6 +23,16 @@ public class KotlinInlineClassExposeTest extends ValidationTestBase {
 
 	public KotlinInlineClassExposeTest() {
 		super(KotlinInlineClassExposeTarget.class);
+	}
+
+	@Test
+	public void bytecodeSnapshots() throws Exception {
+		assertSnapshot(KotlinInlineClassExposeTarget.class, "exposeReturnType",
+				"expose_return_type.txt");
+		assertSnapshot(KotlinInlineClassExposeTarget.class, "exposeParameter",
+				"expose_parameter.txt");
+		assertSnapshot(KotlinInlineClassExposeTarget.class, "exposeUseless",
+				"expose_useless.txt");
 	}
 
 }

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,0 +1,19 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+   L0
+    ALOAD 1
+    LDC "p"
+    INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
+   L1
+    ALOAD 0
+    ALOAD 1
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.unbox-impl ()Ljava/lang/String;
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeParameter-iNKR5zA (Ljava/lang/String;)V
+   L2
+    RETURN
+   L3
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L3 0
+    LOCALVARIABLE p Ljava/lang/String; L0 L3 1
+    LINENUMBER 5 L1
+    LINENUMBER 6 L2
+    MAXSTACK = 2
+    MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,5 +1,6 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
    L_method_start
+// previous instruction starts ignore range 0
     ALOAD 1
     LDC "p"
     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
@@ -15,5 +16,6 @@
     LOCALVARIABLE p Ljava/lang/String; L_method_start L_method_end 1
     LINENUMBER 5 L1
     LINENUMBER 6 L2
+// previous instruction ends ignore range 0
     MAXSTACK = 2
     MAXLOCALS = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt
@@ -1,5 +1,5 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
-   L0
+   L_method_start
     ALOAD 1
     LDC "p"
     INVOKESTATIC kotlin/jvm/internal/Intrinsics.checkNotNullParameter (Ljava/lang/Object;Ljava/lang/String;)V
@@ -10,9 +10,9 @@
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeParameter-iNKR5zA (Ljava/lang/String;)V
    L2
     RETURN
-   L3
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L3 0
-    LOCALVARIABLE p Ljava/lang/String; L0 L3 1
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LOCALVARIABLE p Ljava/lang/String; L_method_start L_method_end 1
     LINENUMBER 5 L1
     LINENUMBER 6 L2
     MAXSTACK = 2

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
@@ -1,14 +1,14 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
   @Lorg/jetbrains/annotations/NotNull;() // invisible
-   L0
+   L_method_start
     ALOAD 0
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeReturnType-WF2O7EA ()Ljava/lang/String;
    L1
     INVOKESTATIC org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.box-impl (Ljava/lang/String;)Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass;
     ARETURN
-   L2
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L2 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     LINENUMBER 6 L1
     MAXSTACK = 1
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
@@ -1,6 +1,7 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
   @Lorg/jetbrains/annotations/NotNull;() // invisible
    L_method_start
+// previous instruction starts ignore range 0
     ALOAD 0
     INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeReturnType-WF2O7EA ()Ljava/lang/String;
    L1
@@ -10,5 +11,6 @@
     LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
     LINENUMBER 5 L_method_start
     LINENUMBER 6 L1
+// previous instruction ends ignore range 0
     MAXSTACK = 1
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt
@@ -1,0 +1,14 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+  @Lorg/jetbrains/annotations/NotNull;() // invisible
+   L0
+    ALOAD 0
+    INVOKEVIRTUAL org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.exposeReturnType-WF2O7EA ()Ljava/lang/String;
+   L1
+    INVOKESTATIC org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass.box-impl (Ljava/lang/String;)Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget$ValueClass;
+    ARETURN
+   L2
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L2 0
+    LINENUMBER 5 L0
+    LINENUMBER 6 L1
+    MAXSTACK = 1
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
@@ -1,9 +1,9 @@
   @Lkotlin/jvm/JvmExposeBoxed;() // invisible
-   L0
+   L_method_start
     INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop ()V
     RETURN
-   L1
-    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L1 0
-    LINENUMBER 5 L0
+   L_method_end
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L_method_start L_method_end 0
+    LINENUMBER 5 L_method_start
     MAXSTACK = 0
     MAXLOCALS = 1

--- a/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
+++ b/org.jacoco.core.test/snapshots/KotlinInlineClassExposeTarget/expose_useless.txt
@@ -1,0 +1,9 @@
+  @Lkotlin/jvm/JvmExposeBoxed;() // invisible
+   L0
+    INVOKESTATIC org/jacoco/core/test/validation/targets/Stubs.nop ()V
+    RETURN
+   L1
+    LOCALVARIABLE this Lorg/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget; L0 L1 0
+    LINENUMBER 5 L0
+    MAXSTACK = 0
+    MAXLOCALS = 1

--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinExposeBoxedFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinExposeBoxedFilterTest.java
@@ -24,63 +24,22 @@ public class KotlinExposeBoxedFilterTest extends FilterTestBase {
 
 	private final KotlinExposeBoxedFilter filter = new KotlinExposeBoxedFilter();
 
-	/**
-	 * <pre>
-	 * &#064;JvmExposeBoxed
-	 * fun example(v: ValueClass) = ...
-	 * </pre>
-	 */
 	@Test
-	public void should_filter_when_parameter_exposed() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "()LValueClass;", null, null);
-		m.visitAnnotation("Lkotlin/jvm/JvmExposeBoxed;", false);
-
-		m.visitVarInsn(Opcodes.ALOAD, 0);
-		m.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "ValueClass", "unbox-impl",
-				"()Ljava/lang/String;", false);
-
-		filter.filter(m, context, output);
-
-		assertMethodIgnored(m);
+	public void should_filter_when_parameter_exposed() throws Exception {
+		assertSnapshot(filter,
+				"snapshots/KotlinInlineClassExposeTarget/expose_parameter.txt");
 	}
 
-	/**
-	 * <pre>
-	 * &#064;JvmExposeBoxed(jvmName = "exposed")
-	 * fun example(): ValueClass = ...
-	 * </pre>
-	 */
 	@Test
-	public void should_filter_when_return_type_exposed() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"exposed", "()LValueClass;", null, null);
-		m.visitAnnotation("Lkotlin/jvm/JvmExposeBoxed;", false);
-
-		m.visitMethodInsn(Opcodes.INVOKESTATIC, "ValueClass", "box-impl",
-				"(Ljava/lang/String;)LValueClass;", false);
-		m.visitInsn(Opcodes.ARETURN);
-
-		filter.filter(m, context, output);
-
-		assertMethodIgnored(m);
+	public void should_filter_when_return_type_exposed() throws Exception {
+		assertSnapshot(filter,
+				"snapshots/KotlinInlineClassExposeTarget/expose_return_type.txt");
 	}
 
-	/**
-	 * <pre>
-	 * &#064;JvmExposeBoxed
-	 * fun example() = ...
-	 * </pre>
-	 */
 	@Test
-	public void should_not_filter_when_nothing_exposed() {
-		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION, 0,
-				"example", "()V", null, null);
-		m.visitAnnotation("Lkotlin/jvm/JvmExposeBoxed;", false);
-
-		filter.filter(m, context, output);
-
-		assertIgnored(m);
+	public void should_not_filter_when_nothing_exposed() throws Exception {
+		assertSnapshot(filter,
+				"snapshots/KotlinInlineClassExposeTarget/expose_useless.txt");
 	}
 
 	/**


### PR DESCRIPTION
In continuation of #2192

- [ ] requires https://github.com/jacoco/jacoco/pull/2243