### PR TITLE
Add missing `assertFullyCovered` to `KotlinInlineClassExposeTarget`

### DIFF
--- a/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.kt
+++ b/org.jacoco.core.test.validation.kotlin/src/org/jacoco/core/test/validation/kotlin/targets/KotlinInlineClassExposeTarget.kt
@@ -26,7 +26,7 @@ object KotlinInlineClassExposeTarget {
 
     @JvmExposeBoxed // assertEmpty()
     fun exposeReturnType(): ValueClass = // assertEmpty()
-        ValueClass("")
+        ValueClass("") // assertFullyCovered()
 
     @JvmExposeBoxed // assertEmpty()
     fun exposeParameter(p: ValueClass) = // assertEmpty()


### PR DESCRIPTION
This was overlooked in 75a4e31fed32f180fbe4593ad91ec5c176c0535b.