### PR TITLE
docs: mark Java 27 class files as officially supported

### DIFF
--- a/org.jacoco.doc/docroot/doc/faq.html
+++ b/org.jacoco.doc/docroot/doc/faq.html
@@ -45,8 +45,8 @@
 
 <h3>What Java versions are supported by JaCoCo?</h3>
 <p>
-  JaCoCo officially supports Java class files from version 1.0 to 26. Also
-  experimental support for class files of version 27 and 28 is provided.
+  JaCoCo officially supports Java class files from version 1.0 to 27. Also
+  experimental support for class files of version 28 is provided.
   However the minimum JRE version required by the JaCoCo runtime
   (e.g. the agent) and the JaCoCo tools is 1.5. Also note that class files under
   test from version 1.6 and above have to contain valid stackmap frames.


### PR DESCRIPTION
## Summary
Update the FAQ Java version support wording so class file version **27** is listed as officially supported (0.8.15+), with **28** remaining experimental.

Fixes #2161

## Test plan
- [ ] Confirm FAQ section "What Java versions are supported by JaCoCo?" reads 1.0–27 official / 28 experimental
